### PR TITLE
feat(frontend): Nightfall sleep dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ android-app/app/release/
 # OS
 .DS_Store
 Thumbs.db
+
+# Design handoff exports
+*.zip

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
+| Nightfall sleep dashboard | `static/index.html`, `static/dashboard.css`, `static/dashboard.js`, `static/api.js` | [`pending`](#2026-04-21-pending) |
 | Workflow bootstrap — CI, labels, hooks, tests | `.github/`, `.githooks/`, `Makefile`, `tests/` | [`939f5ef`](#2026-04-21-939f5ef) |
 | Phase 3: Steps, heart rate, exercise + tabbed dashboard | `server/`, `static/`, `scripts/`, `android-app/` | [`242040a`](#2026-02-16-242040a) |
 | Phase 2: Sleep stages + color-coded calendar + Android app | `server/`, `static/`, `scripts/`, `android-app/` | [`8d5cfb0`](#2026-02-16-8d5cfb0) |
@@ -13,6 +14,16 @@
 ---
 
 ## Changelog
+
+### 2026-04-21 `pending`
+feat(frontend): Nightfall sleep dashboard branché sur l'API réelle
+- Remplacé `static/index.html` par la structure Nightfall (fonts Instrument Serif + Geist, `#app`, `#cursor-glow`)
+- Copié `dashboard.css` et `dashboard.js` du handoff Claude Design (inchangés)
+- Exposé `window.render` dans `dashboard.js` pour découpler chargement des données et rendu
+- Créé `static/api.js` — fetch `GET /api/sleep?include_stages=true`, agrège steps + HR, calcule `totals`/`efficiency`/`score`/`summary`, expose `window.SleepData` puis appelle `render()`
+- Stratégie "30 dernières sessions disponibles" au lieu d'une fenêtre calendaire fixe
+- État vide géré si DB sans données (message sync Android)
+- Ajouté `tests/test_sleep_api_shape.py` — 7 tests de contrat sur le shape de l'API (ISO strings, ordre, filtre, stages)
 
 ### 2026-04-21 `939f5ef`
 chore(workflow): bootstrap project template — CI, labels, hooks, tests

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
-| Nightfall sleep dashboard | `static/index.html`, `static/dashboard.css`, `static/dashboard.js`, `static/api.js` | [`pending`](#2026-04-21-pending) |
+| Nightfall sleep dashboard | `static/index.html`, `static/dashboard.css`, `static/dashboard.js`, `static/api.js` | [`b5cacc7`](#2026-04-21-b5cacc7) |
 | Workflow bootstrap — CI, labels, hooks, tests | `.github/`, `.githooks/`, `Makefile`, `tests/` | [`939f5ef`](#2026-04-21-939f5ef) |
 | Phase 3: Steps, heart rate, exercise + tabbed dashboard | `server/`, `static/`, `scripts/`, `android-app/` | [`242040a`](#2026-02-16-242040a) |
 | Phase 2: Sleep stages + color-coded calendar + Android app | `server/`, `static/`, `scripts/`, `android-app/` | [`8d5cfb0`](#2026-02-16-8d5cfb0) |
@@ -15,7 +15,7 @@
 
 ## Changelog
 
-### 2026-04-21 `pending`
+### 2026-04-21 `b5cacc7`
 feat(frontend): Nightfall sleep dashboard branché sur l'API réelle
 - Remplacé `static/index.html` par la structure Nightfall (fonts Instrument Serif + Geist, `#app`, `#cursor-glow`)
 - Copié `dashboard.css` et `dashboard.js` du handoff Claude Design (inchangés)

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ install:
 
 ## dev : start the FastAPI server (reload + accessible from phone on LAN)
 dev:
-	uvicorn server.main:app --reload --host 0.0.0.0 --port 8000
+	uvicorn server.main:app --reload --host 0.0.0.0 --port 8001
 
 ## test : run the test suite
 test:

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,12 +1,14 @@
 # Notes
 
-## Known Issues
+> Ce fichier contient uniquement des ADR (Architecture Decision Records).
+> Les bugs et features vont dans GitHub Issues + BACKLOG.md.
 
-_None yet._
+---
 
-## Backlog
+## ADR-1 : Port 8001 pour le serveur FastAPI
 
-- Support sub-hour granularity (30-min or 15-min slots) in sleep grid
-- Handle naps (multiple sleep sessions per day)
-- Correlation views (sleep vs. activity)
-- Export visualizations as PNG/PDF
+**Contexte :** DataSaillance tourne sur le port 8000 en dev local. Les deux projets coexistent sur la même machine.
+
+**Décision :** SamsungHealth utilise le port **8001** (`make dev`, Android `DEFAULT_URL`). Aucun port hardcodé dans le code serveur — uniquement dans le Makefile et le `DEFAULT_URL` Android (configurable via l'UI Settings).
+
+**Conséquences :** Pour tester depuis un téléphone physique, l'URL à configurer est `http://<IP_LAN>:8001`.

--- a/REVIEW.current.md
+++ b/REVIEW.current.md
@@ -1,0 +1,28 @@
+# Review — feat/nightfall-dashboard — 2026-04-21
+<!-- branch: feat/nightfall-dashboard | generated: 2026-04-21 -->
+
+## Tests
+
+### Chargement & rendu de base
+- [x] `http://localhost:8001/` charge sans erreur 404 ni console error
+- [x] La page affiche le header "Nightfall / Samsung Sleep" avec la lune et l'heure de sync
+- [x] Les 9 sections s'affichent (heatmap, timeline, hypnogram, radial, small multiples, ridgeline, top nights, week agenda, metrics)
+- [x] Les fonts Instrument Serif et Geist sont bien chargées (titres en serif, labels en mono)
+
+### Données réelles
+- [x] Le hero affiche la dernière nuit avec une date, un score, une durée et un % REM cohérents
+- [x] L'arc SVG de la dernière nuit est tracé avec des segments colorés (deep/light/rem/awake)
+- [x] Le heatmap 30 nuits × 24h est rempli avec des cellules colorées
+- [x] La section Metrics affiche des valeurs non nulles (score régularité, dette, stage mix, HR)
+
+### Navigation
+- [x] Les boutons ‹ › du hypnogram changent de nuit et rechargent le rendu
+- [x] Cliquer une cellule dans les Small Multiples met à jour le hypnogram et le radial clock
+- [x] Les flèches clavier ← → naviguent entre les nuits
+- [x] La touche T ouvre le panneau Tweaks (accent, grain)
+
+### État vide
+- [x] Avec une DB vide (ou `api.js` qui retourne `[]`), l'écran "Aucune donnée" s'affiche sans crash JS
+
+### Résilience données manquantes
+- [x] Si steps et HR ne sont pas en DB pour les mêmes jours que le sleep, le dashboard charge quand même (pas de crash, valeurs à 0)

--- a/android-app/app/src/main/java/com/samsunghealth/data/PreferencesManager.kt
+++ b/android-app/app/src/main/java/com/samsunghealth/data/PreferencesManager.kt
@@ -17,7 +17,7 @@ class PreferencesManager(private val context: Context) {
     companion object {
         private val KEY_BACKEND_URL = stringPreferencesKey("backend_url")
         private val KEY_LAST_SYNC = longPreferencesKey("last_sync_epoch_millis")
-        const val DEFAULT_URL = "http://10.0.2.2:8000"
+        const val DEFAULT_URL = "http://10.0.2.2:8001"
     }
 
     val backendUrl: Flow<String> = context.dataStore.data.map { prefs ->

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/scripts/generate_sample.py
+++ b/scripts/generate_sample.py
@@ -217,7 +217,7 @@ def generate():
     hr_count = conn.execute("SELECT COUNT(*) FROM heart_rate_hourly").fetchone()[0]
     ex_count = conn.execute("SELECT COUNT(*) FROM exercise_sessions").fetchone()[0]
     conn.close()
-    print(f"Inserted into health.db:")
+    print("Inserted into health.db:")
     print(f"  {session_count} sleep sessions with {stage_count} stages")
     print(f"  {step_count} steps_hourly records")
     print(f"  {hr_count} heart_rate_hourly records")

--- a/server/routers/sleep.py
+++ b/server/routers/sleep.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Query
-from datetime import datetime
 from server.database import get_connection
-from server.models import SleepSessionIn, SleepSessionOut, SleepStageOut, SleepBulkIn
+from server.models import SleepSessionOut, SleepBulkIn
 
 router = APIRouter(prefix="/api/sleep", tags=["sleep"])
 

--- a/static/api.js
+++ b/static/api.js
@@ -1,0 +1,172 @@
+(async function () {
+  const MAX_SESSIONS = 30;
+
+  function toDate(isoStr) {
+    return new Date(isoStr);
+  }
+
+  function dateKey(d) {
+    return d.toISOString().slice(0, 10);
+  }
+
+  function computeSession(raw, id) {
+    const sleep_start = toDate(raw.sleep_start);
+    const sleep_end = toDate(raw.sleep_end);
+    const stages = (raw.stages || []).map((st) => ({
+      stage_type: st.stage_type,
+      stage_start: toDate(st.stage_start),
+      stage_end: toDate(st.stage_end),
+    }));
+
+    const totals = { light: 0, deep: 0, rem: 0, awake: 0 };
+    for (const st of stages) {
+      const ms = st.stage_end - st.stage_start;
+      if (totals[st.stage_type] !== undefined) totals[st.stage_type] += ms;
+    }
+
+    const duration_ms = sleep_end - sleep_start;
+    const duration_hours = duration_ms / 3600000;
+    const asleep = duration_ms - totals.awake;
+    const efficiency = duration_ms > 0 ? asleep / duration_ms : 0;
+
+    const remPct = totals.rem / duration_ms;
+    const deepPct = totals.deep / duration_ms;
+    const awakePct = totals.awake / duration_ms;
+    const durScore = Math.max(0, 100 - Math.abs(duration_hours - 8) * 15);
+    const remScore = Math.min(100, (remPct / 0.22) * 100);
+    const deepScore = Math.min(100, (deepPct / 0.18) * 100);
+    const awakeScore = Math.max(0, 100 - awakePct * 400);
+    const score = Math.round(durScore * 0.35 + remScore * 0.2 + deepScore * 0.25 + awakeScore * 0.2);
+
+    return {
+      id,
+      sleep_start,
+      sleep_end,
+      stages,
+      totals,
+      duration_ms,
+      duration_hours,
+      efficiency,
+      score,
+      date_key: dateKey(sleep_end),
+    };
+  }
+
+  function aggregateSteps(records) {
+    const steps = {};
+    for (const r of records) {
+      steps[r.date] = (steps[r.date] || 0) + r.step_count;
+    }
+    return steps;
+  }
+
+  function aggregateHR(records) {
+    const hr = {};
+    const counts = {};
+    for (const r of records) {
+      if (r.hour >= 0 && r.hour <= 6) {
+        hr[r.date] = (hr[r.date] || 0) + r.avg_bpm;
+        counts[r.date] = (counts[r.date] || 0) + 1;
+      }
+    }
+    const result = {};
+    for (const d of Object.keys(hr)) {
+      result[d] = Math.round(hr[d] / counts[d]);
+    }
+    return result;
+  }
+
+  function computeSummary(sessions, steps, hr) {
+    const n = sessions.length;
+    if (n === 0) return {};
+
+    const avgDur = sessions.reduce((a, s) => a + s.duration_hours, 0) / n;
+    const avgScore = sessions.reduce((a, s) => a + s.score, 0) / n;
+    const avgRem = sessions.reduce((a, s) => a + s.totals.rem, 0) / n / 3600000;
+    const avgDeep = sessions.reduce((a, s) => a + s.totals.deep, 0) / n / 3600000;
+    const avgLight = sessions.reduce((a, s) => a + s.totals.light, 0) / n / 3600000;
+    const avgAwake = sessions.reduce((a, s) => a + s.totals.awake, 0) / n / 3600000;
+
+    const bedMinutes = sessions.map((s) => {
+      let m = s.sleep_start.getHours() * 60 + s.sleep_start.getMinutes();
+      if (m < 12 * 60) m += 24 * 60;
+      return m;
+    });
+    const mean = bedMinutes.reduce((a, b) => a + b, 0) / bedMinutes.length;
+    const variance = bedMinutes.reduce((a, b) => a + (b - mean) ** 2, 0) / bedMinutes.length;
+    const bedtimeStdDev = Math.sqrt(variance);
+    const regularity = Math.max(0, 100 - bedtimeStdDev * 0.8);
+
+    let debt = 0;
+    for (const s of sessions) debt += 8 - s.duration_hours;
+
+    const hrVals = Object.values(hr);
+    const avgRestingHR = hrVals.length
+      ? hrVals.reduce((a, b) => a + b, 0) / hrVals.length
+      : 0;
+
+    const stepVals = Object.values(steps);
+    const avgSteps = stepVals.length
+      ? stepVals.reduce((a, b) => a + b, 0) / stepVals.length
+      : 0;
+
+    return {
+      avgDur, avgScore, avgRem, avgDeep, avgLight, avgAwake,
+      regularity, bedtimeStdDev, debt,
+      nights: n,
+      avgRestingHR,
+      avgSteps,
+    };
+  }
+
+  function showEmptyState() {
+    document.getElementById("app").innerHTML = `
+      <div style="display:flex;flex-direction:column;align-items:center;justify-content:center;height:70vh;gap:24px;text-align:center;">
+        <div style="font-size:48px;opacity:0.3">🌙</div>
+        <h2 style="font-family:'Instrument Serif',serif;font-size:clamp(28px,4vw,48px);font-weight:400;color:#e8e4f5;">Aucune donnée de sommeil</h2>
+        <p style="color:#6a6488;max-width:40ch;line-height:1.6;">Lancez une synchronisation depuis l'application Android pour importer vos nuits depuis Samsung Health.</p>
+      </div>
+    `;
+  }
+
+  try {
+    const sleepRes = await fetch("/api/sleep?include_stages=true");
+    const allSessions = await sleepRes.json();
+
+    if (!Array.isArray(allSessions) || allSessions.length === 0) {
+      showEmptyState();
+      return;
+    }
+
+    // Take the last MAX_SESSIONS nights
+    const rawSessions = allSessions.slice(-MAX_SESSIONS);
+
+    // Fetch steps and HR scoped to the date range of those sessions
+    const fromDate = rawSessions[0].sleep_start.slice(0, 10);
+    const toDate = rawSessions[rawSessions.length - 1].sleep_end.slice(0, 10);
+
+    const [stepsRes, hrRes] = await Promise.all([
+      fetch(`/api/steps?from=${fromDate}&to=${toDate}`),
+      fetch(`/api/heartrate?from=${fromDate}&to=${toDate}`),
+    ]);
+
+    const rawSteps = stepsRes.ok ? await stepsRes.json() : [];
+    const rawHR = hrRes.ok ? await hrRes.json() : [];
+
+    const sessions = rawSessions.map((s, i) => computeSession(s, i));
+    const steps = aggregateSteps(rawSteps);
+    const hr = aggregateHR(rawHR);
+
+    window.SleepData = {
+      sessions,
+      steps,
+      hr,
+      summary: computeSummary(sessions, steps, hr),
+    };
+
+    window.render();
+  } catch (err) {
+    console.error("Nightfall: failed to load data", err);
+    showEmptyState();
+  }
+})();

--- a/static/dashboard.css
+++ b/static/dashboard.css
@@ -1,0 +1,339 @@
+:root {
+  --ink-0: #06060e;
+  --ink-1: #0a0a18;
+  --ink-2: #10102a;
+  --ink-3: #1a1a3e;
+  --ink-4: #2a2560;
+  --paper: #e8e4f5;
+  --paper-dim: #aea8c9;
+  --paper-faint: #6a6488;
+  --paper-ghost: #3a3560;
+  --stage-deep: oklch(0.48 0.14 275);
+  --stage-deep-soft: oklch(0.38 0.12 275);
+  --stage-light: oklch(0.68 0.14 295);
+  --stage-light-soft: oklch(0.58 0.13 295);
+  --stage-rem: oklch(0.82 0.13 220);
+  --stage-rem-soft: oklch(0.7 0.12 220);
+  --stage-awake: oklch(0.78 0.15 60);
+  --moon: oklch(0.94 0.04 90);
+  --star: oklch(0.9 0.02 270);
+  --danger: oklch(0.7 0.17 25);
+  --good: oklch(0.78 0.14 155);
+  --radius: 14px;
+  --grain-opacity: 0.04;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html, body {
+  background: var(--ink-0);
+  color: var(--paper);
+  font-family: "Geist", system-ui, sans-serif;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+body {
+  background:
+    radial-gradient(ellipse 80% 60% at 20% 0%, rgba(83, 52, 131, 0.18), transparent 60%),
+    radial-gradient(ellipse 70% 50% at 80% 40%, rgba(42, 60, 140, 0.12), transparent 60%),
+    linear-gradient(180deg, var(--ink-1) 0%, var(--ink-0) 40%, var(--ink-0) 100%);
+  min-height: 100vh;
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence baseFrequency='0.9' numOctaves='2'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.4 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>");
+  opacity: var(--grain-opacity);
+  mix-blend-mode: overlay;
+}
+
+#cursor-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background: radial-gradient(circle 320px at var(--mx, 50%) var(--my, 50%), rgba(120, 80, 200, 0.08), transparent 70%);
+  transition: background 0.2s;
+}
+
+#app {
+  position: relative;
+  z-index: 2;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 48px 32px 120px;
+}
+
+.serif { font-family: "Instrument Serif", serif; font-weight: 400; letter-spacing: -0.01em; }
+.mono { font-family: "Geist Mono", ui-monospace, monospace; letter-spacing: 0.02em; }
+
+.eyebrow {
+  font-family: "Geist Mono", ui-monospace, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--paper-faint);
+}
+
+.chapter { margin-top: 120px; margin-bottom: 32px; }
+.chapter-label { display: flex; align-items: baseline; gap: 14px; margin-bottom: 10px; }
+.chapter-num { font-family: "Instrument Serif", serif; font-style: italic; color: var(--paper-ghost); font-size: 22px; }
+.chapter h2 {
+  font-family: "Instrument Serif", serif;
+  font-size: clamp(36px, 5vw, 64px);
+  line-height: 0.95;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  color: var(--paper);
+  max-width: 22ch;
+}
+.chapter h2 em { font-style: italic; color: var(--stage-rem); }
+.chapter-desc { margin-top: 14px; font-size: 15px; color: var(--paper-dim); max-width: 60ch; line-height: 1.55; }
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: 32px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  margin-bottom: 60px;
+}
+.brand { display: flex; align-items: center; gap: 14px; }
+.brand-moon {
+  width: 28px; height: 28px; border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, var(--moon), oklch(0.78 0.04 85) 70%, oklch(0.4 0.04 85));
+  box-shadow: 0 0 30px rgba(255, 230, 180, 0.3);
+}
+.brand-text { font-family: "Instrument Serif", serif; font-size: 22px; letter-spacing: -0.01em; }
+.brand-text em { font-style: italic; color: var(--stage-rem); }
+.top-meta { display: flex; gap: 28px; align-items: center; font-family: "Geist Mono", monospace; font-size: 11px; text-transform: uppercase; letter-spacing: 0.15em; color: var(--paper-faint); }
+.top-meta .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--good); display: inline-block; margin-right: 6px; box-shadow: 0 0 8px currentColor; color: var(--good); vertical-align: middle; }
+
+.hero { display: grid; grid-template-columns: 1.2fr 1fr; gap: 60px; align-items: start; margin-bottom: 40px; }
+.hero-text .eyebrow { margin-bottom: 18px; display: block; }
+.hero h1 { font-family: "Instrument Serif", serif; font-size: clamp(56px, 9vw, 120px); line-height: 0.9; font-weight: 400; letter-spacing: -0.03em; }
+.hero h1 em { font-style: italic; color: var(--stage-rem); }
+.hero p.lede { margin-top: 28px; font-size: 18px; line-height: 1.55; color: var(--paper-dim); max-width: 42ch; }
+
+.hero-stats { margin-top: 44px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; max-width: 460px; }
+.hero-stat { border-top: 1px solid rgba(255, 255, 255, 0.1); padding-top: 12px; }
+.hero-stat .k { font-family: "Geist Mono", monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--paper-faint); margin-bottom: 6px; }
+.hero-stat .v { font-family: "Instrument Serif", serif; font-size: 34px; font-weight: 400; letter-spacing: -0.01em; }
+.hero-stat .v small { font-size: 14px; color: var(--paper-dim); margin-left: 3px; }
+
+.night-arc { position: relative; aspect-ratio: 1 / 1; width: 100%; max-width: 520px; margin-left: auto; }
+.night-arc svg { width: 100%; height: 100%; overflow: visible; }
+.arc-label { font-family: "Geist Mono", monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; fill: var(--paper-faint); }
+.arc-time { font-family: "Instrument Serif", serif; font-size: 22px; fill: var(--paper); }
+
+.panel {
+  background: linear-gradient(180deg, rgba(26, 26, 62, 0.4), rgba(10, 10, 24, 0.2));
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--radius);
+  padding: 32px;
+  position: relative;
+  overflow: hidden;
+}
+
+.heatmap-wrap { overflow-x: auto; padding-bottom: 6px; }
+.heatmap { display: grid; grid-template-columns: 78px repeat(24, 1fr); gap: 2px; min-width: 720px; }
+.heatmap .hour-head { font-family: "Geist Mono", monospace; font-size: 9px; color: var(--paper-faint); text-align: center; padding-bottom: 6px; letter-spacing: 0.04em; }
+.heatmap .day-label { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); padding-right: 8px; text-align: right; align-self: center; white-space: nowrap; }
+.heatmap .cell { height: 14px; border-radius: 2px; background: rgba(255, 255, 255, 0.02); position: relative; transition: transform 0.15s, filter 0.15s; }
+.heatmap .cell:hover { transform: scale(1.4); z-index: 2; filter: brightness(1.3); }
+.heatmap .cell.light { background: var(--stage-light); }
+.heatmap .cell.deep { background: var(--stage-deep); }
+.heatmap .cell.rem { background: var(--stage-rem); }
+.heatmap .cell.awake { background: var(--stage-awake); }
+
+.legend { display: flex; gap: 22px; margin-top: 22px; flex-wrap: wrap; font-family: "Geist Mono", monospace; font-size: 11px; color: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.08em; }
+.legend .sw { display: inline-block; width: 12px; height: 12px; border-radius: 3px; margin-right: 8px; vertical-align: middle; }
+
+.timeline { position: relative; margin-top: 10px; }
+.timeline-axis { position: relative; height: 22px; margin-left: 80px; margin-bottom: 6px; border-bottom: 1px solid rgba(255, 255, 255, 0.08); }
+.timeline-axis .tick { position: absolute; top: 0; transform: translateX(-50%); font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); }
+.timeline-axis .tick::after { content: ""; position: absolute; left: 50%; bottom: -6px; width: 1px; height: 4px; background: rgba(255, 255, 255, 0.15); }
+.timeline-row { display: grid; grid-template-columns: 80px 1fr; align-items: center; gap: 0; margin-bottom: 3px; }
+.timeline-row .label { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); padding-right: 12px; text-align: right; }
+.timeline-row .track { position: relative; height: 14px; background: rgba(255, 255, 255, 0.025); border-radius: 3px; }
+.timeline-row .stage-seg { position: absolute; top: 0; height: 100%; transition: filter 0.2s; }
+.timeline-row .stage-seg.deep { background: var(--stage-deep); }
+.timeline-row .stage-seg.light { background: var(--stage-light); }
+.timeline-row .stage-seg.rem { background: var(--stage-rem); }
+.timeline-row .stage-seg.awake { background: var(--stage-awake); }
+.timeline-row:hover .stage-seg { filter: brightness(1.15); }
+
+.hypno-header { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 24px; gap: 20px; flex-wrap: wrap; }
+.hypno-date { font-family: "Instrument Serif", serif; font-size: 28px; font-style: italic; }
+.hypno-controls { display: flex; gap: 4px; align-items: center; }
+.hypno-controls button { background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(255, 255, 255, 0.08); color: var(--paper); width: 32px; height: 32px; border-radius: 6px; cursor: pointer; font-family: "Geist Mono", monospace; transition: background 0.15s; }
+.hypno-controls button:hover { background: rgba(255, 255, 255, 0.08); }
+
+.hypno-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; margin-bottom: 28px; padding-bottom: 24px; border-bottom: 1px solid rgba(255, 255, 255, 0.06); }
+.hypno-stat { display: flex; flex-direction: column; gap: 6px; }
+.hypno-stat .k { display: flex; align-items: center; gap: 8px; font-family: "Geist Mono", monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--paper-faint); }
+.hypno-stat .k .sw { width: 10px; height: 10px; border-radius: 2px; }
+.hypno-stat .v { font-family: "Instrument Serif", serif; font-size: 28px; letter-spacing: -0.01em; }
+.hypno-stat .pct { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--paper-dim); }
+.hypno-svg-wrap { position: relative; width: 100%; }
+.hypno-svg { width: 100%; display: block; }
+.hypno-y-label { font-family: "Geist Mono", monospace; font-size: 10px; fill: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.1em; }
+.hypno-x-label { font-family: "Geist Mono", monospace; font-size: 10px; fill: var(--paper-faint); }
+.hypno-grid-line { stroke: rgba(255, 255, 255, 0.05); stroke-width: 1; }
+
+.radial-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 40px; align-items: center; }
+.radial-svg { width: 100%; aspect-ratio: 1; max-width: 520px; }
+.radial-info h3 { font-family: "Instrument Serif", serif; font-size: 40px; font-weight: 400; font-style: italic; letter-spacing: -0.01em; margin-bottom: 14px; }
+.radial-info p { color: var(--paper-dim); font-size: 15px; line-height: 1.6; margin-bottom: 24px; max-width: 40ch; }
+.radial-kv { display: grid; grid-template-columns: auto 1fr; gap: 10px 24px; font-family: "Geist Mono", monospace; font-size: 12px; }
+.radial-kv dt { color: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.1em; }
+.radial-kv dd { color: var(--paper); }
+
+.sm-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 10px; }
+.sm-cell { background: rgba(255, 255, 255, 0.02); border: 1px solid rgba(255, 255, 255, 0.04); border-radius: 8px; padding: 10px 8px 8px; transition: background 0.2s, border-color 0.2s, transform 0.2s; cursor: pointer; }
+.sm-cell:hover { background: rgba(255, 255, 255, 0.05); border-color: rgba(255, 255, 255, 0.12); transform: translateY(-1px); }
+.sm-cell.active { background: rgba(123, 90, 242, 0.1); border-color: var(--stage-light); }
+.sm-cell-head { display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }
+.sm-date { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-dim); }
+.sm-score { font-family: "Instrument Serif", serif; font-size: 14px; }
+.sm-svg { width: 100%; height: 36px; }
+.sm-duration { font-family: "Geist Mono", monospace; font-size: 9px; color: var(--paper-faint); margin-top: 4px; text-align: right; }
+
+.ridge-svg { width: 100%; display: block; }
+.ridge-label { font-family: "Geist Mono", monospace; font-size: 9px; fill: var(--paper-faint); }
+
+.cards-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 18px; }
+.night-card { background: linear-gradient(165deg, rgba(83, 52, 131, 0.12), rgba(10, 10, 24, 0.1)); border: 1px solid rgba(255, 255, 255, 0.06); border-radius: 14px; padding: 22px 20px 20px; position: relative; overflow: hidden; transition: transform 0.2s, border-color 0.2s; }
+.night-card:hover { transform: translateY(-2px); border-color: rgba(255, 255, 255, 0.14); }
+.night-card .rank { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); letter-spacing: 0.14em; text-transform: uppercase; }
+.night-card .date { font-family: "Instrument Serif", serif; font-size: 22px; font-style: italic; margin-top: 4px; margin-bottom: 18px; }
+.night-card .score { display: flex; align-items: baseline; gap: 4px; }
+.night-card .score .n { font-family: "Instrument Serif", serif; font-size: 64px; font-weight: 400; line-height: 1; letter-spacing: -0.02em; }
+.night-card .score .label { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.12em; }
+.night-card .mini-stages { display: flex; height: 6px; border-radius: 3px; overflow: hidden; margin: 18px 0 12px; background: rgba(255, 255, 255, 0.04); }
+.night-card .mini-stages .s { height: 100%; }
+.night-card .mini-stages .s.deep { background: var(--stage-deep); }
+.night-card .mini-stages .s.light { background: var(--stage-light); }
+.night-card .mini-stages .s.rem { background: var(--stage-rem); }
+.night-card .mini-stages .s.awake { background: var(--stage-awake); }
+.night-card .times { font-family: "Geist Mono", monospace; font-size: 11px; color: var(--paper-dim); display: flex; justify-content: space-between; }
+.night-card::after { content: ""; position: absolute; top: 16px; right: 18px; width: 4px; height: 4px; border-radius: 50%; background: var(--star); box-shadow: 0 0 6px var(--star), 16px 8px 0 -1px rgba(232, 228, 245, 0.5), 28px -2px 0 -2px rgba(232, 228, 245, 0.3); }
+
+.agenda-day-head { font-family: "Geist Mono", monospace; font-size: 10px; text-align: center; padding-bottom: 12px; color: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.1em; border-bottom: 1px solid rgba(255, 255, 255, 0.06); margin-bottom: 8px; }
+.agenda-day-head .num { display: block; font-family: "Instrument Serif", serif; font-size: 24px; color: var(--paper); margin-top: 4px; text-transform: none; letter-spacing: 0; }
+.agenda-day { position: relative; background: rgba(255, 255, 255, 0.015); border-radius: 6px; }
+.agenda-day::before { content: ""; position: absolute; left: 0; right: 0; top: 33.33%; height: 1px; background: rgba(255, 255, 255, 0.06); }
+.agenda-seg { position: absolute; left: 4px; right: 4px; border-radius: 3px; }
+.agenda-seg.deep { background: var(--stage-deep); }
+.agenda-seg.light { background: var(--stage-light); }
+.agenda-seg.rem { background: var(--stage-rem); }
+.agenda-seg.awake { background: var(--stage-awake); }
+
+.metrics-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+.metric-card { background: linear-gradient(180deg, rgba(26, 26, 62, 0.3), rgba(10, 10, 24, 0.1)); border: 1px solid rgba(255, 255, 255, 0.05); border-radius: 14px; padding: 28px; min-height: 260px; display: flex; flex-direction: column; }
+.metric-card .head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 20px; }
+.metric-card h3 { font-family: "Instrument Serif", serif; font-size: 26px; font-weight: 400; letter-spacing: -0.01em; }
+.metric-card .hint { font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.12em; }
+.metric-big { font-family: "Instrument Serif", serif; font-size: 56px; line-height: 1; letter-spacing: -0.02em; }
+.metric-big small { font-size: 18px; color: var(--paper-dim); margin-left: 4px; }
+.metric-body { flex: 1; position: relative; }
+.metric-caption { margin-top: auto; padding-top: 16px; font-size: 13px; color: var(--paper-dim); max-width: 42ch; line-height: 1.5; }
+
+.debt-row { display: grid; grid-template-columns: 56px 1fr 48px; align-items: center; gap: 10px; font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-faint); margin-bottom: 3px; }
+.debt-bar-track { height: 12px; position: relative; background: rgba(255, 255, 255, 0.04); border-radius: 2px; overflow: hidden; }
+.debt-bar-track::after { content: ""; position: absolute; left: 50%; top: 0; width: 1px; height: 100%; background: rgba(255, 255, 255, 0.25); }
+.debt-bar { position: absolute; top: 0; height: 100%; border-radius: 2px; }
+.debt-bar.deficit { background: var(--danger); }
+.debt-bar.surplus { background: var(--good); }
+
+.scatter-svg { width: 100%; height: 140px; }
+.scatter-dot { fill: var(--stage-light); opacity: 0.8; }
+.scatter-guide { stroke: rgba(255, 255, 255, 0.08); stroke-width: 1; stroke-dasharray: 2 3; }
+.scatter-label { font-family: "Geist Mono", monospace; font-size: 10px; fill: var(--paper-faint); }
+
+.hr-svg { width: 100%; height: 140px; }
+.hr-line { fill: none; stroke: var(--stage-rem); stroke-width: 1.5; }
+.hr-area { fill: url(#hrGrad); opacity: 0.3; }
+
+.stage-bar-group { display: flex; flex-direction: column; gap: 14px; margin-top: 12px; }
+.stage-bar-row { display: grid; grid-template-columns: 70px 1fr 60px; gap: 12px; align-items: center; font-family: "Geist Mono", monospace; font-size: 11px; }
+.stage-bar-row .name { color: var(--paper-dim); text-transform: uppercase; letter-spacing: 0.08em; }
+.stage-bar-row .track { height: 8px; background: rgba(255, 255, 255, 0.04); border-radius: 2px; position: relative; overflow: hidden; }
+.stage-bar-row .fill { height: 100%; border-radius: 2px; }
+.stage-bar-row .fill.deep { background: var(--stage-deep); }
+.stage-bar-row .fill.rem { background: var(--stage-rem); }
+.stage-bar-row .fill.light { background: var(--stage-light); }
+.stage-bar-row .fill.awake { background: var(--stage-awake); }
+.stage-bar-row .val { text-align: right; color: var(--paper); }
+.stage-bar-row .target { position: absolute; top: -2px; bottom: -2px; width: 1.5px; background: rgba(255, 255, 255, 0.4); }
+
+#hover-tip {
+  position: fixed;
+  background: var(--ink-3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-family: "Geist Mono", monospace;
+  font-size: 11px;
+  color: var(--paper);
+  pointer-events: none;
+  z-index: 100;
+  white-space: pre;
+  opacity: 0;
+  transition: opacity 0.15s;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  max-width: 260px;
+}
+#hover-tip.show { opacity: 1; }
+
+#tweaks {
+  position: fixed; bottom: 20px; right: 20px;
+  background: rgba(16, 16, 42, 0.92); backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 12px;
+  padding: 16px 18px; z-index: 200; min-width: 240px; display: none;
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+}
+#tweaks.show { display: block; }
+#tweaks h4 { font-family: "Geist Mono", monospace; font-size: 10px; text-transform: uppercase; letter-spacing: 0.15em; color: var(--paper-faint); margin-bottom: 14px; }
+.tweak-row { margin-bottom: 12px; }
+.tweak-row label { display: block; font-family: "Geist Mono", monospace; font-size: 10px; color: var(--paper-dim); text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 6px; }
+.tweak-pills { display: flex; gap: 4px; flex-wrap: wrap; }
+.tweak-pill { background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(255, 255, 255, 0.08); color: var(--paper-dim); padding: 4px 10px; border-radius: 12px; font-family: "Geist Mono", monospace; font-size: 10px; cursor: pointer; transition: all 0.15s; text-transform: uppercase; letter-spacing: 0.08em; }
+.tweak-pill.active { background: var(--stage-light); border-color: var(--stage-light); color: var(--ink-0); }
+.tweak-pill:hover:not(.active) { background: rgba(255, 255, 255, 0.06); color: var(--paper); }
+
+footer {
+  margin-top: 140px; padding-top: 32px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex; justify-content: space-between; align-items: center;
+  font-family: "Geist Mono", monospace; font-size: 10px;
+  color: var(--paper-faint); text-transform: uppercase; letter-spacing: 0.12em;
+  flex-wrap: wrap; gap: 14px;
+}
+
+@media (max-width: 900px) {
+  #app { padding: 32px 20px 80px; }
+  .hero { grid-template-columns: 1fr; gap: 40px; }
+  .night-arc { margin: 0 auto; max-width: 360px; }
+  .hero-stats { max-width: none; }
+  .radial-wrap { grid-template-columns: 1fr; }
+  .sm-grid { grid-template-columns: repeat(5, 1fr); }
+  .metrics-grid { grid-template-columns: 1fr; }
+  .hypno-stats { grid-template-columns: repeat(2, 1fr); }
+  .chapter { margin-top: 80px; }
+  .panel { padding: 22px 18px; }
+}
+@media (max-width: 560px) {
+  .sm-grid { grid-template-columns: repeat(4, 1fr); }
+  .hero h1 { font-size: 56px; }
+  .top-meta { display: none; }
+  .metric-big { font-size: 40px; }
+}

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1,0 +1,657 @@
+(function () {
+  const D = window.SleepData;
+  const STAGE_COLORS = {
+    deep: "oklch(0.48 0.14 275)",
+    light: "oklch(0.68 0.14 295)",
+    rem: "oklch(0.82 0.13 220)",
+    awake: "oklch(0.78 0.15 60)",
+  };
+
+  const PREFS = /*EDITMODE-BEGIN*/{
+    "focusNightIndex": 29,
+    "accent": "violet",
+    "showGrain": true
+  }/*EDITMODE-END*/;
+
+  try {
+    const saved = JSON.parse(localStorage.getItem("sleep-prefs") || "{}");
+    Object.assign(PREFS, saved);
+  } catch (e) {}
+
+  const savePrefs = () => {
+    try { localStorage.setItem("sleep-prefs", JSON.stringify(PREFS)); } catch (e) {}
+  };
+
+  const pad = (n) => String(n).padStart(2, "0");
+  const fmtHM = (d) => `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  const fmtDateLong = (d) => d.toLocaleDateString("en-US", { weekday: "long", month: "long", day: "numeric" });
+  const fmtDay = (d) => d.toLocaleDateString("en-US", { weekday: "short" });
+  const hoursMinutes = (ms) => {
+    const m = Math.round(ms / 60000);
+    return `${Math.floor(m / 60)}h ${pad(m % 60)}m`;
+  };
+
+  const app = document.getElementById("app");
+
+  function topbar() {
+    return `
+      <div class="topbar">
+        <div class="brand">
+          <div class="brand-moon"></div>
+          <div class="brand-text">Nightfall <em>/</em> Samsung Sleep</div>
+        </div>
+        <div class="top-meta">
+          <span><span class="dot"></span>Watch synced · ${fmtHM(new Date())}</span>
+          <span>${D.sessions.length} nights observed</span>
+        </div>
+      </div>
+    `;
+  }
+
+  function nightArcSVG(session) {
+    const w = 520, h = 360, cx = w / 2, by = h - 40, radius = w / 2 - 30;
+    const start = session.sleep_start, end = session.sleep_end;
+    const total = end - start;
+    const pt = (t) => {
+      const angle = Math.PI - t * Math.PI;
+      return [cx + Math.cos(angle) * radius, by - Math.sin(angle) * radius * 0.75];
+    };
+    let pathLayers = "";
+    for (const st of session.stages) {
+      const t0 = (st.stage_start - start) / total;
+      const t1 = (st.stage_end - start) / total;
+      const steps = Math.max(2, Math.ceil((t1 - t0) * 80));
+      const pts = [];
+      for (let i = 0; i <= steps; i++) pts.push(pt(t0 + (i / steps) * (t1 - t0)));
+      const d = pts.map((p, i) => (i === 0 ? `M${p[0]},${p[1]}` : `L${p[0]},${p[1]}`)).join(" ");
+      pathLayers += `<path d="${d}" fill="none" stroke="${STAGE_COLORS[st.stage_type]}" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>`;
+    }
+    const horizon = `<line x1="20" x2="${w - 20}" y1="${by}" y2="${by}" stroke="rgba(255,255,255,0.12)" stroke-width="1"/>`;
+    const startLabel = `<text x="30" y="${by + 24}" class="arc-label">Bedtime</text><text x="30" y="${by + 44}" class="arc-time">${fmtHM(start)}</text>`;
+    const endLabel = `<text x="${w - 30}" y="${by + 24}" class="arc-label" text-anchor="end">Wake</text><text x="${w - 30}" y="${by + 44}" class="arc-time" text-anchor="end">${fmtHM(end)}</text>`;
+    let stars = "";
+    for (let i = 0; i < 18; i++) {
+      const x = (i * 37) % (w - 40) + 20;
+      const y = Math.max(20, (i * 53) % (by - 80));
+      const r = (i % 3 === 0) ? 1.5 : 0.8;
+      stars += `<circle cx="${x}" cy="${y}" r="${r}" fill="oklch(0.9 0.02 270)" opacity="${0.3 + (i % 4) * 0.15}"/>`;
+    }
+    const moon = `<circle cx="${w - 60}" cy="40" r="14" fill="url(#moonGrad)"/>`;
+    return `
+      <svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="xMidYMid meet">
+        <defs>
+          <radialGradient id="moonGrad" cx="0.35" cy="0.35">
+            <stop offset="0%" stop-color="oklch(0.96 0.02 85)"/>
+            <stop offset="70%" stop-color="oklch(0.8 0.04 85)"/>
+            <stop offset="100%" stop-color="oklch(0.5 0.03 85)"/>
+          </radialGradient>
+        </defs>
+        ${stars}${moon}${horizon}${pathLayers}${startLabel}${endLabel}
+      </svg>
+    `;
+  }
+
+  function hero() {
+    const last = D.sessions[D.sessions.length - 1];
+    const dur = hoursMinutes(last.duration_ms);
+    const remPct = Math.round((last.totals.rem / last.duration_ms) * 100);
+    return `
+      <section class="hero">
+        <div class="hero-text">
+          <span class="eyebrow">${fmtDateLong(last.sleep_end)} · Last night</span>
+          <h1>You traced an <em>arc</em><br/>across the night.</h1>
+          <p class="lede">${dur} of sleep, through ${last.stages.filter((s)=>s.stage_type==="rem").length} REM cycles. Your body cooled, dreamt, and surfaced — in that order.</p>
+          <div class="hero-stats">
+            <div class="hero-stat"><div class="k">Score</div><div class="v">${last.score}<small>/100</small></div></div>
+            <div class="hero-stat"><div class="k">In bed</div><div class="v">${last.duration_hours.toFixed(1)}<small>h</small></div></div>
+            <div class="hero-stat"><div class="k">REM</div><div class="v">${remPct}<small>%</small></div></div>
+          </div>
+        </div>
+        <div class="night-arc">${nightArcSVG(last)}</div>
+      </section>
+    `;
+  }
+
+  function chapterHeatmap() {
+    const rows = [];
+    let header = '<div></div>';
+    for (let h = 0; h < 24; h++) header += `<div class="hour-head">${h % 3 === 0 ? pad(h) : ""}</div>`;
+    rows.push(header);
+
+    const hourMap = {};
+    for (const s of D.sessions) {
+      let cursor = new Date(s.sleep_start);
+      cursor.setMinutes(0, 0, 0);
+      while (cursor < s.sleep_end) {
+        const key = cursor.toISOString().slice(0, 10);
+        const h = cursor.getHours();
+        if (!hourMap[key]) hourMap[key] = {};
+        if (!hourMap[key][h]) hourMap[key][h] = { stages: {} };
+        const hs = cursor.getTime(), he = hs + 3600000;
+        for (const st of s.stages) {
+          const ss = st.stage_start.getTime(), se = st.stage_end.getTime();
+          if (ss < he && se > hs) {
+            const overlap = Math.min(he, se) - Math.max(hs, ss);
+            hourMap[key][h].stages[st.stage_type] = (hourMap[key][h].stages[st.stage_type] || 0) + overlap;
+          }
+        }
+        cursor = new Date(cursor.getTime() + 3600000);
+      }
+    }
+
+    for (const s of D.sessions) {
+      const day = new Date(s.sleep_end);
+      day.setHours(0, 0, 0, 0);
+      const label = `${fmtDay(day)} ${day.getDate()}`;
+      let row = `<div class="day-label">${label}</div>`;
+      for (let h = 0; h < 24; h++) {
+        let cell = null;
+        const yesterday = new Date(day); yesterday.setDate(yesterday.getDate() - 1);
+        const todayKey = day.toISOString().slice(0, 10);
+        const yestKey = yesterday.toISOString().slice(0, 10);
+        if (h >= 18 && hourMap[yestKey]?.[h]) cell = hourMap[yestKey][h];
+        else if (h < 18 && hourMap[todayKey]?.[h]) cell = hourMap[todayKey][h];
+        if (cell) {
+          let best = null, max = 0;
+          for (const [t, ms] of Object.entries(cell.stages)) if (ms > max) { max = ms; best = t; }
+          const tip = Object.entries(cell.stages).map(([t, ms]) => `${t}: ${Math.round(ms / 60000)}m`).join(" · ");
+          row += `<div class="cell ${best}" data-tip="${fmtDateLong(day)} · ${pad(h)}:00\n${tip}"></div>`;
+        } else row += `<div class="cell"></div>`;
+      }
+      rows.push(row);
+    }
+
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">01</span><span class="eyebrow">Calendar heatmap</span></div>
+        <h2>Thirty nights, <em>unfolded</em> hour by hour.</h2>
+        <p class="chapter-desc">Each row is a night. Each cell is one hour, coloured by the dominant sleep stage.</p>
+      </div>
+      <div class="panel">
+        <div class="heatmap-wrap"><div class="heatmap">${rows.join("")}</div></div>
+        <div class="legend">
+          <span><span class="sw" style="background:${STAGE_COLORS.deep}"></span>Deep</span>
+          <span><span class="sw" style="background:${STAGE_COLORS.light}"></span>Light</span>
+          <span><span class="sw" style="background:${STAGE_COLORS.rem}"></span>REM</span>
+          <span><span class="sw" style="background:${STAGE_COLORS.awake}"></span>Awake</span>
+        </div>
+      </div>
+    `;
+  }
+
+  function chapterTimeline() {
+    const startHour = 18, spanHours = 18, spanMs = spanHours * 3600000;
+    const rows = D.sessions.map((s) => {
+      const wake = new Date(s.sleep_end); wake.setHours(0, 0, 0, 0);
+      const anchorMs = wake.getTime() - (24 - startHour) * 3600000;
+      const segs = s.stages.map((st) => {
+        const left = ((st.stage_start.getTime() - anchorMs) / spanMs) * 100;
+        const width = ((st.stage_end - st.stage_start) / spanMs) * 100;
+        return `<div class="stage-seg ${st.stage_type}" style="left:${left}%;width:${width}%"></div>`;
+      }).join("");
+      const label = `${fmtDay(wake)} ${wake.getDate()}`;
+      const tip = `${fmtDateLong(wake)}\n${fmtHM(s.sleep_start)} → ${fmtHM(s.sleep_end)} · ${hoursMinutes(s.duration_ms)}`;
+      return `<div class="timeline-row" data-tip="${tip}"><div class="label">${label}</div><div class="track">${segs}</div></div>`;
+    }).join("");
+    const ticks = [];
+    for (let i = 0; i <= spanHours; i += 3) {
+      const hour = (startHour + i) % 24;
+      ticks.push(`<div class="tick" style="left:${(i / spanHours) * 100}%">${pad(hour)}</div>`);
+    }
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">02</span><span class="eyebrow">Stacked timeline</span></div>
+        <h2>Your bedtime <em>drifts</em>, but not by much.</h2>
+        <p class="chapter-desc">Each bar is one night, from 6pm to noon. The longer the bar, the longer the night.</p>
+      </div>
+      <div class="panel">
+        <div class="timeline"><div class="timeline-axis">${ticks.join("")}</div>${rows}</div>
+      </div>
+    `;
+  }
+
+  let focusIdx = Math.min(Math.max(0, PREFS.focusNightIndex), D.sessions.length - 1);
+
+  function hypnogramSVG(session) {
+    const w = 1000, h = 260, padL = 70, padR = 20, padT = 16, padB = 40;
+    const innerW = w - padL - padR, innerH = h - padT - padB;
+    const yForStage = { awake: padT + innerH * 0.08, rem: padT + innerH * 0.32, light: padT + innerH * 0.58, deep: padT + innerH * 0.88 };
+    const start = session.sleep_start.getTime(), end = session.sleep_end.getTime(), total = end - start;
+    let segs = "";
+    for (const st of session.stages) {
+      const x0 = padL + ((st.stage_start.getTime() - start) / total) * innerW;
+      const x1 = padL + ((st.stage_end.getTime() - start) / total) * innerW;
+      const y = yForStage[st.stage_type];
+      const baseY = padT + innerH;
+      segs += `<rect x="${x0}" y="${y}" width="${x1 - x0}" height="${baseY - y}" fill="${STAGE_COLORS[st.stage_type]}" opacity="0.2"/>`;
+      segs += `<line x1="${x0}" x2="${x1}" y1="${y}" y2="${y}" stroke="${STAGE_COLORS[st.stage_type]}" stroke-width="2.5" stroke-linecap="round"/>`;
+    }
+    const yLabels = Object.entries(yForStage).map(([k, y]) => `<line class="hypno-grid-line" x1="${padL}" x2="${w - padR}" y1="${y}" y2="${y}"/><text class="hypno-y-label" x="${padL - 12}" y="${y + 4}" text-anchor="end">${k}</text>`).join("");
+    const hours = total / 3600000;
+    let xTicks = "";
+    for (let i = 0; i <= hours; i++) {
+      const t = session.sleep_start.getTime() + i * 3600000;
+      const x = padL + (i / hours) * innerW;
+      xTicks += `<text class="hypno-x-label" x="${x}" y="${h - 14}" text-anchor="middle">${pad(new Date(t).getHours())}:00</text>`;
+    }
+    return `<svg class="hypno-svg" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none">${yLabels}${segs}${xTicks}</svg>`;
+  }
+
+  function chapterHypnogram() {
+    const s = D.sessions[focusIdx];
+    const totals = s.totals;
+    const stats = [
+      { k: "Deep", v: hoursMinutes(totals.deep), pct: totals.deep / s.duration_ms, stage: "deep" },
+      { k: "REM", v: hoursMinutes(totals.rem), pct: totals.rem / s.duration_ms, stage: "rem" },
+      { k: "Light", v: hoursMinutes(totals.light), pct: totals.light / s.duration_ms, stage: "light" },
+      { k: "Awake", v: hoursMinutes(totals.awake), pct: totals.awake / s.duration_ms, stage: "awake" },
+    ];
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">03</span><span class="eyebrow">Hypnogram</span></div>
+        <h2>One night, <em>zoomed in</em>.</h2>
+        <p class="chapter-desc">The classic sleep-lab staircase. Sharp climbs back to REM are where you were dreaming.</p>
+      </div>
+      <div class="panel">
+        <div class="hypno-header">
+          <div class="hypno-date">${fmtDateLong(s.sleep_end)}</div>
+          <div class="hypno-controls"><button id="hypno-prev">‹</button><button id="hypno-next">›</button></div>
+        </div>
+        <div class="hypno-stats">
+          ${stats.map((st) => `<div class="hypno-stat"><div class="k"><span class="sw" style="background:${STAGE_COLORS[st.stage]}"></span>${st.k}</div><div class="v">${st.v}</div><div class="pct">${Math.round(st.pct * 100)}% of night</div></div>`).join("")}
+        </div>
+        <div class="hypno-svg-wrap">${hypnogramSVG(s)}</div>
+      </div>
+    `;
+  }
+
+  function radialSVG(session) {
+    const w = 520, cx = w / 2, cy = w / 2, rOuter = w * 0.46, rInner = w * 0.32;
+    function angleForTime(d) { return -Math.PI / 2 + ((d.getHours() + d.getMinutes() / 60) / 24) * Math.PI * 2; }
+    let stageArcs = "";
+    for (const st of session.stages) {
+      const a0 = angleForTime(st.stage_start);
+      const a1 = angleForTime(st.stage_end);
+      let d = a1 - a0; if (d < 0) d += 2 * Math.PI;
+      const largeArc = d > Math.PI ? 1 : 0;
+      const x0 = cx + Math.cos(a0) * rInner, y0 = cy + Math.sin(a0) * rInner;
+      const x1 = cx + Math.cos(a1) * rInner, y1 = cy + Math.sin(a1) * rInner;
+      const x2 = cx + Math.cos(a1) * rOuter, y2 = cy + Math.sin(a1) * rOuter;
+      const x3 = cx + Math.cos(a0) * rOuter, y3 = cy + Math.sin(a0) * rOuter;
+      const p = `M${x0},${y0} A${rInner},${rInner} 0 ${largeArc} 1 ${x1},${y1} L${x2},${y2} A${rOuter},${rOuter} 0 ${largeArc} 0 ${x3},${y3} Z`;
+      stageArcs += `<path d="${p}" fill="${STAGE_COLORS[st.stage_type]}" opacity="0.85"/>`;
+    }
+    let ticks = "";
+    for (let h = 0; h < 24; h++) {
+      const a = -Math.PI / 2 + (h / 24) * Math.PI * 2;
+      const r1 = rOuter + 4, r2 = rOuter + (h % 6 === 0 ? 16 : 8);
+      ticks += `<line x1="${cx + Math.cos(a) * r1}" y1="${cy + Math.sin(a) * r1}" x2="${cx + Math.cos(a) * r2}" y2="${cy + Math.sin(a) * r2}" stroke="rgba(255,255,255,${h % 6 === 0 ? 0.4 : 0.15})" stroke-width="1"/>`;
+      if (h % 6 === 0) {
+        const rt = rOuter + 32;
+        ticks += `<text x="${cx + Math.cos(a) * rt}" y="${cy + Math.sin(a) * rt + 4}" text-anchor="middle" font-family="Geist Mono" font-size="11" fill="rgba(232,228,245,0.6)">${pad(h)}</text>`;
+      }
+    }
+    const durHrs = session.duration_hours.toFixed(1);
+    const center = `<text x="${cx}" y="${cy - 8}" text-anchor="middle" font-family="Instrument Serif" font-size="48" fill="#e8e4f5">${durHrs}</text><text x="${cx}" y="${cy + 18}" text-anchor="middle" font-family="Geist Mono" font-size="10" fill="#6a6488" letter-spacing="0.15em">HOURS</text>`;
+    return `<svg viewBox="0 0 ${w} ${w}" class="radial-svg"><circle cx="${cx}" cy="${cy}" r="${(rOuter + rInner) / 2}" fill="none" stroke="rgba(255,255,255,0.04)" stroke-width="${rOuter - rInner}"/>${stageArcs}${ticks}${center}</svg>`;
+  }
+
+  function chapterRadial() {
+    const s = D.sessions[focusIdx];
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">04</span><span class="eyebrow">Radial clock</span></div>
+        <h2>A night shaped like a <em>clock face</em>.</h2>
+        <p class="chapter-desc">Twelve at the top, noon at the bottom. The ring's colour shifts with every stage.</p>
+      </div>
+      <div class="panel">
+        <div class="radial-wrap">
+          <div>${radialSVG(s)}</div>
+          <div class="radial-info">
+            <h3>${fmtDateLong(s.sleep_end)}</h3>
+            <p>Read clockwise from midnight. The ring is your night, with each colour marking a sleep stage in real time.</p>
+            <dl class="radial-kv">
+              <dt>Bedtime</dt><dd>${fmtHM(s.sleep_start)}</dd>
+              <dt>Wake</dt><dd>${fmtHM(s.sleep_end)}</dd>
+              <dt>Duration</dt><dd>${hoursMinutes(s.duration_ms)}</dd>
+              <dt>Efficiency</dt><dd>${Math.round(s.efficiency * 100)}%</dd>
+              <dt>Score</dt><dd>${s.score} / 100</dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function smCell(session, idx) {
+    const w = 100, h = 36;
+    const yForStage = { awake: h * 0.08, rem: h * 0.3, light: h * 0.55, deep: h * 0.92 };
+    const start = session.sleep_start.getTime(), total = session.duration_ms;
+    let segs = "";
+    for (const st of session.stages) {
+      const x0 = ((st.stage_start.getTime() - start) / total) * w;
+      const x1 = ((st.stage_end.getTime() - start) / total) * w;
+      const y = yForStage[st.stage_type];
+      segs += `<line x1="${x0}" x2="${x1}" y1="${y}" y2="${y}" stroke="${STAGE_COLORS[st.stage_type]}" stroke-width="2.2" stroke-linecap="round"/>`;
+    }
+    const wake = new Date(session.sleep_end);
+    return `<div class="sm-cell${idx === focusIdx ? ' active' : ''}" data-idx="${idx}"><div class="sm-cell-head"><span class="sm-date">${fmtDay(wake)} ${wake.getDate()}</span><span class="sm-score">${session.score}</span></div><svg viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" class="sm-svg">${segs}</svg><div class="sm-duration">${hoursMinutes(session.duration_ms)}</div></div>`;
+  }
+
+  function chapterSmallMultiples() {
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">05</span><span class="eyebrow">Small multiples</span></div>
+        <h2>Thirty <em>signatures</em>, side by side.</h2>
+        <p class="chapter-desc">Click any night to send it to the hypnogram and radial clock above.</p>
+      </div>
+      <div class="panel"><div class="sm-grid" id="sm-grid">${D.sessions.map(smCell).join("")}</div></div>
+    `;
+  }
+
+  function chapterRidgeline() {
+    const w = 1000, rowH = 22, amp = 28, n = D.sessions.length, h = n * rowH + 80;
+    const padL = 80, padR = 20, innerW = w - padL - padR, spanH = 18;
+    let paths = "";
+    for (let i = 0; i < n; i++) {
+      const s = D.sessions[i];
+      const y0 = 40 + i * rowH;
+      const wake = new Date(s.sleep_end); wake.setHours(0, 0, 0, 0);
+      const anchor = wake.getTime() - 6 * 3600000;
+      const samples = 200;
+      const points = [];
+      for (let k = 0; k <= samples; k++) {
+        const t = anchor + (k / samples) * spanH * 3600000;
+        let depth = 0;
+        for (const st of s.stages) {
+          if (st.stage_start.getTime() <= t && t < st.stage_end.getTime()) {
+            depth = { awake: 0.1, rem: 0.35, light: 0.6, deep: 1.0 }[st.stage_type];
+            break;
+          }
+        }
+        points.push([padL + (k / samples) * innerW, y0 - depth * amp]);
+      }
+      let d = `M${padL},${y0}`;
+      for (const [x, y] of points) d += ` L${x.toFixed(1)},${y.toFixed(1)}`;
+      d += ` L${padL + innerW},${y0} Z`;
+      const label = `${fmtDay(wake)} ${pad(wake.getDate())}`;
+      paths += `<path d="${d}" fill="url(#ridgeGrad)" stroke="oklch(0.75 0.12 280)" stroke-width="1" opacity="${0.3 + (i / n) * 0.55}"/><text class="ridge-label" x="${padL - 10}" y="${y0 + 3}" text-anchor="end">${label}</text>`;
+    }
+    let ticks = "";
+    for (let k = 0; k <= spanH; k += 3) {
+      const x = padL + (k / spanH) * innerW;
+      const hour = (18 + k) % 24;
+      ticks += `<text class="ridge-label" x="${x}" y="20" text-anchor="middle">${pad(hour)}:00</text><line x1="${x}" x2="${x}" y1="28" y2="${h - 20}" stroke="rgba(255,255,255,0.04)" stroke-width="1"/>`;
+    }
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">06</span><span class="eyebrow">Ridgeline</span></div>
+        <h2>A range of <em>mountains</em> — each one a night.</h2>
+        <p class="chapter-desc">Depth maps to altitude. The thickest peaks are your deepest dives.</p>
+      </div>
+      <div class="panel">
+        <svg viewBox="0 0 ${w} ${h}" class="ridge-svg" preserveAspectRatio="none" style="height:${h * 0.7}px">
+          <defs><linearGradient id="ridgeGrad" x1="0" x2="0" y1="0" y2="1"><stop offset="0%" stop-color="oklch(0.7 0.15 285)" stop-opacity="0.75"/><stop offset="100%" stop-color="oklch(0.25 0.08 275)" stop-opacity="0.2"/></linearGradient></defs>
+          ${ticks}${paths}
+        </svg>
+      </div>
+    `;
+  }
+
+  function chapterCards() {
+    const top = [...D.sessions].sort((a, b) => b.score - a.score).slice(0, 4);
+    const cards = top.map((s, i) => {
+      const total = s.duration_ms;
+      const segs = ["deep", "light", "rem", "awake"].map((k) => `<div class="s ${k}" style="width:${(s.totals[k] / total) * 100}%"></div>`).join("");
+      return `<div class="night-card"><div class="rank">Rank ${pad(i + 1)}</div><div class="date">${fmtDateLong(s.sleep_end)}</div><div class="score"><span class="n">${s.score}</span><span class="label">/ 100</span></div><div class="mini-stages">${segs}</div><div class="times"><span>${fmtHM(s.sleep_start)}</span><span>${hoursMinutes(s.duration_ms)}</span><span>${fmtHM(s.sleep_end)}</span></div></div>`;
+    }).join("");
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">07</span><span class="eyebrow">Top nights</span></div>
+        <h2>The nights that <em>earned their stars</em>.</h2>
+        <p class="chapter-desc">Your four highest-scoring nights — a blend of duration, efficiency, REM%, and low fragmentation.</p>
+      </div>
+      <div class="cards-grid">${cards}</div>
+    `;
+  }
+
+  function chapterAgenda() {
+    const last7 = D.sessions.slice(-7);
+    const startHour = 18, totalH = 18;
+    const hoursList = [];
+    for (let i = 0; i <= totalH; i++) {
+      const hour = (startHour + i) % 24;
+      const topPct = (i / totalH) * 100;
+      hoursList.push(`<div style="position:absolute;top:${topPct}%;right:8px;transform:translateY(-50%);font-family:'Geist Mono',monospace;font-size:9px;color:#6a6488;">${pad(hour)}:00</div>`);
+    }
+    const heads = last7.map((s) => {
+      const wake = new Date(s.sleep_end);
+      return `<div class="agenda-day-head">${fmtDay(wake)}<span class="num">${pad(wake.getDate())}</span></div>`;
+    }).join("");
+    const days = last7.map((s) => {
+      const wake = new Date(s.sleep_end); wake.setHours(0, 0, 0, 0);
+      const anchor = wake.getTime() - (24 - startHour) * 3600000;
+      const spanMs = totalH * 3600000;
+      const segs = s.stages.map((st) => {
+        const topPct = ((st.stage_start.getTime() - anchor) / spanMs) * 100;
+        const heightPct = ((st.stage_end - st.stage_start) / spanMs) * 100;
+        return `<div class="agenda-seg ${st.stage_type}" style="top:${topPct}%;height:${heightPct}%"></div>`;
+      }).join("");
+      return `<div class="agenda-day" style="height:460px;">${segs}</div>`;
+    }).join("");
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">08</span><span class="eyebrow">Week agenda</span></div>
+        <h2>Your last seven nights, <em>stood upright</em>.</h2>
+        <p class="chapter-desc">Time flows downward. Weekends push bedtime later.</p>
+      </div>
+      <div class="panel">
+        <div style="display:grid;grid-template-columns:60px repeat(7,1fr);gap:2px;">
+          <div></div>${heads}
+          <div style="position:relative; height:460px; border-right:1px solid rgba(255,255,255,0.06);">${hoursList.join("")}</div>
+          ${days}
+        </div>
+      </div>
+    `;
+  }
+
+  function bedtimeScatterSVG() {
+    const w = 500, h = 140, padL = 40, padR = 10, padT = 10, padB = 24;
+    const innerW = w - padL - padR, innerH = h - padT - padB;
+    const yMinHour = 20 * 60, yRange = 6 * 60;
+    let dots = "";
+    const values = [];
+    for (let i = 0; i < D.sessions.length; i++) {
+      let minOfDay = D.sessions[i].sleep_start.getHours() * 60 + D.sessions[i].sleep_start.getMinutes();
+      if (minOfDay < 12 * 60) minOfDay += 24 * 60;
+      values.push(minOfDay);
+      const x = padL + (i / (D.sessions.length - 1)) * innerW;
+      const y = padT + ((minOfDay - yMinHour) / yRange) * innerH;
+      dots += `<circle class="scatter-dot" cx="${x}" cy="${y}" r="3"/>`;
+    }
+    const mean = values.reduce((a, b) => a + b, 0) / values.length;
+    const meanY = padT + ((mean - yMinHour) / yRange) * innerH;
+    const horizLine = `<line class="scatter-guide" x1="${padL}" x2="${w - padR}" y1="${meanY}" y2="${meanY}"/>`;
+    let yTicks = "";
+    for (let m = yMinHour; m <= yMinHour + yRange; m += 60) {
+      const y = padT + ((m - yMinHour) / yRange) * innerH;
+      const hh = Math.floor((m / 60) % 24);
+      yTicks += `<text class="scatter-label" x="${padL - 6}" y="${y + 3}" text-anchor="end">${pad(hh)}:00</text>`;
+    }
+    return `<svg class="scatter-svg" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none">${yTicks}${horizLine}${dots}</svg>`;
+  }
+
+  function hrSparkSVG() {
+    const w = 500, h = 140, padL = 40, padR = 10, padT = 10, padB = 24;
+    const innerW = w - padL - padR, innerH = h - padT - padB;
+    const vals = D.sessions.map((s) => D.hr[s.date_key]);
+    const min = Math.min(...vals) - 2, max = Math.max(...vals) + 2, range = max - min;
+    const pts = vals.map((v, i) => [padL + (i / (vals.length - 1)) * innerW, padT + innerH - ((v - min) / range) * innerH]);
+    const line = pts.map((p, i) => (i === 0 ? `M${p[0]},${p[1]}` : `L${p[0]},${p[1]}`)).join(" ");
+    const area = `${line} L${pts[pts.length - 1][0]},${padT + innerH} L${pts[0][0]},${padT + innerH} Z`;
+    let yTicks = "";
+    for (let i = 0; i <= 2; i++) {
+      const v = min + (range * i) / 2;
+      const y = padT + innerH - ((v - min) / range) * innerH;
+      yTicks += `<text class="scatter-label" x="${padL - 6}" y="${y + 3}" text-anchor="end">${Math.round(v)}</text><line class="scatter-guide" x1="${padL}" x2="${w - padR}" y1="${y}" y2="${y}"/>`;
+    }
+    return `<svg class="hr-svg" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none"><defs><linearGradient id="hrGrad" x1="0" x2="0" y1="0" y2="1"><stop offset="0%" stop-color="oklch(0.82 0.13 220)" stop-opacity="0.5"/><stop offset="100%" stop-color="oklch(0.82 0.13 220)" stop-opacity="0"/></linearGradient></defs>${yTicks}<path class="hr-area" d="${area}"/><path class="hr-line" d="${line}"/></svg>`;
+  }
+
+  function debtBars() {
+    return D.sessions.slice(-14).map((s) => {
+      const wake = new Date(s.sleep_end);
+      const diff = s.duration_hours - 8;
+      const pct = Math.min(50, Math.abs(diff) * 14);
+      const side = diff < 0 ? "deficit" : "surplus";
+      const style = diff < 0 ? `right:50%;width:${pct}%` : `left:50%;width:${pct}%`;
+      return `<div class="debt-row"><span>${fmtDay(wake)} ${pad(wake.getDate())}</span><div class="debt-bar-track"><div class="debt-bar ${side}" style="${style}"></div></div><span style="text-align:right;color:${diff<0?"oklch(0.7 0.17 25)":"oklch(0.78 0.14 155)"}">${diff>=0?"+":""}${diff.toFixed(1)}h</span></div>`;
+    }).join("");
+  }
+
+  function stageGauge() {
+    const targets = { deep: 0.15, rem: 0.22, light: 0.55, awake: 0.08 };
+    const total = D.sessions.reduce((a, s) => a + s.duration_ms, 0);
+    const totals = { deep: 0, rem: 0, light: 0, awake: 0 };
+    for (const s of D.sessions) for (const k of Object.keys(totals)) totals[k] += s.totals[k];
+    return Object.keys(targets).map((k) => {
+      const pct = totals[k] / total, tpct = targets[k];
+      const width = Math.min(100, (pct / (tpct * 1.6)) * 100);
+      const targetX = (tpct / (tpct * 1.6)) * 100;
+      return `<div class="stage-bar-row"><span class="name">${k}</span><div class="track"><div class="fill ${k}" style="width:${width}%"></div><div class="target" style="left:${targetX}%"></div></div><span class="val">${(pct * 100).toFixed(1)}%</span></div>`;
+    }).join("");
+  }
+
+  function chapterMetrics() {
+    const summary = D.summary;
+    const debtSign = summary.debt > 0 ? "" : "+";
+    return `
+      <div class="chapter">
+        <div class="chapter-label"><span class="chapter-num">09</span><span class="eyebrow">Metrics</span></div>
+        <h2>The <em>numbers</em> behind the nights.</h2>
+        <p class="chapter-desc">Regularity, debt, stage composition, resting heart rate.</p>
+      </div>
+      <div class="metrics-grid">
+        <div class="metric-card">
+          <div class="head"><h3>Bedtime regularity</h3><span class="hint">σ = ${summary.bedtimeStdDev.toFixed(0)} min</span></div>
+          <div class="metric-big">${Math.round(summary.regularity)}<small>/100</small></div>
+          <div class="metric-body">${bedtimeScatterSVG()}</div>
+          <p class="metric-caption">Each dot is a bedtime. The tighter the cloud, the more your circadian rhythm trusts you.</p>
+        </div>
+        <div class="metric-card">
+          <div class="head"><h3>Sleep debt</h3><span class="hint">vs 8h target</span></div>
+          <div class="metric-big">${debtSign}${(-summary.debt).toFixed(1)}<small>h cumulative</small></div>
+          <div class="metric-body" style="margin-top:10px;">${debtBars()}</div>
+          <p class="metric-caption">Last 14 nights. Bars left are hours short; bars right are hours over.</p>
+        </div>
+        <div class="metric-card">
+          <div class="head"><h3>Stage mix</h3><span class="hint">30-night avg</span></div>
+          <div class="metric-big">${Math.round((D.summary.avgRem / (D.summary.avgRem + D.summary.avgDeep + D.summary.avgLight + D.summary.avgAwake)) * 100)}<small>% REM</small></div>
+          <div class="metric-body"><div class="stage-bar-group">${stageGauge()}</div></div>
+          <p class="metric-caption">White ticks mark healthy targets. Deep anchors physical recovery; REM consolidates memory.</p>
+        </div>
+        <div class="metric-card">
+          <div class="head"><h3>Nighttime heart rate</h3><span class="hint">resting, 30 nights</span></div>
+          <div class="metric-big">${Math.round(summary.avgRestingHR)}<small>bpm avg</small></div>
+          <div class="metric-body">${hrSparkSVG()}</div>
+          <p class="metric-caption">Lower is calmer. Dips after good workouts; spikes after late meals or stress.</p>
+        </div>
+      </div>
+    `;
+  }
+
+  function footer() {
+    return `<footer><span>Nightfall · Samsung Health pipeline</span><span>health.db · ${D.sessions.length} sessions · ${D.sessions.reduce((a,s)=>a+s.stages.length,0)} stages</span><span>Press T for tweaks</span></footer>`;
+  }
+
+  function tweaksPanel() {
+    return `
+      <div id="tweaks">
+        <h4>Tweaks</h4>
+        <div class="tweak-row">
+          <label>Accent</label>
+          <div class="tweak-pills" data-key="accent">
+            <button class="tweak-pill ${PREFS.accent==='violet'?'active':''}" data-v="violet">Violet</button>
+            <button class="tweak-pill ${PREFS.accent==='cyan'?'active':''}" data-v="cyan">Cyan</button>
+            <button class="tweak-pill ${PREFS.accent==='amber'?'active':''}" data-v="amber">Amber</button>
+          </div>
+        </div>
+        <div class="tweak-row">
+          <label>Grain</label>
+          <div class="tweak-pills" data-key="showGrain">
+            <button class="tweak-pill ${PREFS.showGrain?'active':''}" data-v="true">On</button>
+            <button class="tweak-pill ${!PREFS.showGrain?'active':''}" data-v="false">Off</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function render() {
+    app.innerHTML = topbar() + hero() + chapterHeatmap() + chapterTimeline() + chapterHypnogram() + chapterRadial() + chapterSmallMultiples() + chapterRidgeline() + chapterCards() + chapterAgenda() + chapterMetrics() + footer() + tweaksPanel() + `<div id="hover-tip"></div>`;
+    bindEvents();
+    applyPrefs();
+  }
+
+  function bindEvents() {
+    document.getElementById("hypno-prev")?.addEventListener("click", () => {
+      focusIdx = (focusIdx - 1 + D.sessions.length) % D.sessions.length;
+      PREFS.focusNightIndex = focusIdx; savePrefs(); render();
+    });
+    document.getElementById("hypno-next")?.addEventListener("click", () => {
+      focusIdx = (focusIdx + 1) % D.sessions.length;
+      PREFS.focusNightIndex = focusIdx; savePrefs(); render();
+    });
+    document.querySelectorAll(".sm-cell").forEach((el) => {
+      el.addEventListener("click", () => {
+        focusIdx = parseInt(el.dataset.idx, 10);
+        PREFS.focusNightIndex = focusIdx; savePrefs(); render();
+      });
+    });
+    const tip = document.getElementById("hover-tip");
+    document.querySelectorAll("[data-tip]").forEach((el) => {
+      el.addEventListener("mouseenter", () => { tip.textContent = el.dataset.tip; tip.classList.add("show"); });
+      el.addEventListener("mousemove", (e) => { tip.style.left = e.clientX + 14 + "px"; tip.style.top = e.clientY + 14 + "px"; });
+      el.addEventListener("mouseleave", () => tip.classList.remove("show"));
+    });
+    document.querySelectorAll(".tweak-pills").forEach((group) => {
+      const key = group.dataset.key;
+      group.querySelectorAll(".tweak-pill").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          let v = btn.dataset.v;
+          if (v === "true") v = true; else if (v === "false") v = false;
+          PREFS[key] = v; savePrefs();
+          try { window.parent.postMessage({ type: "__edit_mode_set_keys", edits: { [key]: v } }, "*"); } catch (e) {}
+          group.querySelectorAll(".tweak-pill").forEach((b) => b.classList.remove("active"));
+          btn.classList.add("active");
+          applyPrefs();
+        });
+      });
+    });
+  }
+
+  function applyPrefs() {
+    const root = document.documentElement;
+    const accentMap = { violet: "oklch(0.68 0.14 295)", cyan: "oklch(0.82 0.13 220)", amber: "oklch(0.78 0.15 60)" };
+    root.style.setProperty("--stage-rem", accentMap[PREFS.accent] || accentMap.violet);
+    root.style.setProperty("--grain-opacity", PREFS.showGrain ? "0.04" : "0");
+  }
+
+  document.addEventListener("mousemove", (e) => {
+    document.documentElement.style.setProperty("--mx", e.clientX + "px");
+    document.documentElement.style.setProperty("--my", e.clientY + "px");
+  });
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "t" || e.key === "T") document.getElementById("tweaks")?.classList.toggle("show");
+    if (e.key === "ArrowLeft") { focusIdx = (focusIdx - 1 + D.sessions.length) % D.sessions.length; render(); }
+    if (e.key === "ArrowRight") { focusIdx = (focusIdx + 1) % D.sessions.length; render(); }
+  });
+  window.addEventListener("message", (e) => {
+    if (!e.data) return;
+    if (e.data.type === "__activate_edit_mode") document.getElementById("tweaks")?.classList.add("show");
+    if (e.data.type === "__deactivate_edit_mode") document.getElementById("tweaks")?.classList.remove("show");
+  });
+  try { window.parent.postMessage({ type: "__edit_mode_available" }, "*"); } catch (e) {}
+
+  window.render = render;
+})();

--- a/static/dashboard.js
+++ b/static/dashboard.js
@@ -1,5 +1,5 @@
 (function () {
-  const D = window.SleepData;
+  let D = window.SleepData;
   const STAGE_COLORS = {
     deep: "oklch(0.48 0.14 275)",
     light: "oklch(0.68 0.14 295)",
@@ -210,7 +210,7 @@
     `;
   }
 
-  let focusIdx = Math.min(Math.max(0, PREFS.focusNightIndex), D.sessions.length - 1);
+  let focusIdx = 0;
 
   function hypnogramSVG(session) {
     const w = 1000, h = 260, padL = 70, padR = 20, padT = 16, padB = 40;
@@ -653,5 +653,9 @@
   });
   try { window.parent.postMessage({ type: "__edit_mode_available" }, "*"); } catch (e) {}
 
-  window.render = render;
+  window.render = function () {
+    D = window.SleepData;
+    focusIdx = Math.min(Math.max(0, PREFS.focusNightIndex), D.sessions.length - 1);
+    render();
+  };
 })();

--- a/static/index.html
+++ b/static/index.html
@@ -1,47 +1,18 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Health Dashboard</title>
-    <link rel="stylesheet" href="/static/style.css">
-</head>
-<body>
-    <div class="container">
-        <header>
-            <button id="prev-month">&larr;</button>
-            <h1 id="month-label"></h1>
-            <button id="next-month">&rarr;</button>
-        </header>
-        <nav class="tabs">
-            <button class="tab active" data-tab="sleep">Sleep</button>
-            <button class="tab" data-tab="steps">Steps</button>
-            <button class="tab" data-tab="heartrate">Heart Rate</button>
-            <button class="tab" data-tab="exercise">Exercise</button>
-            <button class="tab" data-tab="trends">Trends</button>
-        </nav>
-        <div id="panel-sleep" class="panel active">
-            <div id="grid-wrapper">
-                <table id="sleep-grid">
-                    <thead><tr><th>Date</th></tr></thead>
-                    <tbody></tbody>
-                </table>
-            </div>
-        </div>
-        <div id="panel-steps" class="panel">
-            <div id="steps-chart"></div>
-        </div>
-        <div id="panel-heartrate" class="panel">
-            <div id="hr-chart"></div>
-        </div>
-        <div id="panel-exercise" class="panel">
-            <div id="exercise-list"></div>
-        </div>
-        <div id="panel-trends" class="panel">
-            <div id="trends-grid"></div>
-        </div>
-        <div id="tooltip" class="tooltip"></div>
-    </div>
-    <script src="/static/app.js"></script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Nightfall — Samsung Sleep</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/static/dashboard.css" />
+  </head>
+  <body>
+    <div id="app"></div>
+    <div id="cursor-glow"></div>
+    <script src="/static/dashboard.js"></script>
+    <script src="/static/api.js"></script>
+  </body>
 </html>

--- a/tests/test_sleep_api_shape.py
+++ b/tests/test_sleep_api_shape.py
@@ -1,0 +1,94 @@
+"""
+Tests du shape de GET /api/sleep — contrat attendu par le frontend Nightfall (api.js).
+"""
+
+SLEEP_PAYLOAD = {"sessions": [
+    {
+        "sleep_start": "2026-04-20T23:15:00",
+        "sleep_end":   "2026-04-21T07:30:00",
+        "stages": [
+            {"stage_type": "light", "stage_start": "2026-04-20T23:15:00", "stage_end": "2026-04-20T23:45:00"},
+            {"stage_type": "deep",  "stage_start": "2026-04-20T23:45:00", "stage_end": "2026-04-21T01:15:00"},
+            {"stage_type": "rem",   "stage_start": "2026-04-21T01:15:00", "stage_end": "2026-04-21T02:00:00"},
+            {"stage_type": "light", "stage_start": "2026-04-21T02:00:00", "stage_end": "2026-04-21T02:30:00"},
+            {"stage_type": "deep",  "stage_start": "2026-04-21T02:30:00", "stage_end": "2026-04-21T03:30:00"},
+            {"stage_type": "rem",   "stage_start": "2026-04-21T03:30:00", "stage_end": "2026-04-21T04:30:00"},
+            {"stage_type": "light", "stage_start": "2026-04-21T04:30:00", "stage_end": "2026-04-21T05:30:00"},
+            {"stage_type": "rem",   "stage_start": "2026-04-21T05:30:00", "stage_end": "2026-04-21T07:30:00"},
+        ],
+    },
+    {
+        "sleep_start": "2026-04-21T22:45:00",
+        "sleep_end":   "2026-04-22T06:45:00",
+        "stages": [
+            {"stage_type": "light", "stage_start": "2026-04-21T22:45:00", "stage_end": "2026-04-22T00:00:00"},
+            {"stage_type": "deep",  "stage_start": "2026-04-22T00:00:00", "stage_end": "2026-04-22T02:00:00"},
+            {"stage_type": "rem",   "stage_start": "2026-04-22T02:00:00", "stage_end": "2026-04-22T06:45:00"},
+        ],
+    },
+]}
+
+
+def test_sleep_response_fields(client):
+    client.post("/api/sleep", json=SLEEP_PAYLOAD)
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-22&include_stages=true")
+    assert r.status_code == 200
+    sessions = r.json()
+    assert len(sessions) == 2
+
+    s = sessions[0]
+    assert "id" in s
+    assert "sleep_start" in s
+    assert "sleep_end" in s
+    assert "stages" in s
+
+
+def test_sleep_stages_fields(client):
+    client.post("/api/sleep", json=SLEEP_PAYLOAD)
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-22&include_stages=true")
+    stage = r.json()[0]["stages"][0]
+    assert "stage_type" in stage
+    assert "stage_start" in stage
+    assert "stage_end" in stage
+    assert stage["stage_type"] in ("light", "deep", "rem", "awake")
+
+
+def test_sleep_stages_empty_without_flag(client):
+    client.post("/api/sleep", json=SLEEP_PAYLOAD)
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-22")
+    s = r.json()[0]
+    assert s.get("stages") is None or s.get("stages") == []
+
+
+def test_sleep_iso_strings_parseable(client):
+    """sleep_start / sleep_end doivent être des ISO strings parsables par JS new Date()."""
+    client.post("/api/sleep", json=SLEEP_PAYLOAD)
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-22&include_stages=true")
+    s = r.json()[0]
+    from datetime import datetime
+    datetime.fromisoformat(s["sleep_start"])
+    datetime.fromisoformat(s["sleep_end"])
+    for st in s["stages"]:
+        datetime.fromisoformat(st["stage_start"])
+        datetime.fromisoformat(st["stage_end"])
+
+
+def test_sleep_ordered_by_start(client):
+    client.post("/api/sleep", json=SLEEP_PAYLOAD)
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-22&include_stages=true")
+    sessions = r.json()
+    starts = [s["sleep_start"] for s in sessions]
+    assert starts == sorted(starts)
+
+
+def test_sleep_date_range_filter(client):
+    client.post("/api/sleep", json=SLEEP_PAYLOAD)
+    # to=2026-04-20 → seule la session du 20 (sleep_start < 2026-04-21)
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-20&include_stages=true")
+    assert len(r.json()) == 1
+
+
+def test_sleep_empty_db_returns_list(client):
+    r = client.get("/api/sleep?from=2026-04-20&to=2026-04-22&include_stages=true")
+    assert r.status_code == 200
+    assert r.json() == []


### PR DESCRIPTION
## Ce qui change

- Remplacé l'ancien dashboard (grille basique 5 onglets) par le design Nightfall complet
- 9 sections : hero arc SVG, heatmap 30 nuits, timeline, hypnogram, radial clock, small multiples, ridgeline, top nights, week agenda, metrics
- Créé `static/api.js` — fetch `GET /api/sleep?include_stages=true`, adapte le format, calcule totals/efficiency/score/summary, expose `window.SleepData` puis appelle `render()`
- Stratégie "30 dernières sessions disponibles" (pas de fenêtre calendaire fixe)
- État vide géré si DB sans données
- Fix : `dashboard.js` rebinde `D = window.SleepData` dans `window.render` (était capturé à undefined au chargement)
- Port 8001 (évite conflit avec DataSaillance sur :8000) + ADR dans NOTES.md
- 7 tests de contrat API dans `tests/test_sleep_api_shape.py`

## Closes

<!-- Aucune issue liée — feature de refonte frontend -->

## Migrations

Aucune migration.

## Checklist
- [x] CI verte
- [x] Review — 14/14 tests passés