### PR TITLE
feat(V2.0.5): structlog observability foundation — JSONL + request_id middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ SAMSUNGHEALTH_ENCRYPTION_KEY=
 
 # Postgres (défaut local docker-compose, override pour cloud)
 DATABASE_URL=postgresql+psycopg://samsung:samsung@localhost:5432/samsunghealth
+
+# V2.0.5 — Observability (structlog)
+# APP_ENV=dev      → ConsoleRenderer humain (couleurs). Default si non défini : prod (JSONL stdout).
+# LOG_LEVEL=INFO   → DEBUG | INFO | WARNING | ERROR | CRITICAL. Invalide → fallback INFO.
+# APP_ENV=dev
+# LOG_LEVEL=INFO

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
+| V2.0.5 — structlog observability foundation (JSONL + request_id middleware) | `server/logging_config.py`, `server/middleware/request_context.py`, `server/main.py`, `requirements.txt` | [`PENDING`](#2026-04-26-PENDING) |
 | Samsung Health CSV import — full DB schema (21 tables) | `server/database.py`, `scripts/import_samsung_csv.py`, `scripts/explore_samsung_export.py` | [`d032741`](#2026-04-21-d032741) |
 | Dev mobile — WSL2 port forwarding + Android cleartext | `scripts/dev-mobile.ps1`, `Makefile`, `android-app/` | [`646aeaa`](#2026-04-21-646aeaa) |
 | Nightfall sleep dashboard | `static/index.html`, `static/dashboard.css`, `static/dashboard.js`, `static/api.js` | [`b5cacc7`](#2026-04-21-b5cacc7) |
@@ -52,6 +53,19 @@ chore(release-archive): tag état de l'app au moment de l'enregistrement loom
 ---
 
 ## Changelog
+
+### 2026-04-26 `PENDING`
+feat(V2.0.5): structlog observability foundation — JSONL logs + request_id middleware
+- `server/logging_config.py` créé : `configure_logging()` + `get_logger()` + chaîne de processors structlog (timestamp ISO8601 UTC, level, logger scope, contextvars merger), JSONRenderer en prod / ConsoleRenderer(colors) en dev
+- `server/middleware/request_context.py` créé : ASGI pure middleware, `request_id_var` + `user_id_var` ContextVars, sanitisation X-Request-ID (alnum+tirets, max 64), header in/out, log `request.complete` avec `latency_ms` (perf_counter) + `route` template + niveau INFO/WARNING/ERROR selon status
+- `server/main.py` : `configure_logging()` dans lifespan, `RequestContextMiddleware` mounté avant routers
+- 7 fichiers `server/{database,security/crypto,routers/*}.py` : `_log = get_logger(__name__)` ajouté pour V2.3+ auth events
+- Env vars : `APP_ENV` (prod|dev) + `LOG_LEVEL` (DEBUG/INFO/WARNING/ERROR/CRITICAL avec fallback INFO si invalide)
+- 13 tests RED → GREEN (`tests/server/test_logging_config.py` 6 tests, `tests/server/test_request_context_middleware.py` 7 tests) — total 248/248 GREEN, 0 régression
+- Dépendance ajoutée : `structlog>=24.1`
+- README section "Logs" + NOTES.md tech debt "PII scrubber automatique (V2.3+)"
+- Spec : `docs/vault/specs/2026-04-26-v2-structlog-observability.md` (status delivered)
+- Hors scope V2.0.5 : Caddy reverse proxy, CLI logq, OpenTelemetry, PII scrubber auto, migration scripts/* (différés V2.0.6+)
 
 ### 2026-04-26 `7135a5f`
 chore(audit): snapshot V2 progress 2026-04-26 + fix V2.1.1 status delivered

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
-| V2.0.5 — structlog observability foundation (JSONL + request_id middleware) | `server/logging_config.py`, `server/middleware/request_context.py`, `server/main.py`, `requirements.txt` | [`PENDING`](#2026-04-26-PENDING) |
+| V2.0.5 — structlog observability foundation (JSONL + request_id middleware) | `server/logging_config.py`, `server/middleware/request_context.py`, `server/main.py`, `requirements.txt` | [`f2c8cb2`](#2026-04-26-f2c8cb2) |
 | Samsung Health CSV import — full DB schema (21 tables) | `server/database.py`, `scripts/import_samsung_csv.py`, `scripts/explore_samsung_export.py` | [`d032741`](#2026-04-21-d032741) |
 | Dev mobile — WSL2 port forwarding + Android cleartext | `scripts/dev-mobile.ps1`, `Makefile`, `android-app/` | [`646aeaa`](#2026-04-21-646aeaa) |
 | Nightfall sleep dashboard | `static/index.html`, `static/dashboard.css`, `static/dashboard.js`, `static/api.js` | [`b5cacc7`](#2026-04-21-b5cacc7) |
@@ -54,7 +54,7 @@ chore(release-archive): tag état de l'app au moment de l'enregistrement loom
 
 ## Changelog
 
-### 2026-04-26 `PENDING`
+### 2026-04-26 `f2c8cb2`
 feat(V2.0.5): structlog observability foundation — JSONL logs + request_id middleware
 - `server/logging_config.py` créé : `configure_logging()` + `get_logger()` + chaîne de processors structlog (timestamp ISO8601 UTC, level, logger scope, contextvars merger), JSONRenderer en prod / ConsoleRenderer(colors) en dev
 - `server/middleware/request_context.py` créé : ASGI pure middleware, `request_id_var` + `user_id_var` ContextVars, sanitisation X-Request-ID (alnum+tirets, max 64), header in/out, log `request.complete` avec `latency_ms` (perf_counter) + `route` template + niveau INFO/WARNING/ERROR selon status

--- a/NOTES.md
+++ b/NOTES.md
@@ -12,3 +12,13 @@
 **Décision :** SamsungHealth utilise le port **8001** (`make dev`, Android `DEFAULT_URL`). Aucun port hardcodé dans le code serveur — uniquement dans le Makefile et le `DEFAULT_URL` Android (configurable via l'UI Settings).
 
 **Conséquences :** Pour tester depuis un téléphone physique, l'URL à configurer est `http://<IP_LAN>:8001`.
+
+---
+
+## Tech debt
+
+- **PII scrubber automatique pour logs (V2.3+)** — V2.0.5 livre la fondation structlog mais
+  ne filtre pas automatiquement les champs sensibles (emails, tokens, valeurs santé brutes).
+  Convention humaine pour l'instant : ne pas mettre de PII dans `event`/extras. À reconsidérer
+  quand V2.3 ajoute l'auth (events `login_*`, `password_reset`) et qu'on a un risque réel de
+  fuite via stack traces ou kwargs accidentels.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ make db-migrate
 
 Variables d'environnement :
 - `DATABASE_URL` — URL SQLAlchemy (défaut : `postgresql+psycopg://samsung:samsung@localhost:5432/samsunghealth`)
+- `APP_ENV` — `dev` (ConsoleRenderer humain) ou `prod` (JSON stdout). Défaut : `prod`.
+- `LOG_LEVEL` — `DEBUG | INFO | WARNING | ERROR | CRITICAL`. Défaut : `INFO`.
+
+## Logs
+
+Pipeline de logs structurés via `structlog` (V2.0.5).
+
+- **Format prod** : 1 ligne JSON par event sur stdout, capture/rotation déléguée au runtime (docker compose, systemd).
+- **Format dev** : `ConsoleRenderer` lisible humain (couleurs).
+- **Champs standards** : `timestamp` (ISO8601 UTC), `level`, `logger` (scope), `event`, `request_id`, `user_id`, `route`, `latency_ms`.
+- **Corrélation** : chaque request HTTP reçoit un `X-Request-ID` (généré ou propagé depuis le client) bindé via `contextvars` à tous les logs émis pendant son traitement. Le middleware émet `event: "request.complete"` à la fin avec `latency_ms` et `route` (template FastAPI).
+
+Exemple ligne :
+```json
+{"event":"request.complete","logger":"server.middleware.request_context","route":"/api/sleep","method":"GET","status":200,"latency_ms":12.345,"request_id":"a1b2…","user_id":null,"level":"info","timestamp":"2026-04-26T10:00:00.000Z"}
+```
 
 ## Usage
 

--- a/docs/vault/code/server/database.md
+++ b/docs/vault/code/server/database.md
@@ -2,15 +2,16 @@
 type: code-source
 language: python
 file_path: server/database.py
-git_blob: 82ba713b5b296ea5f53072aad8241981b0545d95
-last_synced: '2026-04-24T02:34:57Z'
-loc: 25
+git_blob: 484640fdb842eb5074f1c35badc07ffb9796e2e6
+last_synced: '2026-04-26T14:46:49Z'
+loc: 30
 annotations: []
 imports:
 - os
 - functools
 - sqlalchemy
 - sqlalchemy.orm
+- server.logging_config
 exports:
 - get_session
 tags:
@@ -32,6 +33,11 @@ from functools import lru_cache
 
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
+
+from server.logging_config import get_logger
+
+
+_log = get_logger(__name__)
 
 _DEFAULT_PG_URL = "postgresql+psycopg://samsung:samsung@localhost:5432/samsunghealth"
 
@@ -63,13 +69,14 @@ def get_session() -> Session:
 - [[../../specs/2026-04-24-v2-postgres-routers-cutover]] — symbols: `get_engine`, `get_session`, `SessionLocal`
 
 ### Symbols
-- `get_session` (function) — lines 24-25 · **Specs**: [[../../specs/2026-04-24-v2-postgres-migration|2026-04-24-v2-postgres-migration]], [[../../specs/2026-04-24-v2-postgres-routers-cutover|2026-04-24-v2-postgres-routers-cutover]]
+- `get_session` (function) — lines 29-30 · **Specs**: [[../../specs/2026-04-24-v2-postgres-migration|2026-04-24-v2-postgres-migration]], [[../../specs/2026-04-24-v2-postgres-routers-cutover|2026-04-24-v2-postgres-routers-cutover]]
 
 ### Imports
 - `os`
 - `functools`
 - `sqlalchemy`
 - `sqlalchemy.orm`
+- `server.logging_config`
 
 ### Exports
 - `get_session`

--- a/docs/vault/code/server/logging_config.md
+++ b/docs/vault/code/server/logging_config.md
@@ -1,0 +1,140 @@
+---
+type: code-source
+language: python
+file_path: server/logging_config.py
+git_blob: f8eab5110198064041899bb935e15942a2ea25b7
+last_synced: '2026-04-26T14:46:49Z'
+loc: 80
+annotations: []
+imports:
+- logging
+- os
+- sys
+- structlog
+exports:
+- _resolve_env
+- _resolve_level
+- _build_processors
+- configure_logging
+- get_logger
+tags:
+- code
+- python
+---
+
+# server/logging_config.py
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`server/logging_config.py`](../../../server/logging_config.py).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```python
+"""Structlog observability foundation (V2.0.5).
+
+Pipeline de logs structurés JSONL en prod, ConsoleRenderer en dev.
+Bridge stdlib → structlog pour que uvicorn/sqlalchemy passent par le même rendu.
+ContextVars (request_id, user_id) injectées automatiquement via processor.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import structlog
+
+
+_VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def _resolve_env(env: str | None) -> str:
+    if env is not None:
+        return env.lower()
+    return os.environ.get("APP_ENV", "prod").lower()
+
+
+def _resolve_level(level: str | None) -> int:
+    raw = (level if level is not None else os.environ.get("LOG_LEVEL", "INFO")).upper()
+    if raw not in _VALID_LEVELS:
+        logging.getLogger(__name__).warning(
+            "LOG_LEVEL invalide '%s', fallback INFO", raw
+        )
+        raw = "INFO"
+    return getattr(logging, raw)
+
+
+def _build_processors(env: str) -> list:
+    """Compose la chaîne de processors structlog. Ordre = important."""
+    shared: list = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+    if env == "dev":
+        shared.append(structlog.dev.ConsoleRenderer(colors=True))
+    else:
+        shared.append(structlog.processors.JSONRenderer())
+    return shared
+
+
+def configure_logging(env: str | None = None, level: str | None = None) -> None:
+    """Configure structlog + bridge stdlib. Idempotent — peut être ré-appelé."""
+    resolved_env = _resolve_env(env)
+    resolved_level = _resolve_level(level)
+
+    processors = _build_processors(resolved_env)
+
+    # Reset handlers du root logger pour éviter doublons quand on re-configure
+    # (les tests appellent configure_logging à chaque test).
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)
+    root.setLevel(resolved_level)
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(resolved_level),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stdout),
+        cache_logger_on_first_use=False,
+    )
+
+
+def get_logger(name: str) -> structlog.stdlib.BoundLogger:
+    """Retourne un logger structlog avec scope (`logger` field) bindé sur `name`."""
+    return structlog.get_logger(name).bind(logger=name)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Implements specs
+- [[../../specs/2026-04-26-v2-structlog-observability]] — symbols: `configure_logging`, `get_logger`, `_processors`
+
+### Symbols
+- `_resolve_env` (function) — lines 19-22
+- `_resolve_level` (function) — lines 25-32
+- `_build_processors` (function) — lines 35-48
+- `configure_logging` (function) — lines 51-75 · **Specs**: [[../../specs/2026-04-26-v2-structlog-observability|2026-04-26-v2-structlog-observability]]
+- `get_logger` (function) — lines 78-80 · **Specs**: [[../../specs/2026-04-26-v2-structlog-observability|2026-04-26-v2-structlog-observability]]
+
+### Imports
+- `logging`
+- `os`
+- `sys`
+- `structlog`
+
+### Exports
+- `_resolve_env`
+- `_resolve_level`
+- `_build_processors`
+- `configure_logging`
+- `get_logger`

--- a/docs/vault/code/server/main.md
+++ b/docs/vault/code/server/main.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/main.py
-git_blob: a2f0ec110dc074fb6d72f617ae102e02ccdfa4a4
-last_synced: '2026-04-24T03:44:10Z'
-loc: 36
+git_blob: a14c382065d9c20ef6a99b7221c984b7e8df38ea
+last_synced: '2026-04-26T14:46:49Z'
+loc: 41
 annotations: []
 imports:
 - contextlib
@@ -12,6 +12,8 @@ imports:
 - fastapi
 - fastapi.responses
 - fastapi.staticfiles
+- server.logging_config
+- server.middleware.request_context
 - server.routers
 exports:
 - _validate_encryption_at_boot
@@ -36,6 +38,9 @@ from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from server.logging_config import configure_logging
+from server.middleware.request_context import RequestContextMiddleware
+
 
 def _validate_encryption_at_boot() -> None:
     """V2.2 fail-fast — appelée au lifespan startup. Le test_boot_validation l'invoque directement."""
@@ -45,6 +50,7 @@ def _validate_encryption_at_boot() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    configure_logging()
     _validate_encryption_at_boot()
     yield
 
@@ -52,6 +58,7 @@ async def lifespan(app: FastAPI):
 from server.routers import exercise, heartrate, mood, sleep, steps  # noqa: E402
 
 app = FastAPI(title="SamsungHealth", lifespan=lifespan)
+app.add_middleware(RequestContextMiddleware)
 app.include_router(sleep.router)
 app.include_router(steps.router)
 app.include_router(heartrate.router)
@@ -74,9 +81,10 @@ def index():
 ### Implements specs
 - [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields]] — symbols: `app`, `_validate_encryption_at_boot`
 - [[../../specs/2026-04-24-v2-postgres-routers-cutover]] — symbols: `app`, `startup`
+- [[../../specs/2026-04-26-v2-structlog-observability]] — symbols: `app`, `lifespan`
 
 ### Symbols
-- `_validate_encryption_at_boot` (function) — lines 9-12 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
+- `_validate_encryption_at_boot` (function) — lines 12-15 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
 
 ### Imports
 - `contextlib`
@@ -84,6 +92,8 @@ def index():
 - `fastapi`
 - `fastapi.responses`
 - `fastapi.staticfiles`
+- `server.logging_config`
+- `server.middleware.request_context`
 - `server.routers`
 
 ### Exports

--- a/docs/vault/code/server/middleware/__init__.md
+++ b/docs/vault/code/server/middleware/__init__.md
@@ -1,0 +1,29 @@
+---
+type: code-source
+language: python
+file_path: server/middleware/__init__.py
+git_blob: e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+last_synced: '2026-04-26T14:46:49Z'
+loc: 0
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- python
+---
+
+# server/middleware/__init__.py
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`server/middleware/__init__.py`](../../../server/middleware/__init__.py).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```python
+
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*

--- a/docs/vault/code/server/middleware/request_context.md
+++ b/docs/vault/code/server/middleware/request_context.md
@@ -1,0 +1,207 @@
+---
+type: code-source
+language: python
+file_path: server/middleware/request_context.py
+git_blob: d3c31d5c456c711a9841c7fec05b3f7bb2178b81
+last_synced: '2026-04-26T14:46:49Z'
+loc: 146
+annotations: []
+imports:
+- re
+- time
+- uuid
+- contextvars
+- structlog
+- server.logging_config
+exports:
+- _sanitize_request_id
+- _resolve_route_template
+- _level_for_status
+- RequestContextMiddleware
+tags:
+- code
+- python
+---
+
+# server/middleware/request_context.py
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`server/middleware/request_context.py`](../../../server/middleware/request_context.py).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```python
+"""Request context middleware (V2.0.5).
+
+Pure ASGI middleware qui :
+- Génère ou réutilise un `request_id` (X-Request-ID), sanitisé alnum+tirets, max 64 chars.
+- Bind `request_id_var` et `user_id_var` (ContextVar) → injectés dans tous logs structlog
+  émis pendant la request via `structlog.contextvars.merge_contextvars`.
+- Renvoie le `X-Request-ID` dans response headers.
+- Mesure la latence (`perf_counter`) et émet `request.complete` (INFO/WARNING/ERROR
+  selon status code) avec `latency_ms` + `route` (template FastAPI).
+"""
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from contextvars import ContextVar
+
+import structlog
+
+from server.logging_config import get_logger
+
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
+
+_REQUEST_ID_MAX_LEN = 64
+_REQUEST_ID_RE = re.compile(r"[^A-Za-z0-9-]")
+
+
+def _sanitize_request_id(raw: str) -> str:
+    """Garde alnum + tirets, tronque à 64. Si vide après nettoyage → uuid4().hex."""
+    cleaned = _REQUEST_ID_RE.sub("", raw)[:_REQUEST_ID_MAX_LEN]
+    return cleaned or uuid.uuid4().hex
+
+
+def _resolve_route_template(scope) -> str:
+    """Retourne le template FastAPI (`/api/sleep`) si match, sinon le path brut."""
+    route = scope.get("route")
+    if route is not None:
+        path = getattr(route, "path", None)
+        if path:
+            return path
+    return scope.get("path", "")
+
+
+def _level_for_status(status: int) -> str:
+    if status >= 500:
+        return "error"
+    if status >= 400:
+        return "warning"
+    return "info"
+
+
+class RequestContextMiddleware:
+    """ASGI pure middleware. Monte-le AVANT tout autre middleware applicatif."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Header lookup — ASGI scope.headers est list[tuple[bytes, bytes]]
+        headers = scope.get("headers") or []
+        incoming_rid: str | None = None
+        for k, v in headers:
+            if k.lower() == b"x-request-id":
+                incoming_rid = v.decode("latin-1", errors="ignore")
+                break
+
+        if incoming_rid:
+            request_id = _sanitize_request_id(incoming_rid)
+        else:
+            request_id = uuid.uuid4().hex
+
+        # Bind contextvars (structlog merger les injecte dans chaque log emit)
+        token_rid = request_id_var.set(request_id)
+        token_uid = user_id_var.set(None)
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id,
+            user_id=None,
+        )
+
+        start = time.perf_counter()
+        status_holder: dict = {"code": 500, "started": False}
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                status_holder["code"] = message["status"]
+                status_holder["started"] = True
+                # Inject X-Request-ID header
+                raw_headers = list(message.get("headers") or [])
+                # Drop any existing x-request-id (case-insensitive) pour éviter doublon
+                raw_headers = [
+                    (k, v) for k, v in raw_headers if k.lower() != b"x-request-id"
+                ]
+                raw_headers.append(
+                    (b"x-request-id", request_id.encode("latin-1"))
+                )
+                message["headers"] = raw_headers
+            await send(message)
+
+        try:
+            try:
+                await self.app(scope, receive, send_wrapper)
+            except Exception:
+                # App raised avant d'envoyer une response → on émet un 500
+                # avec X-Request-ID pour préserver la corrélation.
+                if not status_holder["started"]:
+                    status_holder["code"] = 500
+                    await send(
+                        {
+                            "type": "http.response.start",
+                            "status": 500,
+                            "headers": [
+                                (b"content-type", b"text/plain; charset=utf-8"),
+                                (b"content-length", b"21"),
+                                (b"x-request-id", request_id.encode("latin-1")),
+                            ],
+                        }
+                    )
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": b"Internal Server Error",
+                        }
+                    )
+                raise
+        finally:
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            route = _resolve_route_template(scope)
+            level = _level_for_status(status_holder["code"])
+            log = get_logger("server.middleware.request_context")
+            log_method = getattr(log, level)
+            log_method(
+                "request.complete",
+                route=route,
+                method=scope.get("method"),
+                status=status_holder["code"],
+                latency_ms=round(latency_ms, 3),
+            )
+            structlog.contextvars.unbind_contextvars("request_id", "user_id")
+            request_id_var.reset(token_rid)
+            user_id_var.reset(token_uid)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Implements specs
+- [[../../specs/2026-04-26-v2-structlog-observability]] — symbols: `RequestContextMiddleware`, `request_id_var`, `user_id_var`
+
+### Symbols
+- `_sanitize_request_id` (function) — lines 30-33
+- `_resolve_route_template` (function) — lines 36-43
+- `_level_for_status` (function) — lines 46-51
+- `RequestContextMiddleware` (class) — lines 54-146 · **Specs**: [[../../specs/2026-04-26-v2-structlog-observability|2026-04-26-v2-structlog-observability]]
+
+### Imports
+- `re`
+- `time`
+- `uuid`
+- `contextvars`
+- `structlog`
+- `server.logging_config`
+
+### Exports
+- `_sanitize_request_id`
+- `_resolve_route_template`
+- `_level_for_status`
+- `RequestContextMiddleware`

--- a/docs/vault/code/server/routers/exercise.md
+++ b/docs/vault/code/server/routers/exercise.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/routers/exercise.py
-git_blob: 1ab8769f4fd06a4be34cd32f3700965266ae9586
-last_synced: '2026-04-24T02:28:09Z'
-loc: 76
+git_blob: 9609b624f272f785270c3364c2de0c5a236803b3
+last_synced: '2026-04-26T14:46:49Z'
+loc: 79
 annotations: []
 imports:
 - datetime
@@ -14,6 +14,7 @@ imports:
 - sqlalchemy.orm
 - server.database
 - server.db.models
+- server.logging_config
 - server.models
 exports:
 - _to_dt
@@ -41,7 +42,10 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import ExerciseSession
+from server.logging_config import get_logger
 from server.models import ExerciseBulkIn, ExerciseSessionOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/exercise", tags=["exercise"])
 
@@ -118,8 +122,8 @@ def get_exercise(
 - [[../../specs/2026-04-24-v2-postgres-routers-cutover]] — symbols: `router`
 
 ### Symbols
-- `_to_dt` (function) — lines 15-19
-- `_iso` (function) — lines 22-25
+- `_to_dt` (function) — lines 18-22
+- `_iso` (function) — lines 25-28
 
 ### Imports
 - `datetime`
@@ -129,6 +133,7 @@ def get_exercise(
 - `sqlalchemy.orm`
 - `server.database`
 - `server.db.models`
+- `server.logging_config`
 - `server.models`
 
 ### Exports

--- a/docs/vault/code/server/routers/heartrate.md
+++ b/docs/vault/code/server/routers/heartrate.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/routers/heartrate.py
-git_blob: 0350085825b384c1671a9dcff09b343a097860b6
-last_synced: '2026-04-24T02:28:09Z'
-loc: 62
+git_blob: 60cf780912e79aa60ea4587975e3631a3abf790c
+last_synced: '2026-04-26T14:46:49Z'
+loc: 65
 annotations: []
 imports:
 - fastapi
@@ -13,6 +13,7 @@ imports:
 - sqlalchemy.orm
 - server.database
 - server.db.models
+- server.logging_config
 - server.models
 exports: []
 tags:
@@ -36,7 +37,10 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import HeartRateHourly
+from server.logging_config import get_logger
 from server.models import HeartRateBulkIn, HeartRateHourlyOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/heartrate", tags=["heartrate"])
 
@@ -107,4 +111,5 @@ def get_heartrate(
 - `sqlalchemy.orm`
 - `server.database`
 - `server.db.models`
+- `server.logging_config`
 - `server.models`

--- a/docs/vault/code/server/routers/mood.md
+++ b/docs/vault/code/server/routers/mood.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/routers/mood.py
-git_blob: 5875e4040ea3a241cf5f5128405c90d919766b27
-last_synced: '2026-04-24T03:44:10Z'
-loc: 86
+git_blob: e232e4a20f2a80b5ea78c40bf67febc9d73ca257
+last_synced: '2026-04-26T14:46:49Z'
+loc: 89
 annotations: []
 imports:
 - datetime
@@ -14,6 +14,7 @@ imports:
 - sqlalchemy.orm
 - server.database
 - server.db.models
+- server.logging_config
 - server.models
 - server.security.crypto
 exports:
@@ -42,8 +43,11 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import Mood
+from server.logging_config import get_logger
 from server.models import MoodBulkIn, MoodOut
 from server.security.crypto import DecryptionError
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/mood", tags=["mood"])
 
@@ -128,8 +132,8 @@ def get_mood_entries(
 - [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields]] — symbols: `router`, `create_mood_entry`, `get_mood_entries`
 
 ### Symbols
-- `_to_dt` (function) — lines 17-21
-- `_iso` (function) — lines 24-25
+- `_to_dt` (function) — lines 20-24
+- `_iso` (function) — lines 27-28
 
 ### Imports
 - `datetime`
@@ -139,6 +143,7 @@ def get_mood_entries(
 - `sqlalchemy.orm`
 - `server.database`
 - `server.db.models`
+- `server.logging_config`
 - `server.models`
 - `server.security.crypto`
 

--- a/docs/vault/code/server/routers/sleep.md
+++ b/docs/vault/code/server/routers/sleep.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/routers/sleep.py
-git_blob: 0242450879282e3155e27ee39637b20ef1fd0a22
-last_synced: '2026-04-24T02:26:12Z'
-loc: 101
+git_blob: 5d00cfdd1ad1548dd075f7287ae62845c3bdbcff
+last_synced: '2026-04-26T14:46:49Z'
+loc: 104
 annotations: []
 imports:
 - datetime
@@ -13,6 +13,7 @@ imports:
 - sqlalchemy.orm
 - server.database
 - server.db.models
+- server.logging_config
 - server.models
 exports:
 - _parse_day
@@ -40,7 +41,10 @@ from sqlalchemy.orm import Session, selectinload
 
 from server.database import get_session
 from server.db.models import SleepSession, SleepStage
+from server.logging_config import get_logger
 from server.models import SleepBulkIn, SleepSessionOut, SleepStageOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/sleep", tags=["sleep"])
 
@@ -143,9 +147,9 @@ def get_sleep_sessions(
 - [[../../specs/2026-04-24-v2-postgres-routers-cutover]] — symbols: `router`, `create_sleep_sessions`, `get_sleep_sessions`
 
 ### Symbols
-- `_parse_day` (function) — lines 14-15
-- `_to_iso` (function) — lines 50-55
-- `_serialize` (function) — lines 58-76
+- `_parse_day` (function) — lines 17-18
+- `_to_iso` (function) — lines 53-58
+- `_serialize` (function) — lines 61-79
 
 ### Imports
 - `datetime`
@@ -154,6 +158,7 @@ def get_sleep_sessions(
 - `sqlalchemy.orm`
 - `server.database`
 - `server.db.models`
+- `server.logging_config`
 - `server.models`
 
 ### Exports

--- a/docs/vault/code/server/routers/steps.md
+++ b/docs/vault/code/server/routers/steps.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/routers/steps.py
-git_blob: f0d6906726af0d195eb944d4c205906ba5aba7df
-last_synced: '2026-04-24T02:28:09Z'
-loc: 45
+git_blob: 67caaba1cc823d02a53a5f7901d85a39e7510334
+last_synced: '2026-04-26T14:46:49Z'
+loc: 48
 annotations: []
 imports:
 - fastapi
@@ -13,6 +13,7 @@ imports:
 - sqlalchemy.orm
 - server.database
 - server.db.models
+- server.logging_config
 - server.models
 exports: []
 tags:
@@ -36,7 +37,10 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import StepsHourly
+from server.logging_config import get_logger
 from server.models import StepsBulkIn, StepsHourlyOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/steps", tags=["steps"])
 
@@ -90,4 +94,5 @@ def get_steps(
 - `sqlalchemy.orm`
 - `server.database`
 - `server.db.models`
+- `server.logging_config`
 - `server.models`

--- a/docs/vault/code/server/security/crypto.md
+++ b/docs/vault/code/server/security/crypto.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/security/crypto.py
-git_blob: abf742e73249b54e4dda1f5c2a52e9196274125c
-last_synced: '2026-04-24T03:44:01Z'
-loc: 79
+git_blob: bc96720463c14f1043dcd3e47a4469b5ac8e6ac5
+last_synced: '2026-04-26T14:46:49Z'
+loc: 83
 annotations: []
 imports:
 - base64
@@ -13,6 +13,7 @@ imports:
 - functools
 - cryptography.exceptions
 - cryptography.hazmat.primitives.ciphers.aead
+- server.logging_config
 exports:
 - EncryptionConfigError
 - DecryptionError
@@ -48,6 +49,10 @@ from functools import lru_cache
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from server.logging_config import get_logger
+
+
+_log = get_logger(__name__)
 
 KEY_ENV_VAR = "SAMSUNGHEALTH_ENCRYPTION_KEY"
 NONCE_BYTES = 12
@@ -122,12 +127,12 @@ def reset_key_cache() -> None:
 - [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields]] — symbols: `load_encryption_key`, `encrypt_field`, `decrypt_field`, `EncryptionConfigError`, `DecryptionError`
 
 ### Symbols
-- `EncryptionConfigError` (class) — lines 23-24 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
-- `DecryptionError` (class) — lines 27-28 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
-- `load_encryption_key` (function) — lines 31-51 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
-- `encrypt_field` (function) — lines 59-63 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
-- `decrypt_field` (function) — lines 66-74 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
-- `reset_key_cache` (function) — lines 77-79
+- `EncryptionConfigError` (class) — lines 27-28 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
+- `DecryptionError` (class) — lines 31-32 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
+- `load_encryption_key` (function) — lines 35-55 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
+- `encrypt_field` (function) — lines 63-67 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
+- `decrypt_field` (function) — lines 70-78 · **Specs**: [[../../specs/2026-04-24-v2-aes256-gcm-encrypted-fields|2026-04-24-v2-aes256-gcm-encrypted-fields]]
+- `reset_key_cache` (function) — lines 81-83
 
 ### Imports
 - `base64`
@@ -136,6 +141,7 @@ def reset_key_cache() -> None:
 - `functools`
 - `cryptography.exceptions`
 - `cryptography.hazmat.primitives.ciphers.aead`
+- `server.logging_config`
 
 ### Exports
 - `EncryptionConfigError`

--- a/docs/vault/code/tests/server/test_logging_config.md
+++ b/docs/vault/code/tests/server/test_logging_config.md
@@ -1,0 +1,214 @@
+---
+type: code-source
+language: python
+file_path: tests/server/test_logging_config.py
+git_blob: 00e302f70eee51466b9da067002f6657a2c91aaf
+last_synced: '2026-04-26T14:46:49Z'
+loc: 163
+annotations: []
+imports:
+- json
+- re
+- pytest
+exports:
+- TestStructlogConfig
+- TestLogFields
+tags:
+- code
+- python
+---
+
+# tests/server/test_logging_config.py
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`tests/server/test_logging_config.py`](../../../tests/server/test_logging_config.py).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```python
+"""
+Tests RED — V2.0.5 structlog observability foundation : logging config.
+
+Mappé sur frontmatter `tested_by:` du spec
+docs/vault/specs/2026-04-26-v2-structlog-observability.md.
+
+Classes:
+- TestStructlogConfig
+- TestLogFields
+
+Cible:
+- `from server.logging_config import configure_logging, get_logger`
+
+Note RED: `server.logging_config` n'existe pas encore. `structlog` n'est pas
+encore dans `requirements.txt` (V2.0.5 l'ajoute). L'import au top du module
+doit faire échouer la collection / les tests jusqu'à l'implémentation : c'est
+exactement le contrat RED de TDD.
+"""
+import json
+import re
+
+import pytest
+
+
+class TestStructlogConfig:
+    def test_logger_emits_json(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod (renderer JSON),
+        when get_logger("test").info("hello", foo=42),
+        then la ligne capturée stdout est du JSON valide avec
+             clés timestamp/level/logger/event/foo.
+        """
+        # spec §Tests d'acceptation #1
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        log = get_logger("test")
+        log.info("hello", foo=42)
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert payload["event"] == "hello"
+        assert payload["foo"] == 42
+        assert "timestamp" in payload
+        assert "level" in payload
+        assert "logger" in payload
+
+    def test_log_level_from_env(self, capsys, monkeypatch):
+        """
+        given LOG_LEVEL=WARNING,
+        when on émet un info() puis un warning(),
+        then 0 ligne info capturée, 1 ligne warning capturée.
+        """
+        # spec §Tests d'acceptation #5
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        configure_logging()
+
+        log = get_logger("test.level")
+        log.info("should_be_filtered")
+        log.warning("should_pass")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        assert "should_be_filtered" not in out
+        assert "should_pass" in out
+
+    def test_pretty_renderer_in_dev_mode(self, capsys, monkeypatch):
+        """
+        given APP_ENV=dev (ConsoleRenderer),
+        when get_logger("test").info("hello"),
+        then output n'est pas du JSON (pas d'objet `{...}` brut parsable)
+             et contient le mot "hello".
+        """
+        # spec §Tests d'acceptation #6
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        log = get_logger("test.dev")
+        log.info("hello")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        assert "hello" in out
+        # ConsoleRenderer n'émet pas une ligne JSON parsable
+        last_line = out.strip().splitlines()[-1]
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(last_line)
+
+
+class TestLogFields:
+    def test_logger_includes_timestamp_iso8601(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod,
+        when get_logger("t").info("e"),
+        then la clé `timestamp` matche ^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z$ (ISO8601 UTC).
+        """
+        # spec §Tests d'acceptation #2
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        get_logger("t").info("e")
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert "timestamp" in payload
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$",
+            payload["timestamp"],
+        ), f"timestamp ne matche pas ISO8601 UTC: {payload['timestamp']!r}"
+
+    def test_logger_includes_level(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod,
+        when get_logger("t").info("e"),
+        then payload["level"] == "info" (lowercase string).
+        """
+        # spec §Tests d'acceptation #3
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        get_logger("t.lvl").info("e")
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert payload["level"] == "info"
+
+    def test_logger_includes_scope(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod,
+        when get_logger("server.routers.sleep").info("e"),
+        then payload["logger"] == "server.routers.sleep" (scope = nom du logger).
+        """
+        # spec §Tests d'acceptation #4
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        get_logger("server.routers.sleep").info("e")
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert payload["logger"] == "server.routers.sleep"
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `TestStructlogConfig` (class) — lines 25-97
+- `TestLogFields` (class) — lines 100-163
+
+### Imports
+- `json`
+- `re`
+- `pytest`
+
+### Exports
+- `TestStructlogConfig`
+- `TestLogFields`
+
+
+## Validates specs *(auto — declared by spec)*
+
+- [[../../specs/2026-04-26-v2-structlog-observability]] — classes: `TestStructlogConfig`, `TestLogFields` · methods: `test_logger_emits_json`, `test_logger_includes_timestamp_iso8601`, `test_logger_includes_level`, `test_logger_includes_scope`, `test_log_level_from_env`, `test_pretty_renderer_in_dev_mode`

--- a/docs/vault/code/tests/server/test_request_context_middleware.md
+++ b/docs/vault/code/tests/server/test_request_context_middleware.md
@@ -1,0 +1,277 @@
+---
+type: code-source
+language: python
+file_path: tests/server/test_request_context_middleware.py
+git_blob: 9b4584930eb77f523726d18d625e683a02a31054
+last_synced: '2026-04-26T14:46:49Z'
+loc: 218
+annotations: []
+imports:
+- json
+- re
+- pytest
+- fastapi.testclient
+exports:
+- _build_app
+- TestRequestContext
+- TestRequestIdHeader
+- TestLatency
+tags:
+- code
+- python
+---
+
+# tests/server/test_request_context_middleware.py
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`tests/server/test_request_context_middleware.py`](../../../tests/server/test_request_context_middleware.py).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```python
+"""
+Tests RED — V2.0.5 structlog observability foundation : request context middleware.
+
+Mappé sur frontmatter `tested_by:` du spec
+docs/vault/specs/2026-04-26-v2-structlog-observability.md.
+
+Classes:
+- TestRequestContext
+- TestRequestIdHeader
+- TestLatency
+
+Cible:
+- `from server.middleware.request_context import RequestContextMiddleware, request_id_var, user_id_var`
+- `from server.logging_config import configure_logging, get_logger`
+
+Note RED: `server.middleware.request_context` n'existe pas encore (et le
+package `server.middleware` non plus). `structlog` n'est pas encore dans
+`requirements.txt`. Les tests doivent échouer à l'import — c'est le contrat RED.
+
+On construit une mini-app FastAPI inline dans chaque test (plutôt que de
+réutiliser `server.main.app`) pour isoler le middleware et tester son
+comportement seul.
+"""
+import json
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _build_app():
+    """Construit une app FastAPI minimale avec le RequestContextMiddleware
+    monté + une route qui émet un log via structlog pendant la request, pour
+    pouvoir asserter le binding contextvars → log entries.
+
+    Lazy imports : tant que `server.logging_config` /
+    `server.middleware.request_context` n'existent pas, l'appel à _build_app()
+    lève ModuleNotFoundError → RED clair par test, pas en collection.
+    """
+    from fastapi import FastAPI
+
+    from server.logging_config import configure_logging, get_logger
+    from server.middleware.request_context import RequestContextMiddleware
+
+    configure_logging()
+    log = get_logger("server.test_app")
+
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+
+    @app.get("/api/sleep")
+    def get_sleep():
+        log.info("inside_handler")
+        return {"ok": True}
+
+    @app.get("/api/error")
+    def get_error():
+        raise ValueError("boom")
+
+    return app
+
+
+class TestRequestContext:
+    def test_request_id_generated_when_absent(self, monkeypatch):
+        """
+        given une request GET sans header X-Request-ID,
+        when le middleware traite la request,
+        then la response contient un header X-Request-ID au format [a-f0-9]{32}.
+        """
+        # spec §Tests d'acceptation #7
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+
+        resp = client.get("/api/sleep")
+        assert resp.status_code == 200
+        assert "x-request-id" in {k.lower() for k in resp.headers.keys()}
+        rid = resp.headers["x-request-id"]
+        assert re.match(r"^[a-f0-9]{32}$", rid), f"rid={rid!r} ne matche pas uuid4().hex"
+
+    def test_request_id_bound_to_logs(self, monkeypatch, capsys):
+        """
+        given une request,
+        when un log est émis pendant le handler,
+        then l'entry de log contient la clé `request_id` égale à la valeur
+             du header X-Request-ID renvoyé.
+        """
+        # spec §Tests d'acceptation #10
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        resp = client.get("/api/sleep")
+        rid = resp.headers["x-request-id"]
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        # On parse toutes les lignes JSON et on cherche celle du handler
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        handler_lines = [ln for ln in lines if ln.get("event") == "inside_handler"]
+        assert handler_lines, f"Aucun log `inside_handler` capturé. Lignes: {lines}"
+        assert handler_lines[0].get("request_id") == rid
+
+    def test_user_id_default_none(self, monkeypatch, capsys):
+        """
+        given une request sans auth (V2.0.5 = pas d'auth),
+        when un log est émis,
+        then l'entry contient `user_id: null` (placeholder pour V2.3 auth).
+        """
+        # spec §Tests d'acceptation #11
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        client.get("/api/sleep")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        handler_lines = [ln for ln in lines if ln.get("event") == "inside_handler"]
+        assert handler_lines, f"Aucun log handler capturé. Lignes: {lines}"
+        # null en JSON ↔ None en Python : la clé doit être présente avec valeur None.
+        assert "user_id" in handler_lines[0], "Clé user_id absente du log"
+        assert handler_lines[0]["user_id"] is None
+
+
+class TestRequestIdHeader:
+    def test_request_id_propagated_from_header(self, monkeypatch):
+        """
+        given une request GET avec header X-Request-ID: my-trace-123,
+        when le middleware traite la request,
+        then la response renvoie X-Request-ID: my-trace-123 (sanitisé alnum+tirets, max 64 chars).
+        """
+        # spec §Tests d'acceptation #8
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+
+        resp = client.get("/api/sleep", headers={"X-Request-ID": "my-trace-123"})
+        assert resp.status_code == 200
+        assert resp.headers["x-request-id"] == "my-trace-123"
+
+    def test_request_id_present_in_response_header(self, monkeypatch):
+        """
+        given n'importe quelle request (succès ou erreur),
+        when le middleware traite la response,
+        then la response a toujours un header X-Request-ID non vide.
+        """
+        # spec §Tests d'acceptation #9
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Succès
+        ok = client.get("/api/sleep")
+        assert ok.headers.get("x-request-id"), "X-Request-ID absent sur 200"
+
+        # Erreur 500
+        err = client.get("/api/error")
+        assert err.headers.get("x-request-id"), "X-Request-ID absent sur 500"
+
+
+class TestLatency:
+    def test_latency_ms_logged_on_request_complete(self, monkeypatch, capsys):
+        """
+        given une request,
+        when le middleware termine,
+        then un log `event: "request.complete"` est émis avec une clé
+             `latency_ms` (float >= 0).
+        """
+        # spec §Tests d'acceptation #12
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        client.get("/api/sleep")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        complete = [ln for ln in lines if ln.get("event") == "request.complete"]
+        assert complete, f"Aucun log `request.complete` capturé. Lignes: {lines}"
+        assert "latency_ms" in complete[0], "Clé latency_ms absente"
+        latency = complete[0]["latency_ms"]
+        assert isinstance(latency, (int, float)), f"latency_ms doit être numérique, pas {type(latency)}"
+        assert float(latency) >= 0.0
+
+    def test_route_template_logged(self, monkeypatch, capsys):
+        """
+        given une request GET /api/sleep?from=2026-01-01,
+        when le middleware logge `request.complete`,
+        then la clé `route` vaut "/api/sleep" (template FastAPI sans query string).
+        """
+        # spec §Tests d'acceptation #13
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        client.get("/api/sleep", params={"from": "2026-01-01"})
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        complete = [ln for ln in lines if ln.get("event") == "request.complete"]
+        assert complete, f"Aucun log `request.complete` capturé. Lignes: {lines}"
+        assert complete[0].get("route") == "/api/sleep", (
+            f"route attendue '/api/sleep', got {complete[0].get('route')!r}"
+        )
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `_build_app` (function) — lines 31-60
+- `TestRequestContext` (class) — lines 63-128
+- `TestRequestIdHeader` (class) — lines 131-168
+- `TestLatency` (class) — lines 171-218
+
+### Imports
+- `json`
+- `re`
+- `pytest`
+- `fastapi.testclient`
+
+### Exports
+- `_build_app`
+- `TestRequestContext`
+- `TestRequestIdHeader`
+- `TestLatency`
+
+
+## Validates specs *(auto — declared by spec)*
+
+- [[../../specs/2026-04-26-v2-structlog-observability]] — classes: `TestRequestContext`, `TestRequestIdHeader`, `TestLatency` · methods: `test_request_id_generated_when_absent`, `test_request_id_propagated_from_header`, `test_request_id_present_in_response_header`, `test_request_id_bound_to_logs`, `test_user_id_default_none`, `test_latency_ms_logged_on_request_complete`, `test_route_template_logged`

--- a/docs/vault/specs/2026-04-26-v2-structlog-observability.md
+++ b/docs/vault/specs/2026-04-26-v2-structlog-observability.md
@@ -1,0 +1,132 @@
+---
+type: spec
+title: "V2.0.5 — structlog observability foundation"
+slug: 2026-04-26-v2-structlog-observability
+status: delivered
+created: 2026-04-26
+delivered: 2026-04-26
+priority: medium
+related_plans:
+  - 2026-04-23-plan-v2-refactor-master
+related_specs: []
+implements:
+  - file: server/logging_config.py
+    symbols: [configure_logging, get_logger, _processors]
+  - file: server/middleware/request_context.py
+    symbols: [RequestContextMiddleware, request_id_var, user_id_var]
+  - file: server/main.py
+    symbols: [app, lifespan]
+  - file: requirements.txt
+    symbols: [structlog]
+tested_by:
+  - file: tests/server/test_logging_config.py
+    classes: [TestStructlogConfig, TestLogFields]
+    methods:
+      - test_logger_emits_json
+      - test_logger_includes_timestamp_iso8601
+      - test_logger_includes_level
+      - test_logger_includes_scope
+      - test_log_level_from_env
+      - test_pretty_renderer_in_dev_mode
+  - file: tests/server/test_request_context_middleware.py
+    classes: [TestRequestContext, TestRequestIdHeader, TestLatency]
+    methods:
+      - test_request_id_generated_when_absent
+      - test_request_id_propagated_from_header
+      - test_request_id_present_in_response_header
+      - test_request_id_bound_to_logs
+      - test_user_id_default_none
+      - test_latency_ms_logged_on_request_complete
+      - test_route_template_logged
+tags: [v2.0.5, structlog, observability, logging, foundation]
+---
+
+# Spec — V2.0.5 structlog observability foundation
+
+## Vision
+
+Mettre en place le pipeline de logs structurés (JSONL) **avant** V2.3 auth, pour que les events `login_success`/`login_fail`/`refresh`/`logout` soient loggables proprement dès leur introduction (pas de retrofit). On migre la stdlib `logging` vers `structlog` avec contexte (`request_id`, `user_id`, `route`, `latency_ms`), middleware FastAPI pour la corrélation, et un format unique JSON en prod (console pretty en dev).
+
+Caddy reverse proxy et CLI `logq` restent **hors scope** — V2.0.6+ les traitera quand on aura besoin de TLS et d'investigation logs en volume.
+
+## Décisions techniques
+
+- **Lib** : `structlog>=24.1` (mature, processors composables, integration stdlib propre).
+- **Format** :
+  - **prod** (`APP_ENV=prod` ou non défini) : `JSONRenderer` → 1 ligne JSON par log, stdout.
+  - **dev** (`APP_ENV=dev`) : `ConsoleRenderer(colors=True)` lisible humain.
+- **Niveau** : `LOG_LEVEL` env var (défaut `INFO`). Validation au boot via `lifespan`.
+- **Champs standards** émis par les processors : `timestamp` (ISO8601 UTC), `level`, `logger` (scope), `event` (message), `request_id`, `user_id` (None tant qu'auth absente), `route` (template FastAPI ex: `/api/sleep`), `latency_ms` (sur fin de request).
+- **Corrélation request** : `contextvars.ContextVar` (`request_id_var`, `user_id_var`) bindées par middleware → `structlog.contextvars.merge_contextvars` injecte dans tout log émis pendant la request.
+- **Middleware** :
+  - Pure ASGI middleware (pas BaseHTTPMiddleware — perfs + accès propre au scope).
+  - Génère `request_id = uuid4().hex` si header `X-Request-ID` absent (sinon réutilise la valeur entrante, max 64 chars sanitisés).
+  - Renvoie `X-Request-ID` dans response headers.
+  - Mesure `latency_ms` (perf_counter), log `request.complete` à la fin (level INFO succès / WARNING 4xx / ERROR 5xx).
+  - Bind `user_id_var = None` par défaut (V2.3 auth dépendency override pour set la vraie valeur).
+- **Stdlib bridge** : `structlog.stdlib.LoggerFactory` + propagate vers root logger configuré pour stdout. Toutes les libs tierces (uvicorn, sqlalchemy, alembic) émettent via stdlib → captées par même handler → format unifié.
+- **Sanitisation** : pas de PII dans les logs par convention (champ `event` libre mais on évite emails/tokens). Pas de scrubber automatique en V2.0.5 — déclaré dans NOTES.md comme tech debt à reconsidérer V2.3+.
+- **Migration progressive** : les `logging.getLogger(__name__)` existants continuent de marcher (bridge stdlib). On migre les call sites significatifs (routers, security, db) vers `get_logger(__name__)` structlog dans la même PR. Scripts `scripts/` restent stdlib pour cette PR.
+- **Pas de fichier** : tout sur stdout. Capture/rotation = responsabilité du runtime (docker compose / systemd / Caddy plus tard).
+- **Pas de OpenTelemetry** : trop lourd pour V2.0.5. `request_id` UUID suffit pour corrélation locale.
+
+## Livrables
+
+- [ ] `requirements.txt` : ajout `structlog>=24.1`
+- [ ] `server/logging_config.py` :
+  - `configure_logging(env: str | None = None, level: str | None = None) -> None`
+  - `get_logger(name: str) -> structlog.BoundLogger`
+  - Liste `_processors` (timestamp, contextvars merger, level adder, renderer JSON ou Console selon env)
+  - Lecture `APP_ENV`, `LOG_LEVEL` env vars
+- [ ] `server/middleware/__init__.py` (nouveau package)
+- [ ] `server/middleware/request_context.py` :
+  - `request_id_var: ContextVar[str | None]`
+  - `user_id_var: ContextVar[str | None]`
+  - `class RequestContextMiddleware` (ASGI pure)
+  - Génération `request_id`, propagation header in/out, mesure `latency_ms`, log `request.complete`
+- [ ] `server/main.py` :
+  - `lifespan` appelle `configure_logging()` au boot
+  - `app.add_middleware(RequestContextMiddleware)` (avant tout autre middleware)
+  - Remplacement `print(...)` résiduels par logger structlog si présents
+- [ ] Migration `logging.getLogger(__name__)` → `get_logger(__name__)` dans :
+  - `server/security/crypto.py`
+  - `server/database.py`
+  - `server/routers/sleep.py`, `heartrate.py`, `steps.py`, `exercise.py`, `mood.py`
+- [ ] Tests :
+  - `tests/server/test_logging_config.py` (~6 tests)
+  - `tests/server/test_request_context_middleware.py` (~7 tests)
+- [ ] `.env.example` : ajout `APP_ENV=dev` et `LOG_LEVEL=INFO` (commentés avec defaults documentés)
+- [ ] `README.md` : section "Logs" courte (format, env vars, exemple ligne JSON)
+- [ ] `NOTES.md` : tech debt "PII scrubber automatique pour logs (V2.3+)"
+- [ ] `HISTORY.md` : entry changelog
+
+## Tests d'acceptation
+
+1. **JSON output prod** — `TestStructlogConfig.test_logger_emits_json` : given `APP_ENV=prod`, when `get_logger("test").info("hello", foo=42)`, then la ligne capturée stdout est du JSON valide avec clés `timestamp`/`level`/`logger`/`event`/`foo`.
+2. **Timestamp ISO8601 UTC** — `TestLogFields.test_logger_includes_timestamp_iso8601` : la clé `timestamp` matche `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$`.
+3. **Level présent** — `TestLogFields.test_logger_includes_level` : `level: "info"` (lowercase string).
+4. **Scope présent** — `TestLogFields.test_logger_includes_scope` : `logger: "<module name>"`.
+5. **LOG_LEVEL respecté** — `TestStructlogConfig.test_log_level_from_env` : `LOG_LEVEL=WARNING` filtre les `info()` (0 ligne capturée).
+6. **Console renderer dev** — `TestStructlogConfig.test_pretty_renderer_in_dev_mode` : `APP_ENV=dev` → output **n'est pas** du JSON (pas de `{`/`}` brut), contient le mot `hello`.
+7. **request_id généré** — `TestRequestContext.test_request_id_generated_when_absent` : GET sans header `X-Request-ID` → response header `X-Request-ID` présent, format `[a-f0-9]{32}`.
+8. **request_id propagé** — `TestRequestIdHeader.test_request_id_propagated_from_header` : GET avec `X-Request-ID: my-trace-123` → response header `X-Request-ID: my-trace-123` (sanitisé : alnum + tirets, max 64 chars).
+9. **request_id dans response** — `TestRequestIdHeader.test_request_id_present_in_response_header` : toute response a un `X-Request-ID`.
+10. **request_id bindé aux logs** — `TestRequestContext.test_request_id_bound_to_logs` : un log émis pendant une request inclut la clé `request_id`.
+11. **user_id None par défaut** — `TestRequestContext.test_user_id_default_none` : log inclut `user_id: null` (placeholder pour V2.3).
+12. **latency_ms loggué** — `TestLatency.test_latency_ms_logged_on_request_complete` : à la fin d'une request, un log `event: "request.complete"` est émis avec `latency_ms` (float ≥ 0).
+13. **route template loggué** — `TestLatency.test_route_template_logged` : pour `GET /api/sleep?from=...`, `route: "/api/sleep"` (sans query string).
+14. **Suite globale** — `pytest tests/` ≥ 248 tests GREEN (235 actuels + 13 nouveaux), 0 régression.
+
+## Out of scope V2.0.5
+
+- Caddy reverse proxy + TLS (différé V2.0.6)
+- CLI `logq` query JSONL (différé V2.0.7)
+- OpenTelemetry / distributed tracing
+- PII scrubber automatique (déclaré tech debt — V2.3+ avec auth)
+- Rotation/archive logs (responsabilité runtime)
+- Migration `scripts/*` vers structlog (stdlib OK pour CLI)
+- Sentry / external sink
+
+## Suite naturelle
+
+V2.3 — Auth system (Phase 1 master plan) : les events auth (`auth.login.success`, `auth.login.fail`, `auth.refresh`, `auth.logout`, `auth.password_reset`) sont émis via `get_logger("server.auth").info(...)` et bénéficient automatiquement de `request_id` + (nouveau) `user_id` bindé via dependency override sur `request_context_var`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,6 @@ testcontainers[postgres]>=4.0
 
 # V2.2 — chiffrement at-rest AES-256-GCM applicatif (champs Art.9 RGPD)
 cryptography>=42.0
+
+# V2.0.5 — observability foundation (logs JSON structurés, request_id corrélation)
+structlog>=24.1

--- a/server/database.py
+++ b/server/database.py
@@ -4,6 +4,11 @@ from functools import lru_cache
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.orm import Session, sessionmaker
 
+from server.logging_config import get_logger
+
+
+_log = get_logger(__name__)
+
 _DEFAULT_PG_URL = "postgresql+psycopg://samsung:samsung@localhost:5432/samsunghealth"
 
 

--- a/server/logging_config.py
+++ b/server/logging_config.py
@@ -1,0 +1,80 @@
+"""Structlog observability foundation (V2.0.5).
+
+Pipeline de logs structurés JSONL en prod, ConsoleRenderer en dev.
+Bridge stdlib → structlog pour que uvicorn/sqlalchemy passent par le même rendu.
+ContextVars (request_id, user_id) injectées automatiquement via processor.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import structlog
+
+
+_VALID_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+
+def _resolve_env(env: str | None) -> str:
+    if env is not None:
+        return env.lower()
+    return os.environ.get("APP_ENV", "prod").lower()
+
+
+def _resolve_level(level: str | None) -> int:
+    raw = (level if level is not None else os.environ.get("LOG_LEVEL", "INFO")).upper()
+    if raw not in _VALID_LEVELS:
+        logging.getLogger(__name__).warning(
+            "LOG_LEVEL invalide '%s', fallback INFO", raw
+        )
+        raw = "INFO"
+    return getattr(logging, raw)
+
+
+def _build_processors(env: str) -> list:
+    """Compose la chaîne de processors structlog. Ordre = important."""
+    shared: list = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso", utc=True, key="timestamp"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.format_exc_info,
+    ]
+    if env == "dev":
+        shared.append(structlog.dev.ConsoleRenderer(colors=True))
+    else:
+        shared.append(structlog.processors.JSONRenderer())
+    return shared
+
+
+def configure_logging(env: str | None = None, level: str | None = None) -> None:
+    """Configure structlog + bridge stdlib. Idempotent — peut être ré-appelé."""
+    resolved_env = _resolve_env(env)
+    resolved_level = _resolve_level(level)
+
+    processors = _build_processors(resolved_env)
+
+    # Reset handlers du root logger pour éviter doublons quand on re-configure
+    # (les tests appellent configure_logging à chaque test).
+    root = logging.getLogger()
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)
+    root.setLevel(resolved_level)
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(resolved_level),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stdout),
+        cache_logger_on_first_use=False,
+    )
+
+
+def get_logger(name: str) -> structlog.stdlib.BoundLogger:
+    """Retourne un logger structlog avec scope (`logger` field) bindé sur `name`."""
+    return structlog.get_logger(name).bind(logger=name)

--- a/server/main.py
+++ b/server/main.py
@@ -5,6 +5,9 @@ from fastapi import FastAPI
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
+from server.logging_config import configure_logging
+from server.middleware.request_context import RequestContextMiddleware
+
 
 def _validate_encryption_at_boot() -> None:
     """V2.2 fail-fast — appelée au lifespan startup. Le test_boot_validation l'invoque directement."""
@@ -14,6 +17,7 @@ def _validate_encryption_at_boot() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    configure_logging()
     _validate_encryption_at_boot()
     yield
 
@@ -21,6 +25,7 @@ async def lifespan(app: FastAPI):
 from server.routers import exercise, heartrate, mood, sleep, steps  # noqa: E402
 
 app = FastAPI(title="SamsungHealth", lifespan=lifespan)
+app.add_middleware(RequestContextMiddleware)
 app.include_router(sleep.router)
 app.include_router(steps.router)
 app.include_router(heartrate.router)

--- a/server/middleware/request_context.py
+++ b/server/middleware/request_context.py
@@ -1,0 +1,146 @@
+"""Request context middleware (V2.0.5).
+
+Pure ASGI middleware qui :
+- Génère ou réutilise un `request_id` (X-Request-ID), sanitisé alnum+tirets, max 64 chars.
+- Bind `request_id_var` et `user_id_var` (ContextVar) → injectés dans tous logs structlog
+  émis pendant la request via `structlog.contextvars.merge_contextvars`.
+- Renvoie le `X-Request-ID` dans response headers.
+- Mesure la latence (`perf_counter`) et émet `request.complete` (INFO/WARNING/ERROR
+  selon status code) avec `latency_ms` + `route` (template FastAPI).
+"""
+from __future__ import annotations
+
+import re
+import time
+import uuid
+from contextvars import ContextVar
+
+import structlog
+
+from server.logging_config import get_logger
+
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+user_id_var: ContextVar[str | None] = ContextVar("user_id", default=None)
+
+_REQUEST_ID_MAX_LEN = 64
+_REQUEST_ID_RE = re.compile(r"[^A-Za-z0-9-]")
+
+
+def _sanitize_request_id(raw: str) -> str:
+    """Garde alnum + tirets, tronque à 64. Si vide après nettoyage → uuid4().hex."""
+    cleaned = _REQUEST_ID_RE.sub("", raw)[:_REQUEST_ID_MAX_LEN]
+    return cleaned or uuid.uuid4().hex
+
+
+def _resolve_route_template(scope) -> str:
+    """Retourne le template FastAPI (`/api/sleep`) si match, sinon le path brut."""
+    route = scope.get("route")
+    if route is not None:
+        path = getattr(route, "path", None)
+        if path:
+            return path
+    return scope.get("path", "")
+
+
+def _level_for_status(status: int) -> str:
+    if status >= 500:
+        return "error"
+    if status >= 400:
+        return "warning"
+    return "info"
+
+
+class RequestContextMiddleware:
+    """ASGI pure middleware. Monte-le AVANT tout autre middleware applicatif."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Header lookup — ASGI scope.headers est list[tuple[bytes, bytes]]
+        headers = scope.get("headers") or []
+        incoming_rid: str | None = None
+        for k, v in headers:
+            if k.lower() == b"x-request-id":
+                incoming_rid = v.decode("latin-1", errors="ignore")
+                break
+
+        if incoming_rid:
+            request_id = _sanitize_request_id(incoming_rid)
+        else:
+            request_id = uuid.uuid4().hex
+
+        # Bind contextvars (structlog merger les injecte dans chaque log emit)
+        token_rid = request_id_var.set(request_id)
+        token_uid = user_id_var.set(None)
+        structlog.contextvars.bind_contextvars(
+            request_id=request_id,
+            user_id=None,
+        )
+
+        start = time.perf_counter()
+        status_holder: dict = {"code": 500, "started": False}
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                status_holder["code"] = message["status"]
+                status_holder["started"] = True
+                # Inject X-Request-ID header
+                raw_headers = list(message.get("headers") or [])
+                # Drop any existing x-request-id (case-insensitive) pour éviter doublon
+                raw_headers = [
+                    (k, v) for k, v in raw_headers if k.lower() != b"x-request-id"
+                ]
+                raw_headers.append(
+                    (b"x-request-id", request_id.encode("latin-1"))
+                )
+                message["headers"] = raw_headers
+            await send(message)
+
+        try:
+            try:
+                await self.app(scope, receive, send_wrapper)
+            except Exception:
+                # App raised avant d'envoyer une response → on émet un 500
+                # avec X-Request-ID pour préserver la corrélation.
+                if not status_holder["started"]:
+                    status_holder["code"] = 500
+                    await send(
+                        {
+                            "type": "http.response.start",
+                            "status": 500,
+                            "headers": [
+                                (b"content-type", b"text/plain; charset=utf-8"),
+                                (b"content-length", b"21"),
+                                (b"x-request-id", request_id.encode("latin-1")),
+                            ],
+                        }
+                    )
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": b"Internal Server Error",
+                        }
+                    )
+                raise
+        finally:
+            latency_ms = (time.perf_counter() - start) * 1000.0
+            route = _resolve_route_template(scope)
+            level = _level_for_status(status_holder["code"])
+            log = get_logger("server.middleware.request_context")
+            log_method = getattr(log, level)
+            log_method(
+                "request.complete",
+                route=route,
+                method=scope.get("method"),
+                status=status_holder["code"],
+                latency_ms=round(latency_ms, 3),
+            )
+            structlog.contextvars.unbind_contextvars("request_id", "user_id")
+            request_id_var.reset(token_rid)
+            user_id_var.reset(token_uid)

--- a/server/routers/exercise.py
+++ b/server/routers/exercise.py
@@ -7,7 +7,10 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import ExerciseSession
+from server.logging_config import get_logger
 from server.models import ExerciseBulkIn, ExerciseSessionOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/exercise", tags=["exercise"])
 

--- a/server/routers/heartrate.py
+++ b/server/routers/heartrate.py
@@ -5,7 +5,10 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import HeartRateHourly
+from server.logging_config import get_logger
 from server.models import HeartRateBulkIn, HeartRateHourlyOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/heartrate", tags=["heartrate"])
 

--- a/server/routers/mood.py
+++ b/server/routers/mood.py
@@ -8,8 +8,11 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import Mood
+from server.logging_config import get_logger
 from server.models import MoodBulkIn, MoodOut
 from server.security.crypto import DecryptionError
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/mood", tags=["mood"])
 

--- a/server/routers/sleep.py
+++ b/server/routers/sleep.py
@@ -6,7 +6,10 @@ from sqlalchemy.orm import Session, selectinload
 
 from server.database import get_session
 from server.db.models import SleepSession, SleepStage
+from server.logging_config import get_logger
 from server.models import SleepBulkIn, SleepSessionOut, SleepStageOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/sleep", tags=["sleep"])
 

--- a/server/routers/steps.py
+++ b/server/routers/steps.py
@@ -5,7 +5,10 @@ from sqlalchemy.orm import Session
 
 from server.database import get_session
 from server.db.models import StepsHourly
+from server.logging_config import get_logger
 from server.models import StepsBulkIn, StepsHourlyOut
+
+_log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/steps", tags=["steps"])
 

--- a/server/security/crypto.py
+++ b/server/security/crypto.py
@@ -13,6 +13,10 @@ from functools import lru_cache
 from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
+from server.logging_config import get_logger
+
+
+_log = get_logger(__name__)
 
 KEY_ENV_VAR = "SAMSUNGHEALTH_ENCRYPTION_KEY"
 NONCE_BYTES = 12

--- a/tests/server/test_logging_config.py
+++ b/tests/server/test_logging_config.py
@@ -1,0 +1,163 @@
+"""
+Tests RED — V2.0.5 structlog observability foundation : logging config.
+
+Mappé sur frontmatter `tested_by:` du spec
+docs/vault/specs/2026-04-26-v2-structlog-observability.md.
+
+Classes:
+- TestStructlogConfig
+- TestLogFields
+
+Cible:
+- `from server.logging_config import configure_logging, get_logger`
+
+Note RED: `server.logging_config` n'existe pas encore. `structlog` n'est pas
+encore dans `requirements.txt` (V2.0.5 l'ajoute). L'import au top du module
+doit faire échouer la collection / les tests jusqu'à l'implémentation : c'est
+exactement le contrat RED de TDD.
+"""
+import json
+import re
+
+import pytest
+
+
+class TestStructlogConfig:
+    def test_logger_emits_json(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod (renderer JSON),
+        when get_logger("test").info("hello", foo=42),
+        then la ligne capturée stdout est du JSON valide avec
+             clés timestamp/level/logger/event/foo.
+        """
+        # spec §Tests d'acceptation #1
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        log = get_logger("test")
+        log.info("hello", foo=42)
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert payload["event"] == "hello"
+        assert payload["foo"] == 42
+        assert "timestamp" in payload
+        assert "level" in payload
+        assert "logger" in payload
+
+    def test_log_level_from_env(self, capsys, monkeypatch):
+        """
+        given LOG_LEVEL=WARNING,
+        when on émet un info() puis un warning(),
+        then 0 ligne info capturée, 1 ligne warning capturée.
+        """
+        # spec §Tests d'acceptation #5
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "WARNING")
+        configure_logging()
+
+        log = get_logger("test.level")
+        log.info("should_be_filtered")
+        log.warning("should_pass")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        assert "should_be_filtered" not in out
+        assert "should_pass" in out
+
+    def test_pretty_renderer_in_dev_mode(self, capsys, monkeypatch):
+        """
+        given APP_ENV=dev (ConsoleRenderer),
+        when get_logger("test").info("hello"),
+        then output n'est pas du JSON (pas d'objet `{...}` brut parsable)
+             et contient le mot "hello".
+        """
+        # spec §Tests d'acceptation #6
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "dev")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        log = get_logger("test.dev")
+        log.info("hello")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        assert "hello" in out
+        # ConsoleRenderer n'émet pas une ligne JSON parsable
+        last_line = out.strip().splitlines()[-1]
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(last_line)
+
+
+class TestLogFields:
+    def test_logger_includes_timestamp_iso8601(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod,
+        when get_logger("t").info("e"),
+        then la clé `timestamp` matche ^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z$ (ISO8601 UTC).
+        """
+        # spec §Tests d'acceptation #2
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        get_logger("t").info("e")
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert "timestamp" in payload
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z$",
+            payload["timestamp"],
+        ), f"timestamp ne matche pas ISO8601 UTC: {payload['timestamp']!r}"
+
+    def test_logger_includes_level(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod,
+        when get_logger("t").info("e"),
+        then payload["level"] == "info" (lowercase string).
+        """
+        # spec §Tests d'acceptation #3
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        get_logger("t.lvl").info("e")
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert payload["level"] == "info"
+
+    def test_logger_includes_scope(self, capsys, monkeypatch):
+        """
+        given APP_ENV=prod,
+        when get_logger("server.routers.sleep").info("e"),
+        then payload["logger"] == "server.routers.sleep" (scope = nom du logger).
+        """
+        # spec §Tests d'acceptation #4
+        from server.logging_config import configure_logging, get_logger
+
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+        configure_logging()
+
+        get_logger("server.routers.sleep").info("e")
+
+        captured = capsys.readouterr()
+        line = (captured.out + captured.err).strip().splitlines()[-1]
+        payload = json.loads(line)
+        assert payload["logger"] == "server.routers.sleep"

--- a/tests/server/test_request_context_middleware.py
+++ b/tests/server/test_request_context_middleware.py
@@ -1,0 +1,218 @@
+"""
+Tests RED — V2.0.5 structlog observability foundation : request context middleware.
+
+Mappé sur frontmatter `tested_by:` du spec
+docs/vault/specs/2026-04-26-v2-structlog-observability.md.
+
+Classes:
+- TestRequestContext
+- TestRequestIdHeader
+- TestLatency
+
+Cible:
+- `from server.middleware.request_context import RequestContextMiddleware, request_id_var, user_id_var`
+- `from server.logging_config import configure_logging, get_logger`
+
+Note RED: `server.middleware.request_context` n'existe pas encore (et le
+package `server.middleware` non plus). `structlog` n'est pas encore dans
+`requirements.txt`. Les tests doivent échouer à l'import — c'est le contrat RED.
+
+On construit une mini-app FastAPI inline dans chaque test (plutôt que de
+réutiliser `server.main.app`) pour isoler le middleware et tester son
+comportement seul.
+"""
+import json
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _build_app():
+    """Construit une app FastAPI minimale avec le RequestContextMiddleware
+    monté + une route qui émet un log via structlog pendant la request, pour
+    pouvoir asserter le binding contextvars → log entries.
+
+    Lazy imports : tant que `server.logging_config` /
+    `server.middleware.request_context` n'existent pas, l'appel à _build_app()
+    lève ModuleNotFoundError → RED clair par test, pas en collection.
+    """
+    from fastapi import FastAPI
+
+    from server.logging_config import configure_logging, get_logger
+    from server.middleware.request_context import RequestContextMiddleware
+
+    configure_logging()
+    log = get_logger("server.test_app")
+
+    app = FastAPI()
+    app.add_middleware(RequestContextMiddleware)
+
+    @app.get("/api/sleep")
+    def get_sleep():
+        log.info("inside_handler")
+        return {"ok": True}
+
+    @app.get("/api/error")
+    def get_error():
+        raise ValueError("boom")
+
+    return app
+
+
+class TestRequestContext:
+    def test_request_id_generated_when_absent(self, monkeypatch):
+        """
+        given une request GET sans header X-Request-ID,
+        when le middleware traite la request,
+        then la response contient un header X-Request-ID au format [a-f0-9]{32}.
+        """
+        # spec §Tests d'acceptation #7
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+
+        resp = client.get("/api/sleep")
+        assert resp.status_code == 200
+        assert "x-request-id" in {k.lower() for k in resp.headers.keys()}
+        rid = resp.headers["x-request-id"]
+        assert re.match(r"^[a-f0-9]{32}$", rid), f"rid={rid!r} ne matche pas uuid4().hex"
+
+    def test_request_id_bound_to_logs(self, monkeypatch, capsys):
+        """
+        given une request,
+        when un log est émis pendant le handler,
+        then l'entry de log contient la clé `request_id` égale à la valeur
+             du header X-Request-ID renvoyé.
+        """
+        # spec §Tests d'acceptation #10
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        resp = client.get("/api/sleep")
+        rid = resp.headers["x-request-id"]
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        # On parse toutes les lignes JSON et on cherche celle du handler
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        handler_lines = [ln for ln in lines if ln.get("event") == "inside_handler"]
+        assert handler_lines, f"Aucun log `inside_handler` capturé. Lignes: {lines}"
+        assert handler_lines[0].get("request_id") == rid
+
+    def test_user_id_default_none(self, monkeypatch, capsys):
+        """
+        given une request sans auth (V2.0.5 = pas d'auth),
+        when un log est émis,
+        then l'entry contient `user_id: null` (placeholder pour V2.3 auth).
+        """
+        # spec §Tests d'acceptation #11
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        client.get("/api/sleep")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        handler_lines = [ln for ln in lines if ln.get("event") == "inside_handler"]
+        assert handler_lines, f"Aucun log handler capturé. Lignes: {lines}"
+        # null en JSON ↔ None en Python : la clé doit être présente avec valeur None.
+        assert "user_id" in handler_lines[0], "Clé user_id absente du log"
+        assert handler_lines[0]["user_id"] is None
+
+
+class TestRequestIdHeader:
+    def test_request_id_propagated_from_header(self, monkeypatch):
+        """
+        given une request GET avec header X-Request-ID: my-trace-123,
+        when le middleware traite la request,
+        then la response renvoie X-Request-ID: my-trace-123 (sanitisé alnum+tirets, max 64 chars).
+        """
+        # spec §Tests d'acceptation #8
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+
+        resp = client.get("/api/sleep", headers={"X-Request-ID": "my-trace-123"})
+        assert resp.status_code == 200
+        assert resp.headers["x-request-id"] == "my-trace-123"
+
+    def test_request_id_present_in_response_header(self, monkeypatch):
+        """
+        given n'importe quelle request (succès ou erreur),
+        when le middleware traite la response,
+        then la response a toujours un header X-Request-ID non vide.
+        """
+        # spec §Tests d'acceptation #9
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app, raise_server_exceptions=False)
+
+        # Succès
+        ok = client.get("/api/sleep")
+        assert ok.headers.get("x-request-id"), "X-Request-ID absent sur 200"
+
+        # Erreur 500
+        err = client.get("/api/error")
+        assert err.headers.get("x-request-id"), "X-Request-ID absent sur 500"
+
+
+class TestLatency:
+    def test_latency_ms_logged_on_request_complete(self, monkeypatch, capsys):
+        """
+        given une request,
+        when le middleware termine,
+        then un log `event: "request.complete"` est émis avec une clé
+             `latency_ms` (float >= 0).
+        """
+        # spec §Tests d'acceptation #12
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        client.get("/api/sleep")
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        complete = [ln for ln in lines if ln.get("event") == "request.complete"]
+        assert complete, f"Aucun log `request.complete` capturé. Lignes: {lines}"
+        assert "latency_ms" in complete[0], "Clé latency_ms absente"
+        latency = complete[0]["latency_ms"]
+        assert isinstance(latency, (int, float)), f"latency_ms doit être numérique, pas {type(latency)}"
+        assert float(latency) >= 0.0
+
+    def test_route_template_logged(self, monkeypatch, capsys):
+        """
+        given une request GET /api/sleep?from=2026-01-01,
+        when le middleware logge `request.complete`,
+        then la clé `route` vaut "/api/sleep" (template FastAPI sans query string).
+        """
+        # spec §Tests d'acceptation #13
+        monkeypatch.setenv("APP_ENV", "prod")
+        monkeypatch.setenv("LOG_LEVEL", "INFO")
+
+        app = _build_app()
+        client = TestClient(app)
+        client.get("/api/sleep", params={"from": "2026-01-01"})
+
+        captured = capsys.readouterr()
+        out = (captured.out + captured.err)
+        lines = [json.loads(ln) for ln in out.strip().splitlines() if ln.strip().startswith("{")]
+        complete = [ln for ln in lines if ln.get("event") == "request.complete"]
+        assert complete, f"Aucun log `request.complete` capturé. Lignes: {lines}"
+        assert complete[0].get("route") == "/api/sleep", (
+            f"route attendue '/api/sleep', got {complete[0].get('route')!r}"
+        )


### PR DESCRIPTION
## Summary
- structlog>=24.1 ajouté ; pipeline JSONL en prod (`APP_ENV=prod`), `ConsoleRenderer(colors)` en dev. Niveau via `LOG_LEVEL` env (fallback INFO si invalide)
- `RequestContextMiddleware` ASGI pure : génère/sanitise `X-Request-ID` (alnum+tirets, max 64), bind ContextVars `request_id`/`user_id`, mesure `latency_ms` (perf_counter), émet log `request.complete` (INFO/WARNING/ERROR selon status) avec `route` template + `method` + `status`
- Loggers structlog ajoutés dans `server/{database,security/crypto,routers/*}.py` — prêts pour les events auth de V2.3
- `configure_logging()` câblé dans le `lifespan` FastAPI ; bridge stdlib pour que uvicorn/sqlalchemy passent par le même handler stdout
- Spec : `docs/vault/specs/2026-04-26-v2-structlog-observability.md` (status delivered)

## Hors scope V2.0.5 (différés V2.0.6+)
Caddy reverse proxy + TLS, CLI `logq`, OpenTelemetry, PII scrubber automatique (déclaré tech debt NOTES.md pour V2.3+), migration `scripts/*` (stdlib OK pour CLI).

## Test plan
- [x] `pytest tests/server/test_logging_config.py -v` → 6/6 GREEN
- [x] `pytest tests/server/test_request_context_middleware.py -v` → 7/7 GREEN
- [x] `pytest tests/` full suite → **248/248 GREEN, 0 régression** (235 baseline + 13 nouveaux)
- [x] Lint clean