### PR TITLE
chore(dev): dev-mobile WSL2 port forwarding + Android cleartext fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
+| Dev mobile — WSL2 port forwarding + Android cleartext | `scripts/dev-mobile.ps1`, `Makefile`, `android-app/` | [`646aeaa`](#2026-04-21-646aeaa) |
 | Nightfall sleep dashboard | `static/index.html`, `static/dashboard.css`, `static/dashboard.js`, `static/api.js` | [`b5cacc7`](#2026-04-21-b5cacc7) |
 | Workflow bootstrap — CI, labels, hooks, tests | `.github/`, `.githooks/`, `Makefile`, `tests/` | [`939f5ef`](#2026-04-21-939f5ef) |
 | Phase 3: Steps, heart rate, exercise + tabbed dashboard | `server/`, `static/`, `scripts/`, `android-app/` | [`242040a`](#2026-02-16-242040a) |
@@ -14,6 +15,14 @@
 ---
 
 ## Changelog
+
+### 2026-04-21 `646aeaa`
+chore(dev): dev-mobile script + fix Android cleartext HTTP
+- Ajout `scripts/dev-mobile.ps1` — détecte auto les IPs WSL2/Windows, configure port forwarding 8001 et règle firewall
+- Ajout `make dev-mobile` — affiche les instructions pour tester depuis le téléphone
+- Ajout `android-app/res/xml/network_security_config.xml` — autorise HTTP cleartext (app locale uniquement, pas de données sensibles en transit)
+- Référencé dans `AndroidManifest.xml` via `android:networkSecurityConfig`
+- Fix `PreferencesManager.kt` — `DEFAULT_URL` sur port 8001
 
 ### 2026-04-21 `b5cacc7`
 feat(frontend): Nightfall sleep dashboard branché sur l'API réelle

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint install ci-test ci-lint
+.PHONY: dev dev-mobile test lint install ci-test ci-lint
 
 ## install : install Python dependencies
 install:
@@ -8,6 +8,20 @@ install:
 ## dev : start the FastAPI server (reload + accessible from phone on LAN)
 dev:
 	uvicorn server.main:app --reload --host 0.0.0.0 --port 8001
+
+## dev-mobile : instructions pour tester depuis le téléphone (WSL2 port forwarding)
+dev-mobile:
+	@echo "" ;\
+	echo "=== Test depuis téléphone (WSL2) ===" ;\
+	echo "" ;\
+	echo "1. Sur Windows (PowerShell Admin) :" ;\
+	echo "   PowerShell -ExecutionPolicy Bypass -File '\\\\wsl.localhost\\Ubuntu\\home\\tats\\MyPersonalProjects\\SamsungHealth\\scripts\\dev-mobile.ps1'" ;\
+	echo "" ;\
+	echo "2. Dans WSL2, lancer le serveur :" ;\
+	echo "   make dev" ;\
+	echo "" ;\
+	echo "3. Le script affiche l'URL à entrer dans l'app Android -> Settings -> Backend URL" ;\
+	echo ""
 
 ## test : run the test suite
 test:

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.SamsungHealthSync">
+        android:theme="@style/Theme.SamsungHealthSync"
+        android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
             android:name=".MainActivity"

--- a/android-app/app/src/main/res/xml/network_security_config.xml
+++ b/android-app/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!--
+        Cette app ne communique qu'avec un serveur local sur le réseau privé.
+        On autorise le cleartext (HTTP) globalement — pas de données sensibles en transit.
+    -->
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/scripts/dev-mobile.ps1
+++ b/scripts/dev-mobile.ps1
@@ -1,0 +1,40 @@
+# dev-mobile.ps1 — Expose WSL2 FastAPI (port 8001) on LAN for Android app testing
+# Run as Administrator in PowerShell on Windows
+#
+# If blocked by execution policy, run with:
+#   PowerShell -ExecutionPolicy Bypass -File "\\wsl.localhost\Ubuntu\home\tats\MyPersonalProjects\SamsungHealth\scripts\dev-mobile.ps1"
+
+$wslIp = (wsl -d Ubuntu hostname -I).Trim().Split()[0]
+$winIp = (Get-NetIPAddress -AddressFamily IPv4 -InterfaceAlias 'Wi-Fi' -ErrorAction SilentlyContinue).IPAddress
+if (-not $winIp) {
+    $winIp = (Get-NetIPAddress -AddressFamily IPv4 | Where-Object {
+        $_.IPAddress -notlike '127.*' -and $_.IPAddress -notlike '172.*'
+    } | Select-Object -First 1).IPAddress
+}
+
+if (-not $wslIp) {
+    Write-Host 'ERROR: Could not detect WSL2 IP. Make sure WSL2 is running.' -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ''
+Write-Host "WSL2 IP   : $wslIp"
+Write-Host "Windows IP : $winIp"
+Write-Host ''
+
+# Remove existing rule (idempotent)
+netsh interface portproxy delete v4tov4 listenport=8001 listenaddress=0.0.0.0 2>$null
+Remove-NetFirewallRule -DisplayName 'WSL2 SamsungHealth 8001' -ErrorAction SilentlyContinue
+
+# Add port forwarding: Windows 0.0.0.0:8001 -> WSL2:8001
+netsh interface portproxy add v4tov4 listenport=8001 listenaddress=0.0.0.0 connectport=8001 connectaddress=$wslIp
+New-NetFirewallRule -DisplayName 'WSL2 SamsungHealth 8001' -Direction Inbound -LocalPort 8001 -Protocol TCP -Action Allow | Out-Null
+
+Write-Host 'Port forwarding configured:'
+Write-Host "  http://${winIp}:8001  ->  WSL2 FastAPI (SamsungHealth)"
+Write-Host ''
+Write-Host 'Dans l app Android -> Settings -> Backend URL :'
+Write-Host "  http://${winIp}:8001"
+Write-Host ''
+Write-Host 'Assure-toi que le serveur tourne dans WSL2 : make dev'
+Write-Host ''


### PR DESCRIPTION
## Ce qui change

- Ajout `scripts/dev-mobile.ps1` — script PowerShell qui détecte auto les IPs WSL2/Windows, configure le port forwarding 8001 et la règle firewall (idempotent)
- Ajout `make dev-mobile` — affiche les instructions pour tester depuis le téléphone
- Ajout `android-app/res/xml/network_security_config.xml` — autorise HTTP cleartext pour les IPs locales (app locale, pas de données sensibles en transit)
- Fix `AndroidManifest.xml` — référence `networkSecurityConfig`
- Fix `PreferencesManager.kt` — `DEFAULT_URL` sur port 8001

## Closes

<!-- Aucune issue — infra dev -->

## Migrations

Aucune migration.

## Checklist
- [x] CI verte
- [x] Review — testé en conditions réelles (sync Android → 118 sessions importées)