### PR TITLE
chore(V2.3.0.1): user_id NOT NULL sur 21 tables santé + scripts CSV multi-user

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
+| V2.3.0.1 — `user_id NOT NULL` cleanup + scripts CSV multi-user | `alembic/versions/0005_user_id_not_null.py`, `server/db/models.py`, `scripts/import_samsung_csv.py`, `scripts/generate_sample.py` | [`PENDING`](#2026-04-26-PENDING) |
 | V2.3 — Auth foundation atomique (users + JWT access+refresh + multi-user FK + redaction + audit) | `server/security/auth.py`, `server/security/redaction.py`, `server/routers/auth.py`, `server/db/models.py`, `alembic/versions/0004_auth_foundation.py` | [`e32801a`](#2026-04-26-e32801a) |
 | V2.0.5 — structlog observability foundation (JSONL + request_id middleware) | `server/logging_config.py`, `server/middleware/request_context.py`, `server/main.py`, `requirements.txt` | [`f2c8cb2`](#2026-04-26-f2c8cb2) |
 | Samsung Health CSV import — full DB schema (21 tables) | `server/database.py`, `scripts/import_samsung_csv.py`, `scripts/explore_samsung_export.py` | [`d032741`](#2026-04-21-d032741) |
@@ -54,6 +55,17 @@ chore(release-archive): tag état de l'app au moment de l'enregistrement loom
 ---
 
 ## Changelog
+
+### 2026-04-26 `PENDING`
+chore(V2.3.0.1): user_id NOT NULL sur 21 tables santé + scripts CSV multi-user
+- `alembic/versions/0005_user_id_not_null.py` créé (revision `8c1d2e4f5a90`, parent `7a3b9c0e1d24`) — safety check raise si rows orphelines, ALTER COLUMN SET NOT NULL sur 21 tables, drop des index partiels `WHERE user_id IS NULL`. Downgrade restaure l'état nullable + index partiel.
+- `server/db/models.py` — 21 occurrences de `user_id: Mapped[UUID | None]` + `nullable=True` → `Mapped[UUID]` + `nullable=False`. RefreshToken déjà NOT NULL, AuthEvent reste nullable (login_failure sur email inexistant).
+- `scripts/import_samsung_csv.py` — argparse `--user-email` (default `legacy@samsunghealth.local`), helper `_resolve_target_user_id`, `_upsert` injecte `user_id=TARGET_USER_ID` côté serveur, drop `index_where=text("user_id IS NULL")`, l'unique constraint matchée est désormais `(user_id, ...cols)`.
+- `scripts/generate_sample.py` — argparse `--user-email`, propagation `user_id` aux 5 call sites (sleep + stages + steps + heart_rate + exercise), drop des `index_where`.
+- `alembic/versions/0004_auth_foundation.py` — fix bug downgrade : remplace `op.drop_constraint(uq_name, ...)` par `op.execute("DROP INDEX IF EXISTS ...")` (l'upgrade créait un INDEX partiel, pas un constraint, donc drop_constraint échouait). Drop aussi `uq_<table>_user_window` créé par l'upgrade.
+- `tests/server/conftest.py` — fixture `default_user_db` + helper `_ensure_orm_default_user` (insertion idempotente raw SQL, évite argon2 200ms par test) + autouse hook `_auto_inject_user_id_for_health_inserts` (event `before_insert` SQLAlchemy qui injecte un user_id par défaut si absent — évite de patcher 30+ inserts ORM dans les tests existants).
+- `tests/server/test_crypto_foundation.py` + `tests/server/test_scripts_csv_import.py` — adaptation aux nouvelles signatures CLI argparse + injection `TARGET_USER_ID` via le fixture `csv_export_dir`.
+- 123 tests verts (`pytest tests/server/`).
 
 ### 2026-04-26 `2beb3c7`
 chore(design): référence rebrand Data Saillance (palette + typo + logos, dark + light) pour le produit Nightfall

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,7 @@
 
 | Feature | Files | Commit |
 |---------|-------|--------|
-| V2.3.0.1 — `user_id NOT NULL` cleanup + scripts CSV multi-user | `alembic/versions/0005_user_id_not_null.py`, `server/db/models.py`, `scripts/import_samsung_csv.py`, `scripts/generate_sample.py` | [`PENDING`](#2026-04-26-PENDING) |
+| V2.3.0.1 — `user_id NOT NULL` cleanup + scripts CSV multi-user | `alembic/versions/0005_user_id_not_null.py`, `server/db/models.py`, `scripts/import_samsung_csv.py`, `scripts/generate_sample.py` | [`08101d1`](#2026-04-26-08101d1) |
 | V2.3 — Auth foundation atomique (users + JWT access+refresh + multi-user FK + redaction + audit) | `server/security/auth.py`, `server/security/redaction.py`, `server/routers/auth.py`, `server/db/models.py`, `alembic/versions/0004_auth_foundation.py` | [`e32801a`](#2026-04-26-e32801a) |
 | V2.0.5 — structlog observability foundation (JSONL + request_id middleware) | `server/logging_config.py`, `server/middleware/request_context.py`, `server/main.py`, `requirements.txt` | [`f2c8cb2`](#2026-04-26-f2c8cb2) |
 | Samsung Health CSV import — full DB schema (21 tables) | `server/database.py`, `scripts/import_samsung_csv.py`, `scripts/explore_samsung_export.py` | [`d032741`](#2026-04-21-d032741) |
@@ -56,7 +56,7 @@ chore(release-archive): tag état de l'app au moment de l'enregistrement loom
 
 ## Changelog
 
-### 2026-04-26 `PENDING`
+### 2026-04-26 `08101d1`
 chore(V2.3.0.1): user_id NOT NULL sur 21 tables santé + scripts CSV multi-user
 - `alembic/versions/0005_user_id_not_null.py` créé (revision `8c1d2e4f5a90`, parent `7a3b9c0e1d24`) — safety check raise si rows orphelines, ALTER COLUMN SET NOT NULL sur 21 tables, drop des index partiels `WHERE user_id IS NULL`. Downgrade restaure l'état nullable + index partiel.
 - `server/db/models.py` — 21 occurrences de `user_id: Mapped[UUID | None]` + `nullable=True` → `Mapped[UUID]` + `nullable=False`. RefreshToken déjà NOT NULL, AuthEvent reste nullable (login_failure sur email inexistant).

--- a/alembic/versions/0004_auth_foundation.py
+++ b/alembic/versions/0004_auth_foundation.py
@@ -241,8 +241,11 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Reverse the unique/index/column changes on health tables.
+    # NB: l'upgrade a remplacé `uq_<table>` par un INDEX partiel (pas un constraint),
+    # donc on drop l'index puis on recrée le constraint d'origine.
     for table_name, uq_name, uq_cols in HEALTH_TABLES_UNIQUE:
-        op.drop_constraint(uq_name, table_name, type_="unique")
+        op.drop_constraint(f"uq_{table_name}_user_window", table_name, type_="unique")
+        op.execute(f'DROP INDEX IF EXISTS {uq_name}')
         op.create_unique_constraint(uq_name, table_name, uq_cols)
         op.drop_index(f"idx_{table_name}_user_id", table_name=table_name)
         op.drop_constraint(f"fk_{table_name}_user_id", table_name, type_="foreignkey")

--- a/alembic/versions/0005_user_id_not_null.py
+++ b/alembic/versions/0005_user_id_not_null.py
@@ -1,0 +1,107 @@
+"""V2.3.0.1 cleanup: user_id NOT NULL on health tables (after legacy backfill)
+
+Revision ID: 8c1d2e4f5a90
+Revises: 7a3b9c0e1d24
+Create Date: 2026-04-26 22:00:00.000000
+
+Suite naturelle de 0004 (V2.3 auth foundation). 0004 a :
+- ajouté `user_id UUID NULL` sur 21 tables santé,
+- backfill des rows existantes vers le user `legacy@samsunghealth.local`,
+- créé un index partiel `WHERE user_id IS NULL` pour préserver l'unicité historique
+  pendant que les scripts CSV (qui n'avaient pas encore notion de user_id) tournent.
+
+V2.3.0.1 ferme la fenêtre de tolérance :
+- Vérifie qu'aucune row n'a `user_id IS NULL` (safety, fail si oui),
+- ALTER COLUMN ... SET NOT NULL sur les 21 tables,
+- Drop l'index partiel devenu inutile.
+
+Les scripts CSV ont été mis à jour dans le même PR pour ne plus produire de rows NULL.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8c1d2e4f5a90"
+down_revision: Union[str, Sequence[str], None] = "7a3b9c0e1d24"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Doit rester aligné avec HEALTH_TABLES_UNIQUE de 0004_auth_foundation.py.
+HEALTH_TABLES_UNIQUE: list[tuple[str, str, list[str]]] = [
+    ("activity_daily", "uq_activity_daily_day", ["day_date"]),
+    ("activity_level", "uq_activity_level_time", ["start_time"]),
+    ("blood_pressure", "uq_bp_time", ["start_time"]),
+    ("ecg", "uq_ecg_window", ["start_time", "end_time"]),
+    ("exercise_sessions", "uq_exercise_window", ["exercise_start", "exercise_end"]),
+    ("floors_daily", "uq_floors_day", ["day_date"]),
+    ("heart_rate_hourly", "uq_hr_hourly_slot", ["date", "hour"]),
+    ("height", "uq_height_time", ["start_time"]),
+    ("hrv", "uq_hrv_window", ["start_time", "end_time"]),
+    ("mood", "uq_mood_time", ["start_time"]),
+    ("respiratory_rate", "uq_respi_window", ["start_time", "end_time"]),
+    ("skin_temperature", "uq_skin_temp_window", ["start_time", "end_time"]),
+    ("sleep_sessions", "uq_sleep_sessions_window", ["sleep_start", "sleep_end"]),
+    ("sleep_stages", "uq_sleep_stages_window", ["stage_start", "stage_end"]),
+    ("spo2", "uq_spo2_window", ["start_time", "end_time"]),
+    ("steps_daily", "uq_steps_daily_day", ["day_date"]),
+    ("steps_hourly", "uq_steps_hourly_slot", ["date", "hour"]),
+    ("stress", "uq_stress_window", ["start_time", "end_time"]),
+    ("vitality_score", "uq_vitality_day", ["day_date"]),
+    ("water_intake", "uq_water_time", ["start_time"]),
+    ("weight", "uq_weight_time", ["start_time"]),
+]
+
+
+def upgrade() -> None:
+    # 1. Safety check : aucune row ne doit rester avec user_id IS NULL.
+    # Si oui, l'opérateur doit reset password du user legacy et ré-assigner
+    # les rows manuellement avant de re-tenter la migration.
+    table_names = [t for t, _, _ in HEALTH_TABLES_UNIQUE]
+    union_query = " UNION ALL ".join(
+        f"SELECT '{name}' AS table_name, COUNT(*) AS n "
+        f"FROM {name} WHERE user_id IS NULL"
+        for name in table_names
+    )
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+          orphan_row record;
+          orphan_total bigint := 0;
+          orphan_detail text := '';
+        BEGIN
+          FOR orphan_row IN
+            SELECT table_name, n FROM ({union_query}) s WHERE n > 0
+          LOOP
+            orphan_total := orphan_total + orphan_row.n;
+            orphan_detail := orphan_detail
+              || format(' %s=%s', orphan_row.table_name, orphan_row.n);
+          END LOOP;
+          IF orphan_total > 0 THEN
+            RAISE EXCEPTION 'V2.3.0.1: % rows still have user_id IS NULL. Detail:%',
+              orphan_total, orphan_detail
+              USING HINT = 'Re-run V2.3 backfill or assign rows to a user before retrying.';
+          END IF;
+        END $$;
+        """
+    )
+
+    # 2. ALTER COLUMN ... SET NOT NULL + drop l'index partiel devenu inutile.
+    for table_name, uq_name, _uq_cols in HEALTH_TABLES_UNIQUE:
+        op.alter_column(table_name, "user_id", nullable=False)
+        op.drop_index(uq_name, table_name=table_name)
+
+
+def downgrade() -> None:
+    for table_name, uq_name, uq_cols in HEALTH_TABLES_UNIQUE:
+        op.alter_column(table_name, "user_id", nullable=True)
+        op.create_index(
+            uq_name,
+            table_name,
+            uq_cols,
+            unique=True,
+            postgresql_where="user_id IS NULL",
+        )

--- a/docs/vault/code/alembic/versions/0004_auth_foundation.md
+++ b/docs/vault/code/alembic/versions/0004_auth_foundation.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: alembic/versions/0004_auth_foundation.py
-git_blob: e87bbd6f7fc56e63cbeb9b19df632ac0e38029d5
-last_synced: '2026-04-26T16:48:27Z'
-loc: 260
+git_blob: be9ad46e4903555a58be466d39dcaab144b9df58
+last_synced: '2026-04-26T18:27:44Z'
+loc: 263
 annotations: []
 imports:
 - typing
@@ -270,8 +270,11 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     # Reverse the unique/index/column changes on health tables.
+    # NB: l'upgrade a remplacé `uq_<table>` par un INDEX partiel (pas un constraint),
+    # donc on drop l'index puis on recrée le constraint d'origine.
     for table_name, uq_name, uq_cols in HEALTH_TABLES_UNIQUE:
-        op.drop_constraint(uq_name, table_name, type_="unique")
+        op.drop_constraint(f"uq_{table_name}_user_window", table_name, type_="unique")
+        op.execute(f'DROP INDEX IF EXISTS {uq_name}')
         op.create_unique_constraint(uq_name, table_name, uq_cols)
         op.drop_index(f"idx_{table_name}_user_id", table_name=table_name)
         op.drop_constraint(f"fk_{table_name}_user_id", table_name, type_="foreignkey")
@@ -298,7 +301,7 @@ def downgrade() -> None:
 
 ### Symbols
 - `upgrade` (function) — lines 51-239 · **Specs**: [[../../specs/2026-04-26-v2-auth-foundation|2026-04-26-v2-auth-foundation]]
-- `downgrade` (function) — lines 242-260 · **Specs**: [[../../specs/2026-04-26-v2-auth-foundation|2026-04-26-v2-auth-foundation]]
+- `downgrade` (function) — lines 242-263 · **Specs**: [[../../specs/2026-04-26-v2-auth-foundation|2026-04-26-v2-auth-foundation]]
 
 ### Imports
 - `typing`

--- a/docs/vault/code/alembic/versions/0005_user_id_not_null.md
+++ b/docs/vault/code/alembic/versions/0005_user_id_not_null.md
@@ -1,0 +1,151 @@
+---
+type: code-source
+language: python
+file_path: alembic/versions/0005_user_id_not_null.py
+git_blob: c82e1e61ea8f43c8a53d836bafa783c04fb84f46
+last_synced: '2026-04-26T18:27:44Z'
+loc: 107
+annotations: []
+imports:
+- typing
+- alembic
+exports:
+- upgrade
+- downgrade
+tags:
+- code
+- python
+---
+
+# alembic/versions/0005_user_id_not_null.py
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`alembic/versions/0005_user_id_not_null.py`](../../../alembic/versions/0005_user_id_not_null.py).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```python
+"""V2.3.0.1 cleanup: user_id NOT NULL on health tables (after legacy backfill)
+
+Revision ID: 8c1d2e4f5a90
+Revises: 7a3b9c0e1d24
+Create Date: 2026-04-26 22:00:00.000000
+
+Suite naturelle de 0004 (V2.3 auth foundation). 0004 a :
+- ajouté `user_id UUID NULL` sur 21 tables santé,
+- backfill des rows existantes vers le user `legacy@samsunghealth.local`,
+- créé un index partiel `WHERE user_id IS NULL` pour préserver l'unicité historique
+  pendant que les scripts CSV (qui n'avaient pas encore notion de user_id) tournent.
+
+V2.3.0.1 ferme la fenêtre de tolérance :
+- Vérifie qu'aucune row n'a `user_id IS NULL` (safety, fail si oui),
+- ALTER COLUMN ... SET NOT NULL sur les 21 tables,
+- Drop l'index partiel devenu inutile.
+
+Les scripts CSV ont été mis à jour dans le même PR pour ne plus produire de rows NULL.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "8c1d2e4f5a90"
+down_revision: Union[str, Sequence[str], None] = "7a3b9c0e1d24"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Doit rester aligné avec HEALTH_TABLES_UNIQUE de 0004_auth_foundation.py.
+HEALTH_TABLES_UNIQUE: list[tuple[str, str, list[str]]] = [
+    ("activity_daily", "uq_activity_daily_day", ["day_date"]),
+    ("activity_level", "uq_activity_level_time", ["start_time"]),
+    ("blood_pressure", "uq_bp_time", ["start_time"]),
+    ("ecg", "uq_ecg_window", ["start_time", "end_time"]),
+    ("exercise_sessions", "uq_exercise_window", ["exercise_start", "exercise_end"]),
+    ("floors_daily", "uq_floors_day", ["day_date"]),
+    ("heart_rate_hourly", "uq_hr_hourly_slot", ["date", "hour"]),
+    ("height", "uq_height_time", ["start_time"]),
+    ("hrv", "uq_hrv_window", ["start_time", "end_time"]),
+    ("mood", "uq_mood_time", ["start_time"]),
+    ("respiratory_rate", "uq_respi_window", ["start_time", "end_time"]),
+    ("skin_temperature", "uq_skin_temp_window", ["start_time", "end_time"]),
+    ("sleep_sessions", "uq_sleep_sessions_window", ["sleep_start", "sleep_end"]),
+    ("sleep_stages", "uq_sleep_stages_window", ["stage_start", "stage_end"]),
+    ("spo2", "uq_spo2_window", ["start_time", "end_time"]),
+    ("steps_daily", "uq_steps_daily_day", ["day_date"]),
+    ("steps_hourly", "uq_steps_hourly_slot", ["date", "hour"]),
+    ("stress", "uq_stress_window", ["start_time", "end_time"]),
+    ("vitality_score", "uq_vitality_day", ["day_date"]),
+    ("water_intake", "uq_water_time", ["start_time"]),
+    ("weight", "uq_weight_time", ["start_time"]),
+]
+
+
+def upgrade() -> None:
+    # 1. Safety check : aucune row ne doit rester avec user_id IS NULL.
+    # Si oui, l'opérateur doit reset password du user legacy et ré-assigner
+    # les rows manuellement avant de re-tenter la migration.
+    table_names = [t for t, _, _ in HEALTH_TABLES_UNIQUE]
+    union_query = " UNION ALL ".join(
+        f"SELECT '{name}' AS table_name, COUNT(*) AS n "
+        f"FROM {name} WHERE user_id IS NULL"
+        for name in table_names
+    )
+    op.execute(
+        f"""
+        DO $$
+        DECLARE
+          orphan_row record;
+          orphan_total bigint := 0;
+          orphan_detail text := '';
+        BEGIN
+          FOR orphan_row IN
+            SELECT table_name, n FROM ({union_query}) s WHERE n > 0
+          LOOP
+            orphan_total := orphan_total + orphan_row.n;
+            orphan_detail := orphan_detail
+              || format(' %s=%s', orphan_row.table_name, orphan_row.n);
+          END LOOP;
+          IF orphan_total > 0 THEN
+            RAISE EXCEPTION 'V2.3.0.1: % rows still have user_id IS NULL. Detail:%',
+              orphan_total, orphan_detail
+              USING HINT = 'Re-run V2.3 backfill or assign rows to a user before retrying.';
+          END IF;
+        END $$;
+        """
+    )
+
+    # 2. ALTER COLUMN ... SET NOT NULL + drop l'index partiel devenu inutile.
+    for table_name, uq_name, _uq_cols in HEALTH_TABLES_UNIQUE:
+        op.alter_column(table_name, "user_id", nullable=False)
+        op.drop_index(uq_name, table_name=table_name)
+
+
+def downgrade() -> None:
+    for table_name, uq_name, uq_cols in HEALTH_TABLES_UNIQUE:
+        op.alter_column(table_name, "user_id", nullable=True)
+        op.create_index(
+            uq_name,
+            table_name,
+            uq_cols,
+            unique=True,
+            postgresql_where="user_id IS NULL",
+        )
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `upgrade` (function) — lines 58-95
+- `downgrade` (function) — lines 98-107
+
+### Imports
+- `typing`
+- `alembic`
+
+### Exports
+- `upgrade`
+- `downgrade`

--- a/docs/vault/code/scripts/generate_sample.md
+++ b/docs/vault/code/scripts/generate_sample.md
@@ -2,11 +2,12 @@
 type: code-source
 language: python
 file_path: scripts/generate_sample.py
-git_blob: 6c856c2fb2c51a691c82c1408579f9c7144a5aa7
-last_synced: '2026-04-26T16:48:27Z'
-loc: 241
+git_blob: 56649bf84ff7cdf1db3e8b0dc8cc43a525658953
+last_synced: '2026-04-26T18:27:44Z'
+loc: 270
 annotations: []
 imports:
+- argparse
 - random
 - sys
 - datetime
@@ -21,6 +22,7 @@ exports:
 - _upsert_steps
 - _upsert_heart_rate
 - _upsert_exercise
+- _resolve_target_user_id
 - main
 tags:
 - code
@@ -37,8 +39,15 @@ coverage_pct: 0.0
 
 ```python
 #!/usr/bin/env python3
-"""Generate ~30 days of realistic sample health data into Postgres (V2.1.2 SQLAlchemy)."""
+"""Generate ~30 days of realistic sample health data into Postgres (V2.1.2 SQLAlchemy).
 
+Usage:
+    python3 scripts/generate_sample.py [--user-email <email>]
+
+Default user_email: legacy@samsunghealth.local (créé par alembic 0004 backfill).
+"""
+
+import argparse
 import random
 import sys
 from datetime import datetime, timedelta, timezone
@@ -46,7 +55,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from sqlalchemy import text
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -57,7 +66,11 @@ from server.db.models import (
     SleepSession,
     SleepStage,
     StepsHourly,
+    User,
 )
+
+
+DEFAULT_LEGACY_EMAIL = "legacy@samsunghealth.local"
 
 
 STAGE_TYPES = ["light", "deep", "rem", "awake"]
@@ -94,7 +107,7 @@ def generate_stages(sleep_start: datetime, sleep_end: datetime) -> list[dict]:
     return stages
 
 
-def _upsert_steps(db: Session, base_date: datetime, num_days: int) -> int:  # base_date timezone-aware
+def _upsert_steps(db: Session, base_date: datetime, num_days: int, user_id: str) -> int:  # base_date timezone-aware
     inserted = 0
     for day_offset in range(num_days):
         date = base_date + timedelta(days=day_offset)
@@ -116,10 +129,9 @@ def _upsert_steps(db: Session, base_date: datetime, num_days: int) -> int:  # ba
                 steps = random.randint(20, 150)
             stmt = (
                 pg_insert(StepsHourly)
-                .values(date=date_str, hour=hour, step_count=steps)
+                .values(user_id=user_id, date=date_str, hour=hour, step_count=steps)
                 .on_conflict_do_nothing(
-                    index_elements=["date", "hour"],
-                    index_where=text("user_id IS NULL"),
+                    index_elements=["user_id", "date", "hour"],
                 )
                 .returning(StepsHourly.id)
             )
@@ -128,7 +140,7 @@ def _upsert_steps(db: Session, base_date: datetime, num_days: int) -> int:  # ba
     return inserted
 
 
-def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
+def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int, user_id: str) -> int:
     inserted = 0
     for day_offset in range(num_days):
         date = base_date + timedelta(days=day_offset)
@@ -149,6 +161,7 @@ def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
             stmt = (
                 pg_insert(HeartRateHourly)
                 .values(
+                    user_id=user_id,
                     date=date_str,
                     hour=hour,
                     min_bpm=min_bpm,
@@ -157,8 +170,7 @@ def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
                     sample_count=random.randint(5, 30),
                 )
                 .on_conflict_do_nothing(
-                    index_elements=["date", "hour"],
-                    index_where=text("user_id IS NULL"),
+                    index_elements=["user_id", "date", "hour"],
                 )
                 .returning(HeartRateHourly.id)
             )
@@ -167,7 +179,7 @@ def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
     return inserted
 
 
-def _upsert_exercise(db: Session, base_date: datetime, num_days: int) -> int:
+def _upsert_exercise(db: Session, base_date: datetime, num_days: int, user_id: str) -> int:
     inserted = 0
     num_sessions = random.randint(10, 15)
     used_days = random.sample(range(num_days), min(num_sessions, num_days))
@@ -182,14 +194,14 @@ def _upsert_exercise(db: Session, base_date: datetime, num_days: int) -> int:
         stmt = (
             pg_insert(ExerciseSession)
             .values(
+                user_id=user_id,
                 exercise_type=ex_type,
                 exercise_start=ex_start,
                 exercise_end=ex_end,
                 duration_minutes=float(duration),
             )
             .on_conflict_do_nothing(
-                index_elements=["exercise_start", "exercise_end"],
-                index_where=text("user_id IS NULL"),
+                index_elements=["user_id", "exercise_start", "exercise_end"],
             )
             .returning(ExerciseSession.id)
         )
@@ -198,10 +210,30 @@ def _upsert_exercise(db: Session, base_date: datetime, num_days: int) -> int:
     return inserted
 
 
+def _resolve_target_user_id(db: Session, email: str) -> str:
+    user = db.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if user is None:
+        raise SystemExit(
+            f"ERROR: user '{email}' introuvable. Crée-le via /auth/register "
+            f"(ou attends que la migration 0004 ait backfill le legacy user)."
+        )
+    return str(user.id)
+
+
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--user-email",
+        default=DEFAULT_LEGACY_EMAIL,
+        help=f"Email of the target user (default: {DEFAULT_LEGACY_EMAIL})",
+    )
+    args = parser.parse_args()
+
     # Seed déterministe : permet l'idempotence (2 runs = mêmes timestamps → ON CONFLICT skip)
     random.seed(42)
     db = get_session()
+    user_id = _resolve_target_user_id(db, args.user_email)
+    print(f"Target user: {args.user_email} ({user_id})")
     base_date = datetime(2026, 1, 15, tzinfo=timezone.utc)
     num_days = 30
 
@@ -235,10 +267,9 @@ def main():
         new_uuid = uuid7()
         stmt = (
             pg_insert(SleepSession)
-            .values(id=new_uuid, sleep_start=sleep_start, sleep_end=sleep_end)
+            .values(id=new_uuid, user_id=user_id, sleep_start=sleep_start, sleep_end=sleep_end)
             .on_conflict_do_nothing(
-                index_elements=["sleep_start", "sleep_end"],
-                index_where=text("user_id IS NULL"),
+                index_elements=["user_id", "sleep_start", "sleep_end"],
             )
             .returning(SleepSession.id)
         )
@@ -251,21 +282,21 @@ def main():
             stage_stmt = (
                 pg_insert(SleepStage)
                 .values(
+                    user_id=user_id,
                     session_id=session_id,
                     stage_type=st["stage_type"],
                     stage_start=st["start"],
                     stage_end=st["end"],
                 )
                 .on_conflict_do_nothing(
-                    index_elements=["stage_start", "stage_end"],
-                    index_where=text("user_id IS NULL"),
+                    index_elements=["user_id", "stage_start", "stage_end"],
                 )
             )
             db.execute(stage_stmt)
 
-    steps_inserted = _upsert_steps(db, base_date, num_days)
-    hr_inserted = _upsert_heart_rate(db, base_date, num_days)
-    ex_inserted = _upsert_exercise(db, base_date, num_days)
+    steps_inserted = _upsert_steps(db, base_date, num_days, user_id)
+    hr_inserted = _upsert_heart_rate(db, base_date, num_days, user_id)
+    ex_inserted = _upsert_exercise(db, base_date, num_days, user_id)
     db.commit()
 
     print("Inserted into Postgres :")
@@ -287,13 +318,15 @@ if __name__ == "__main__":
 - [[../../specs/2026-04-24-v2-csv-import-sqlalchemy]] — symbols: `main`, `generate_sleep_sessions`, `generate_steps_hourly`, `generate_heart_rate_hourly`, `generate_exercise_sessions`
 
 ### Symbols
-- `generate_stages` (function) — lines 29-56 · ⚠️ no test
-- `_upsert_steps` (function) — lines 59-90
-- `_upsert_heart_rate` (function) — lines 93-129
-- `_upsert_exercise` (function) — lines 132-160
-- `main` (function) — lines 163-237 · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `generate_stages` (function) — lines 40-67 · ⚠️ no test
+- `_upsert_steps` (function) — lines 70-100
+- `_upsert_heart_rate` (function) — lines 103-139
+- `_upsert_exercise` (function) — lines 142-170
+- `_resolve_target_user_id` (function) — lines 173-180
+- `main` (function) — lines 183-266 · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
 
 ### Imports
+- `argparse`
 - `random`
 - `sys`
 - `datetime`
@@ -309,4 +342,5 @@ if __name__ == "__main__":
 - `_upsert_steps`
 - `_upsert_heart_rate`
 - `_upsert_exercise`
+- `_resolve_target_user_id`
 - `main`

--- a/docs/vault/code/scripts/import_samsung_csv.md
+++ b/docs/vault/code/scripts/import_samsung_csv.md
@@ -2,11 +2,12 @@
 type: code-source
 language: python
 file_path: scripts/import_samsung_csv.py
-git_blob: 7cd534dc9b55b34d643f9431e992407ff0504765
-last_synced: '2026-04-26T16:48:27Z'
-loc: 672
+git_blob: 9a94e563514af3d1951cdc23a72a600bbe422132
+last_synced: '2026-04-26T18:27:44Z'
+loc: 709
 annotations: []
 imports:
+- argparse
 - csv
 - sys
 - collections
@@ -28,6 +29,7 @@ exports:
 - to_int
 - report
 - _upsert
+- _resolve_target_user_id
 - import_sleep
 - import_sleep_stages
 - import_steps_hourly
@@ -70,11 +72,13 @@ Import Samsung Health CSV export into Postgres (V2.1.2 SQLAlchemy refactor).
 Idempotent — toutes les insertions utilisent `ON CONFLICT DO NOTHING`.
 
 Usage:
-    python3 scripts/import_samsung_csv.py [export_dir]
+    python3 scripts/import_samsung_csv.py [export_dir] [--user-email <email>]
 
 Default export_dir: /mnt/c/Users/idsmf/Desktop/SamsungHealth
+Default user_email: legacy@samsunghealth.local (créé par alembic 0004 backfill)
 """
 
+import argparse
 import csv
 import sys
 from collections import defaultdict
@@ -107,12 +111,19 @@ from server.db.models import (
     StepsDaily,
     StepsHourly,
     Stress,
+    User,
     VitalityScore,
     WaterIntake,
     Weight,
 )
 
-EXPORT_DIR = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/mnt/c/Users/idsmf/Desktop/SamsungHealth")
+DEFAULT_LEGACY_EMAIL = "legacy@samsunghealth.local"
+DEFAULT_EXPORT_DIR = Path("/mnt/c/Users/idsmf/Desktop/SamsungHealth")
+
+# Réinjectés par main() via argparse, exposés en module-global pour ne pas
+# avoir à propager un user_id à chaque signature import_*(db).
+EXPORT_DIR: Path = DEFAULT_EXPORT_DIR
+TARGET_USER_ID: str | None = None
 
 # Samsung shealth CSV stage codes (different from Health Connect 1-4)
 SLEEP_STAGE_MAP = {40001: "awake", 40002: "light", 40003: "deep", 40004: "rem"}
@@ -196,23 +207,31 @@ def report(label: str, ins: int, skp: int) -> None:
 def _upsert(db: Session, model, values: dict, conflict_cols: list[str]) -> bool:
     """Insert via ON CONFLICT DO NOTHING. Returns True si insert effectif, False si skip.
 
-    V2.3 — legacy import scripts ne gèrent pas user_id (NULL). Les nouvelles unique
-    constraints sont sur (user_id, ...cols). On utilise donc un index partiel
-    (`uq_<table>_<...>` WHERE user_id IS NULL) créé en alembic 0004 — d'où le
-    `index_where=text("user_id IS NULL")` ajouté ici pour matcher l'arbiter.
+    V2.3.0.1 — l'unique constraint matche `(user_id, ...cols)` pour permettre
+    le multi-user. Le helper injecte `user_id=TARGET_USER_ID` côté serveur.
     """
-    from sqlalchemy import text
+    if TARGET_USER_ID is None:
+        raise RuntimeError("TARGET_USER_ID not initialized — call main() first")
 
     stmt = (
         pg_insert(model)
-        .values(**values)
+        .values(user_id=TARGET_USER_ID, **values)
         .on_conflict_do_nothing(
-            index_elements=conflict_cols,
-            index_where=text("user_id IS NULL"),
+            index_elements=["user_id", *conflict_cols],
         )
         .returning(model.id)
     )
     return db.execute(stmt).first() is not None
+
+
+def _resolve_target_user_id(db: Session, email: str) -> str:
+    user = db.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if user is None:
+        raise SystemExit(
+            f"ERROR: user '{email}' introuvable. Crée-le via /auth/register "
+            f"(ou attends que la migration 0004 ait backfill le legacy user)."
+        )
+    return str(user.id)
 
 
 # ── importers ────────────────────────────────────────────────────────────────
@@ -700,6 +719,24 @@ def import_ecg(db: Session) -> None:
 
 
 def main() -> None:
+    global EXPORT_DIR, TARGET_USER_ID
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "export_dir",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_EXPORT_DIR,
+        help=f"Samsung Health export directory (default: {DEFAULT_EXPORT_DIR})",
+    )
+    parser.add_argument(
+        "--user-email",
+        default=DEFAULT_LEGACY_EMAIL,
+        help=f"Email of the target user (default: {DEFAULT_LEGACY_EMAIL})",
+    )
+    args = parser.parse_args()
+    EXPORT_DIR = args.export_dir
+
     if not EXPORT_DIR.exists():
         print(f"ERROR: export dir not found: {EXPORT_DIR}", file=sys.stderr)
         sys.exit(1)
@@ -707,6 +744,8 @@ def main() -> None:
     print(f"Export: {EXPORT_DIR}")
     print("Importing into Postgres (alembic schema déjà appliqué via `make db-migrate`) …")
     db = get_session()
+    TARGET_USER_ID = _resolve_target_user_id(db, args.user_email)
+    print(f"Target user: {args.user_email} ({TARGET_USER_ID})")
 
     uuid_map = import_sleep(db)
     import_sleep_stages(db, uuid_map)
@@ -746,40 +785,42 @@ if __name__ == "__main__":
 - [[../../specs/2026-04-24-v2-csv-import-sqlalchemy]] — symbols: `main`, `import_sleep`, `import_sleep_stages`, `import_steps_hourly`, `import_steps_daily`, `import_heart_rate_hourly`, `import_exercise`, `import_stress`, `import_spo2`, `import_respiratory_rate`, `import_hrv`, `import_skin_temperature`, `import_weight`, `import_height`, `import_blood_pressure`, `import_mood`, `import_water_intake`, `import_activity_daily`, `import_vitality_score`, `import_floors_daily`, `import_activity_level`, `import_ecg`
 
 ### Symbols
-- `find_csv` (function) — lines 58-60 · ⚠️ no test
-- `read_csv` (function) — lines 63-71 · ⚠️ no test
-- `fv` (function) — lines 74-79 · ⚠️ no test
-- `parse_dt` (function) — lines 82-91 · ⚠️ no test
-- `ms_to_date_str` (function) — lines 94-101
-- `parse_day` (function) — lines 104-109
-- `to_float` (function) — lines 112-116 · ⚠️ no test
-- `to_int` (function) — lines 119-123 · ⚠️ no test
-- `report` (function) — lines 126-127 · ⚠️ no test
-- `_upsert` (function) — lines 130-149
-- `import_sleep` (function) — lines 155-185 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_sleep_stages` (function) — lines 188-222 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_steps_hourly` (function) — lines 225-240 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_steps_daily` (function) — lines 243-263 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_heart_rate_hourly` (function) — lines 266-290 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_exercise` (function) — lines 293-321 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_stress` (function) — lines 324-342 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_spo2` (function) — lines 345-367 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_respiratory_rate` (function) — lines 370-389 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_hrv` (function) — lines 392-404 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_skin_temperature` (function) — lines 407-427 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_weight` (function) — lines 430-451 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_height` (function) — lines 454-466 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_blood_pressure` (function) — lines 469-488 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_mood` (function) — lines 491-511 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_water_intake` (function) — lines 514-526 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_activity_daily` (function) — lines 529-550 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_vitality_score` (function) — lines 553-579 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_floors_daily` (function) — lines 582-593 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_activity_level` (function) — lines 596-607 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `import_ecg` (function) — lines 610-630 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
-- `main` (function) — lines 636-668 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `find_csv` (function) — lines 67-69 · ⚠️ no test
+- `read_csv` (function) — lines 72-80 · ⚠️ no test
+- `fv` (function) — lines 83-88 · ⚠️ no test
+- `parse_dt` (function) — lines 91-100 · ⚠️ no test
+- `ms_to_date_str` (function) — lines 103-110
+- `parse_day` (function) — lines 113-118
+- `to_float` (function) — lines 121-125 · ⚠️ no test
+- `to_int` (function) — lines 128-132 · ⚠️ no test
+- `report` (function) — lines 135-136 · ⚠️ no test
+- `_upsert` (function) — lines 139-156
+- `_resolve_target_user_id` (function) — lines 159-166
+- `import_sleep` (function) — lines 172-202 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_sleep_stages` (function) — lines 205-239 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_steps_hourly` (function) — lines 242-257 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_steps_daily` (function) — lines 260-280 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_heart_rate_hourly` (function) — lines 283-307 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_exercise` (function) — lines 310-338 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_stress` (function) — lines 341-359 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_spo2` (function) — lines 362-384 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_respiratory_rate` (function) — lines 387-406 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_hrv` (function) — lines 409-421 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_skin_temperature` (function) — lines 424-444 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_weight` (function) — lines 447-468 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_height` (function) — lines 471-483 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_blood_pressure` (function) — lines 486-505 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_mood` (function) — lines 508-528 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_water_intake` (function) — lines 531-543 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_activity_daily` (function) — lines 546-567 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_vitality_score` (function) — lines 570-596 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_floors_daily` (function) — lines 599-610 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_activity_level` (function) — lines 613-624 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `import_ecg` (function) — lines 627-647 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
+- `main` (function) — lines 653-705 · ⚠️ no test · **Specs**: [[../../specs/2026-04-24-v2-csv-import-sqlalchemy|2026-04-24-v2-csv-import-sqlalchemy]]
 
 ### Imports
+- `argparse`
 - `csv`
 - `sys`
 - `collections`
@@ -802,6 +843,7 @@ if __name__ == "__main__":
 - `to_int`
 - `report`
 - `_upsert`
+- `_resolve_target_user_id`
 - `import_sleep`
 - `import_sleep_stages`
 - `import_steps_hourly`

--- a/docs/vault/code/server/db/models.md
+++ b/docs/vault/code/server/db/models.md
@@ -2,8 +2,8 @@
 type: code-source
 language: python
 file_path: server/db/models.py
-git_blob: 4bb63fbd5f3040deffbf1cc166407db7538bb5f1
-last_synced: '2026-04-26T16:48:27Z'
+git_blob: 03ebaf9a7bfca035751c5c3ea6a0fb2b4571f2e5
+last_synced: '2026-04-26T18:27:45Z'
 loc: 555
 annotations: []
 imports:
@@ -115,8 +115,8 @@ class SleepSession(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_sleep_sessions_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     sleep_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     sleep_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -149,8 +149,8 @@ class SleepStage(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_sleep_stages_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     session_id: Mapped[UUID] = mapped_column(
         Uuid7(), ForeignKey("sleep_sessions.id", ondelete="CASCADE"), nullable=False
@@ -170,8 +170,8 @@ class StepsHourly(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_steps_hourly_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     date: Mapped[str] = mapped_column(String(10), nullable=False)
     hour: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -185,8 +185,8 @@ class StepsDaily(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_steps_daily_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     step_count: Mapped[int | None] = mapped_column(Integer)
@@ -205,8 +205,8 @@ class HeartRateHourly(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_heart_rate_hourly_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     date: Mapped[str] = mapped_column(String(10), nullable=False)
     hour: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -228,8 +228,8 @@ class ExerciseSession(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_exercise_sessions_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     exercise_type: Mapped[str] = mapped_column(String(64), nullable=False)
     exercise_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -252,8 +252,8 @@ class Stress(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_stress_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -271,8 +271,8 @@ class Spo2(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_spo2_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -295,8 +295,8 @@ class RespiratoryRate(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_respiratory_rate_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -316,8 +316,8 @@ class Hrv(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_hrv_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -330,8 +330,8 @@ class SkinTemperature(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_skin_temperature_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -353,8 +353,8 @@ class Weight(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_weight_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     # V2.2.1 — colonnes Art.9 chiffrées
@@ -381,8 +381,8 @@ class Height(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_height_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     height_cm: Mapped[float | None] = mapped_column(Float)
@@ -395,8 +395,8 @@ class BloodPressure(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_blood_pressure_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     # V2.2.1 — colonnes Art.9 chiffrées
@@ -417,8 +417,8 @@ class Mood(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_mood_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     # V2.2 — colonnes Art.9 chiffrées AES-256-GCM (BYTEA en DB, str/int en Python)
@@ -443,8 +443,8 @@ class WaterIntake(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_water_intake_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     amount_ml: Mapped[float | None] = mapped_column(Float)
@@ -458,8 +458,8 @@ class ActivityDaily(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_activity_daily_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     step_count: Mapped[int | None] = mapped_column(Integer)
@@ -478,8 +478,8 @@ class VitalityScore(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_vitality_score_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     total_score: Mapped[float | None] = mapped_column(Float)
@@ -503,8 +503,8 @@ class FloorsDaily(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_floors_daily_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     floor_count: Mapped[int | None] = mapped_column(Integer)
@@ -517,8 +517,8 @@ class ActivityLevel(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_activity_level_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     activity_level: Mapped[int | None] = mapped_column(Integer)
@@ -532,8 +532,8 @@ class Ecg(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_ecg_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/docs/vault/code/tests/server/conftest.md
+++ b/docs/vault/code/tests/server/conftest.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: tests/server/conftest.py
-git_blob: 1dc4923e211faf3797d4b05cafde7c930cee5471
-last_synced: '2026-04-26T16:48:28Z'
-loc: 207
+git_blob: 17fc28ebfc8c2c1de88c702c44a5a55e1de8e981
+last_synced: '2026-04-26T18:27:45Z'
+loc: 286
 annotations: []
 imports:
 - base64
@@ -12,6 +12,7 @@ imports:
 - secrets
 - pytest
 exports:
+- _ensure_orm_default_user
 - _register_default_user
 tags:
 - code
@@ -166,6 +167,85 @@ def schema_ready(pg_url):
     yield pg_url
 
 
+_ORM_DEFAULT_USER_EMAIL = "default-orm-user@samsunghealth.local"
+_ORM_DEFAULT_USER_HASH = "$argon2id$v=19$m=46080,t=2,p=1$ORMTESTUSERNOLOGINPOSSIBLE"
+
+
+def _ensure_orm_default_user(connection):
+    """Crée (ou récupère) le user par défaut pour les inserts ORM-only en test."""
+    from sqlalchemy import text
+
+    connection.execute(
+        text(
+            """
+            INSERT INTO users (id, email, password_hash, is_active, password_changed_at)
+            VALUES (gen_random_uuid(), :email, :hash, false, now())
+            ON CONFLICT (email) DO NOTHING
+            """
+        ),
+        {"email": _ORM_DEFAULT_USER_EMAIL, "hash": _ORM_DEFAULT_USER_HASH},
+    )
+    row = connection.execute(
+        text("SELECT id FROM users WHERE email = :email"),
+        {"email": _ORM_DEFAULT_USER_EMAIL},
+    ).fetchone()
+    return row[0]
+
+
+@pytest.fixture
+def default_user_db(db_session):
+    """V2.3.0.1 — user d'ancrage pour les tests ORM-only (sans booter le client HTTP).
+
+    Tous les inserts ORM de tables santé peuvent assigner `user_id=default_user_db.id`.
+    Le hook `_auto_inject_user_id_for_health_inserts` (autouse) fait l'injection
+    automatique pour les tests qui ne définissent pas `user_id`.
+    """
+    from sqlalchemy import select
+
+    from server.db.models import User
+
+    user_id = _ensure_orm_default_user(db_session.connection())
+    db_session.commit()
+    return db_session.execute(select(User).where(User.id == user_id)).scalar_one()
+
+
+@pytest.fixture(autouse=True)
+def _auto_inject_user_id_for_health_inserts(request):
+    """V2.3.0.1 — auto-injection user_id sur inserts ORM des tables santé.
+
+    Évite de patcher chaque test ORM-only qui ferait `db_session.add(SleepSession(...))`
+    sans user_id. Hook désactivé pour les tests qui ne touchent pas Postgres.
+    """
+    if "pg_container" not in request.fixturenames and "schema_ready" not in request.fixturenames:
+        yield
+        return
+
+    from sqlalchemy import event
+
+    try:
+        from server.db.models import Base
+    except ImportError:
+        yield
+        return
+
+    cached_user_id: list[str | None] = [None]
+
+    def _inject(mapper, connection, target):
+        if not hasattr(target, "user_id"):
+            return
+        if getattr(target, "user_id", None) is not None:
+            return
+        if "user_id" not in {c.name for c in mapper.columns}:
+            return
+        if cached_user_id[0] is None:
+            cached_user_id[0] = _ensure_orm_default_user(connection)
+        target.user_id = cached_user_id[0]
+
+    event.listen(Base, "before_insert", _inject, propagate=True)
+    yield
+    event.remove(Base, "before_insert", _inject)
+
+
 def _register_default_user(client) -> str | None:
     """V2.3 — register + login a default test user, return access_token (None on failure)."""
     email = "default-test-user@samsunghealth.local"
@@ -240,7 +320,8 @@ def client_pg(pg_url, engine):
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `_register_default_user` (function) — lines 141-155
+- `_ensure_orm_default_user` (function) — lines 145-163
+- `_register_default_user` (function) — lines 220-234
 
 ### Imports
 - `base64`
@@ -249,4 +330,5 @@ def client_pg(pg_url, engine):
 - `pytest`
 
 ### Exports
+- `_ensure_orm_default_user`
 - `_register_default_user`

--- a/docs/vault/code/tests/server/test_crypto_foundation.md
+++ b/docs/vault/code/tests/server/test_crypto_foundation.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: tests/server/test_crypto_foundation.py
-git_blob: dea8a32c87401116d49bb433f3be5b91345b3ac8
-last_synced: '2026-04-24T03:32:00Z'
-loc: 122
+git_blob: 3329ef2f1a8e44fc79cff41365f519abd9131e06
+last_synced: '2026-04-26T18:27:45Z'
+loc: 123
 annotations: []
 imports:
 - base64
@@ -116,13 +116,14 @@ class TestEncryptDecryptField:
 
 
 class TestEncryptedTypeDecorator:
-    def test_typedecorator_transparent_on_orm(self, schema_ready, db_session):
-        # spec V2.2 §9
+    def test_typedecorator_transparent_on_orm(self, schema_ready, db_session, default_user_db):
+        # spec V2.2 §9 — user_id obligatoire depuis V2.3.0.1
         from datetime import datetime, timezone
 
         from server.db.models import Mood
 
         m = Mood(
+            user_id=default_user_db.id,
             start_time=datetime(2026, 4, 24, 9, 30, tzinfo=timezone.utc),
             mood_type=3,
             notes="weekend cool",
@@ -162,8 +163,8 @@ class TestBootValidation:
 - `_b64` (function) — lines 14-15
 - `TestLoadEncryptionKey` (class) — lines 18-52
 - `TestEncryptDecryptField` (class) — lines 55-83
-- `TestEncryptedTypeDecorator` (class) — lines 86-111
-- `TestBootValidation` (class) — lines 114-122
+- `TestEncryptedTypeDecorator` (class) — lines 86-112
+- `TestBootValidation` (class) — lines 115-123
 
 ### Imports
 - `base64`

--- a/docs/vault/code/tests/server/test_scripts_csv_import.md
+++ b/docs/vault/code/tests/server/test_scripts_csv_import.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: tests/server/test_scripts_csv_import.py
-git_blob: e2d8b91d5a3cacc4e9b56a3d31db3bd1694fc1c9
-last_synced: '2026-04-24T02:52:13Z'
-loc: 153
+git_blob: 6f41d7490ad0a5cc7912d2fc88b99786a0e015c9
+last_synced: '2026-04-26T18:27:45Z'
+loc: 170
 annotations: []
 imports:
 - csv
@@ -70,10 +70,15 @@ def _write_sleep_csv(tmp_path: Path, rows: list[dict]) -> Path:
 
 
 @pytest.fixture
-def csv_export_dir(tmp_path, monkeypatch):
-    """Pointe le script import_samsung_csv vers tmp_path et reload le module."""
+def csv_export_dir(tmp_path, monkeypatch, db_session):
+    """Pointe le script import_samsung_csv vers tmp_path + injecte TARGET_USER_ID."""
     import scripts.import_samsung_csv as mod
+    from tests.server.conftest import _ensure_orm_default_user
+
     monkeypatch.setattr(mod, "EXPORT_DIR", tmp_path)
+    user_id = _ensure_orm_default_user(db_session.connection())
+    db_session.commit()
+    monkeypatch.setattr(mod, "TARGET_USER_ID", str(user_id))
     return tmp_path
 
 
@@ -154,8 +159,14 @@ class TestGenerateSample:
         from server.db.models import HeartRateHourly, SleepSession, StepsHourly
 
         # Override get_session du script pour pointer vers le testcontainer
+        import sys
         import scripts.generate_sample as mod
+        from tests.server.conftest import _ensure_orm_default_user, _ORM_DEFAULT_USER_EMAIL
+
+        _ensure_orm_default_user(db_session.connection())
+        db_session.commit()
         monkeypatch.setattr(mod, "get_session", lambda: db_session)
+        monkeypatch.setattr(sys, "argv", ["generate_sample.py", "--user-email", _ORM_DEFAULT_USER_EMAIL])
 
         mod.main()
 
@@ -171,8 +182,14 @@ class TestGenerateSample:
         # spec V2.1.2 §Tests d'acceptation #4
         from server.db.models import SleepSession
 
+        import sys
         import scripts.generate_sample as mod
+        from tests.server.conftest import _ensure_orm_default_user, _ORM_DEFAULT_USER_EMAIL
+
+        _ensure_orm_default_user(db_session.connection())
+        db_session.commit()
         monkeypatch.setattr(mod, "get_session", lambda: db_session)
+        monkeypatch.setattr(sys, "argv", ["generate_sample.py", "--user-email", _ORM_DEFAULT_USER_EMAIL])
 
         mod.main()
         count_first = len(db_session.execute(select(SleepSession)).scalars().all())
@@ -190,8 +207,8 @@ class TestGenerateSample:
 
 ### Symbols
 - `_write_sleep_csv` (function) — lines 29-38
-- `TestImportSamsungCsv` (class) — lines 49-117
-- `TestGenerateSample` (class) — lines 120-153
+- `TestImportSamsungCsv` (class) — lines 54-122
+- `TestGenerateSample` (class) — lines 125-170
 
 ### Imports
 - `csv`

--- a/scripts/generate_sample.py
+++ b/scripts/generate_sample.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python3
-"""Generate ~30 days of realistic sample health data into Postgres (V2.1.2 SQLAlchemy)."""
+"""Generate ~30 days of realistic sample health data into Postgres (V2.1.2 SQLAlchemy).
 
+Usage:
+    python3 scripts/generate_sample.py [--user-email <email>]
+
+Default user_email: legacy@samsunghealth.local (créé par alembic 0004 backfill).
+"""
+
+import argparse
 import random
 import sys
 from datetime import datetime, timedelta, timezone
@@ -8,7 +15,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from sqlalchemy import text
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -19,7 +26,11 @@ from server.db.models import (
     SleepSession,
     SleepStage,
     StepsHourly,
+    User,
 )
+
+
+DEFAULT_LEGACY_EMAIL = "legacy@samsunghealth.local"
 
 
 STAGE_TYPES = ["light", "deep", "rem", "awake"]
@@ -56,7 +67,7 @@ def generate_stages(sleep_start: datetime, sleep_end: datetime) -> list[dict]:
     return stages
 
 
-def _upsert_steps(db: Session, base_date: datetime, num_days: int) -> int:  # base_date timezone-aware
+def _upsert_steps(db: Session, base_date: datetime, num_days: int, user_id: str) -> int:  # base_date timezone-aware
     inserted = 0
     for day_offset in range(num_days):
         date = base_date + timedelta(days=day_offset)
@@ -78,10 +89,9 @@ def _upsert_steps(db: Session, base_date: datetime, num_days: int) -> int:  # ba
                 steps = random.randint(20, 150)
             stmt = (
                 pg_insert(StepsHourly)
-                .values(date=date_str, hour=hour, step_count=steps)
+                .values(user_id=user_id, date=date_str, hour=hour, step_count=steps)
                 .on_conflict_do_nothing(
-                    index_elements=["date", "hour"],
-                    index_where=text("user_id IS NULL"),
+                    index_elements=["user_id", "date", "hour"],
                 )
                 .returning(StepsHourly.id)
             )
@@ -90,7 +100,7 @@ def _upsert_steps(db: Session, base_date: datetime, num_days: int) -> int:  # ba
     return inserted
 
 
-def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
+def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int, user_id: str) -> int:
     inserted = 0
     for day_offset in range(num_days):
         date = base_date + timedelta(days=day_offset)
@@ -111,6 +121,7 @@ def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
             stmt = (
                 pg_insert(HeartRateHourly)
                 .values(
+                    user_id=user_id,
                     date=date_str,
                     hour=hour,
                     min_bpm=min_bpm,
@@ -119,8 +130,7 @@ def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
                     sample_count=random.randint(5, 30),
                 )
                 .on_conflict_do_nothing(
-                    index_elements=["date", "hour"],
-                    index_where=text("user_id IS NULL"),
+                    index_elements=["user_id", "date", "hour"],
                 )
                 .returning(HeartRateHourly.id)
             )
@@ -129,7 +139,7 @@ def _upsert_heart_rate(db: Session, base_date: datetime, num_days: int) -> int:
     return inserted
 
 
-def _upsert_exercise(db: Session, base_date: datetime, num_days: int) -> int:
+def _upsert_exercise(db: Session, base_date: datetime, num_days: int, user_id: str) -> int:
     inserted = 0
     num_sessions = random.randint(10, 15)
     used_days = random.sample(range(num_days), min(num_sessions, num_days))
@@ -144,14 +154,14 @@ def _upsert_exercise(db: Session, base_date: datetime, num_days: int) -> int:
         stmt = (
             pg_insert(ExerciseSession)
             .values(
+                user_id=user_id,
                 exercise_type=ex_type,
                 exercise_start=ex_start,
                 exercise_end=ex_end,
                 duration_minutes=float(duration),
             )
             .on_conflict_do_nothing(
-                index_elements=["exercise_start", "exercise_end"],
-                index_where=text("user_id IS NULL"),
+                index_elements=["user_id", "exercise_start", "exercise_end"],
             )
             .returning(ExerciseSession.id)
         )
@@ -160,10 +170,30 @@ def _upsert_exercise(db: Session, base_date: datetime, num_days: int) -> int:
     return inserted
 
 
+def _resolve_target_user_id(db: Session, email: str) -> str:
+    user = db.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if user is None:
+        raise SystemExit(
+            f"ERROR: user '{email}' introuvable. Crée-le via /auth/register "
+            f"(ou attends que la migration 0004 ait backfill le legacy user)."
+        )
+    return str(user.id)
+
+
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--user-email",
+        default=DEFAULT_LEGACY_EMAIL,
+        help=f"Email of the target user (default: {DEFAULT_LEGACY_EMAIL})",
+    )
+    args = parser.parse_args()
+
     # Seed déterministe : permet l'idempotence (2 runs = mêmes timestamps → ON CONFLICT skip)
     random.seed(42)
     db = get_session()
+    user_id = _resolve_target_user_id(db, args.user_email)
+    print(f"Target user: {args.user_email} ({user_id})")
     base_date = datetime(2026, 1, 15, tzinfo=timezone.utc)
     num_days = 30
 
@@ -197,10 +227,9 @@ def main():
         new_uuid = uuid7()
         stmt = (
             pg_insert(SleepSession)
-            .values(id=new_uuid, sleep_start=sleep_start, sleep_end=sleep_end)
+            .values(id=new_uuid, user_id=user_id, sleep_start=sleep_start, sleep_end=sleep_end)
             .on_conflict_do_nothing(
-                index_elements=["sleep_start", "sleep_end"],
-                index_where=text("user_id IS NULL"),
+                index_elements=["user_id", "sleep_start", "sleep_end"],
             )
             .returning(SleepSession.id)
         )
@@ -213,21 +242,21 @@ def main():
             stage_stmt = (
                 pg_insert(SleepStage)
                 .values(
+                    user_id=user_id,
                     session_id=session_id,
                     stage_type=st["stage_type"],
                     stage_start=st["start"],
                     stage_end=st["end"],
                 )
                 .on_conflict_do_nothing(
-                    index_elements=["stage_start", "stage_end"],
-                    index_where=text("user_id IS NULL"),
+                    index_elements=["user_id", "stage_start", "stage_end"],
                 )
             )
             db.execute(stage_stmt)
 
-    steps_inserted = _upsert_steps(db, base_date, num_days)
-    hr_inserted = _upsert_heart_rate(db, base_date, num_days)
-    ex_inserted = _upsert_exercise(db, base_date, num_days)
+    steps_inserted = _upsert_steps(db, base_date, num_days, user_id)
+    hr_inserted = _upsert_heart_rate(db, base_date, num_days, user_id)
+    ex_inserted = _upsert_exercise(db, base_date, num_days, user_id)
     db.commit()
 
     print("Inserted into Postgres :")

--- a/scripts/import_samsung_csv.py
+++ b/scripts/import_samsung_csv.py
@@ -4,11 +4,13 @@ Import Samsung Health CSV export into Postgres (V2.1.2 SQLAlchemy refactor).
 Idempotent — toutes les insertions utilisent `ON CONFLICT DO NOTHING`.
 
 Usage:
-    python3 scripts/import_samsung_csv.py [export_dir]
+    python3 scripts/import_samsung_csv.py [export_dir] [--user-email <email>]
 
 Default export_dir: /mnt/c/Users/idsmf/Desktop/SamsungHealth
+Default user_email: legacy@samsunghealth.local (créé par alembic 0004 backfill)
 """
 
+import argparse
 import csv
 import sys
 from collections import defaultdict
@@ -41,12 +43,19 @@ from server.db.models import (
     StepsDaily,
     StepsHourly,
     Stress,
+    User,
     VitalityScore,
     WaterIntake,
     Weight,
 )
 
-EXPORT_DIR = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("/mnt/c/Users/idsmf/Desktop/SamsungHealth")
+DEFAULT_LEGACY_EMAIL = "legacy@samsunghealth.local"
+DEFAULT_EXPORT_DIR = Path("/mnt/c/Users/idsmf/Desktop/SamsungHealth")
+
+# Réinjectés par main() via argparse, exposés en module-global pour ne pas
+# avoir à propager un user_id à chaque signature import_*(db).
+EXPORT_DIR: Path = DEFAULT_EXPORT_DIR
+TARGET_USER_ID: str | None = None
 
 # Samsung shealth CSV stage codes (different from Health Connect 1-4)
 SLEEP_STAGE_MAP = {40001: "awake", 40002: "light", 40003: "deep", 40004: "rem"}
@@ -130,23 +139,31 @@ def report(label: str, ins: int, skp: int) -> None:
 def _upsert(db: Session, model, values: dict, conflict_cols: list[str]) -> bool:
     """Insert via ON CONFLICT DO NOTHING. Returns True si insert effectif, False si skip.
 
-    V2.3 — legacy import scripts ne gèrent pas user_id (NULL). Les nouvelles unique
-    constraints sont sur (user_id, ...cols). On utilise donc un index partiel
-    (`uq_<table>_<...>` WHERE user_id IS NULL) créé en alembic 0004 — d'où le
-    `index_where=text("user_id IS NULL")` ajouté ici pour matcher l'arbiter.
+    V2.3.0.1 — l'unique constraint matche `(user_id, ...cols)` pour permettre
+    le multi-user. Le helper injecte `user_id=TARGET_USER_ID` côté serveur.
     """
-    from sqlalchemy import text
+    if TARGET_USER_ID is None:
+        raise RuntimeError("TARGET_USER_ID not initialized — call main() first")
 
     stmt = (
         pg_insert(model)
-        .values(**values)
+        .values(user_id=TARGET_USER_ID, **values)
         .on_conflict_do_nothing(
-            index_elements=conflict_cols,
-            index_where=text("user_id IS NULL"),
+            index_elements=["user_id", *conflict_cols],
         )
         .returning(model.id)
     )
     return db.execute(stmt).first() is not None
+
+
+def _resolve_target_user_id(db: Session, email: str) -> str:
+    user = db.execute(select(User).where(User.email == email)).scalar_one_or_none()
+    if user is None:
+        raise SystemExit(
+            f"ERROR: user '{email}' introuvable. Crée-le via /auth/register "
+            f"(ou attends que la migration 0004 ait backfill le legacy user)."
+        )
+    return str(user.id)
 
 
 # ── importers ────────────────────────────────────────────────────────────────
@@ -634,6 +651,24 @@ def import_ecg(db: Session) -> None:
 
 
 def main() -> None:
+    global EXPORT_DIR, TARGET_USER_ID
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "export_dir",
+        nargs="?",
+        type=Path,
+        default=DEFAULT_EXPORT_DIR,
+        help=f"Samsung Health export directory (default: {DEFAULT_EXPORT_DIR})",
+    )
+    parser.add_argument(
+        "--user-email",
+        default=DEFAULT_LEGACY_EMAIL,
+        help=f"Email of the target user (default: {DEFAULT_LEGACY_EMAIL})",
+    )
+    args = parser.parse_args()
+    EXPORT_DIR = args.export_dir
+
     if not EXPORT_DIR.exists():
         print(f"ERROR: export dir not found: {EXPORT_DIR}", file=sys.stderr)
         sys.exit(1)
@@ -641,6 +676,8 @@ def main() -> None:
     print(f"Export: {EXPORT_DIR}")
     print("Importing into Postgres (alembic schema déjà appliqué via `make db-migrate`) …")
     db = get_session()
+    TARGET_USER_ID = _resolve_target_user_id(db, args.user_email)
+    print(f"Target user: {args.user_email} ({TARGET_USER_ID})")
 
     uuid_map = import_sleep(db)
     import_sleep_stages(db, uuid_map)

--- a/server/db/models.py
+++ b/server/db/models.py
@@ -58,8 +58,8 @@ class SleepSession(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_sleep_sessions_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     sleep_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     sleep_end: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -92,8 +92,8 @@ class SleepStage(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_sleep_stages_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     session_id: Mapped[UUID] = mapped_column(
         Uuid7(), ForeignKey("sleep_sessions.id", ondelete="CASCADE"), nullable=False
@@ -113,8 +113,8 @@ class StepsHourly(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_steps_hourly_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     date: Mapped[str] = mapped_column(String(10), nullable=False)
     hour: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -128,8 +128,8 @@ class StepsDaily(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_steps_daily_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     step_count: Mapped[int | None] = mapped_column(Integer)
@@ -148,8 +148,8 @@ class HeartRateHourly(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_heart_rate_hourly_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     date: Mapped[str] = mapped_column(String(10), nullable=False)
     hour: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -171,8 +171,8 @@ class ExerciseSession(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_exercise_sessions_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     exercise_type: Mapped[str] = mapped_column(String(64), nullable=False)
     exercise_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -195,8 +195,8 @@ class Stress(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_stress_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -214,8 +214,8 @@ class Spo2(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_spo2_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -238,8 +238,8 @@ class RespiratoryRate(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_respiratory_rate_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -259,8 +259,8 @@ class Hrv(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_hrv_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -273,8 +273,8 @@ class SkinTemperature(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_skin_temperature_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
@@ -296,8 +296,8 @@ class Weight(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_weight_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     # V2.2.1 — colonnes Art.9 chiffrées
@@ -324,8 +324,8 @@ class Height(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_height_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     height_cm: Mapped[float | None] = mapped_column(Float)
@@ -338,8 +338,8 @@ class BloodPressure(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_blood_pressure_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     # V2.2.1 — colonnes Art.9 chiffrées
@@ -360,8 +360,8 @@ class Mood(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_mood_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     # V2.2 — colonnes Art.9 chiffrées AES-256-GCM (BYTEA en DB, str/int en Python)
@@ -386,8 +386,8 @@ class WaterIntake(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_water_intake_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     amount_ml: Mapped[float | None] = mapped_column(Float)
@@ -401,8 +401,8 @@ class ActivityDaily(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_activity_daily_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     step_count: Mapped[int | None] = mapped_column(Integer)
@@ -421,8 +421,8 @@ class VitalityScore(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_vitality_score_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     total_score: Mapped[float | None] = mapped_column(Float)
@@ -446,8 +446,8 @@ class FloorsDaily(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_floors_daily_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     day_date: Mapped[str] = mapped_column(String(10), nullable=False)
     floor_count: Mapped[int | None] = mapped_column(Integer)
@@ -460,8 +460,8 @@ class ActivityLevel(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_activity_level_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     activity_level: Mapped[int | None] = mapped_column(Integer)
@@ -475,8 +475,8 @@ class Ecg(Uuid7PkMixin, TimestampedMixin, Base):
         Index("idx_ecg_user_id", "user_id"),
     )
 
-    user_id: Mapped[UUID | None] = mapped_column(
-        Uuid7(), ForeignKey("users.id"), nullable=True
+    user_id: Mapped[UUID] = mapped_column(
+        Uuid7(), ForeignKey("users.id"), nullable=False
     )
     start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     end_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -138,6 +138,85 @@ def schema_ready(pg_url):
     yield pg_url
 
 
+_ORM_DEFAULT_USER_EMAIL = "default-orm-user@samsunghealth.local"
+_ORM_DEFAULT_USER_HASH = "$argon2id$v=19$m=46080,t=2,p=1$ORMTESTUSERNOLOGINPOSSIBLE"
+
+
+def _ensure_orm_default_user(connection):
+    """Crée (ou récupère) le user par défaut pour les inserts ORM-only en test."""
+    from sqlalchemy import text
+
+    connection.execute(
+        text(
+            """
+            INSERT INTO users (id, email, password_hash, is_active, password_changed_at)
+            VALUES (gen_random_uuid(), :email, :hash, false, now())
+            ON CONFLICT (email) DO NOTHING
+            """
+        ),
+        {"email": _ORM_DEFAULT_USER_EMAIL, "hash": _ORM_DEFAULT_USER_HASH},
+    )
+    row = connection.execute(
+        text("SELECT id FROM users WHERE email = :email"),
+        {"email": _ORM_DEFAULT_USER_EMAIL},
+    ).fetchone()
+    return row[0]
+
+
+@pytest.fixture
+def default_user_db(db_session):
+    """V2.3.0.1 — user d'ancrage pour les tests ORM-only (sans booter le client HTTP).
+
+    Tous les inserts ORM de tables santé peuvent assigner `user_id=default_user_db.id`.
+    Le hook `_auto_inject_user_id_for_health_inserts` (autouse) fait l'injection
+    automatique pour les tests qui ne définissent pas `user_id`.
+    """
+    from sqlalchemy import select
+
+    from server.db.models import User
+
+    user_id = _ensure_orm_default_user(db_session.connection())
+    db_session.commit()
+    return db_session.execute(select(User).where(User.id == user_id)).scalar_one()
+
+
+@pytest.fixture(autouse=True)
+def _auto_inject_user_id_for_health_inserts(request):
+    """V2.3.0.1 — auto-injection user_id sur inserts ORM des tables santé.
+
+    Évite de patcher chaque test ORM-only qui ferait `db_session.add(SleepSession(...))`
+    sans user_id. Hook désactivé pour les tests qui ne touchent pas Postgres.
+    """
+    if "pg_container" not in request.fixturenames and "schema_ready" not in request.fixturenames:
+        yield
+        return
+
+    from sqlalchemy import event
+
+    try:
+        from server.db.models import Base
+    except ImportError:
+        yield
+        return
+
+    cached_user_id: list[str | None] = [None]
+
+    def _inject(mapper, connection, target):
+        if not hasattr(target, "user_id"):
+            return
+        if getattr(target, "user_id", None) is not None:
+            return
+        if "user_id" not in {c.name for c in mapper.columns}:
+            return
+        if cached_user_id[0] is None:
+            cached_user_id[0] = _ensure_orm_default_user(connection)
+        target.user_id = cached_user_id[0]
+
+    event.listen(Base, "before_insert", _inject, propagate=True)
+    yield
+    event.remove(Base, "before_insert", _inject)
+
+
 def _register_default_user(client) -> str | None:
     """V2.3 — register + login a default test user, return access_token (None on failure)."""
     email = "default-test-user@samsunghealth.local"

--- a/tests/server/test_crypto_foundation.py
+++ b/tests/server/test_crypto_foundation.py
@@ -84,13 +84,14 @@ class TestEncryptDecryptField:
 
 
 class TestEncryptedTypeDecorator:
-    def test_typedecorator_transparent_on_orm(self, schema_ready, db_session):
-        # spec V2.2 §9
+    def test_typedecorator_transparent_on_orm(self, schema_ready, db_session, default_user_db):
+        # spec V2.2 §9 — user_id obligatoire depuis V2.3.0.1
         from datetime import datetime, timezone
 
         from server.db.models import Mood
 
         m = Mood(
+            user_id=default_user_db.id,
             start_time=datetime(2026, 4, 24, 9, 30, tzinfo=timezone.utc),
             mood_type=3,
             notes="weekend cool",

--- a/tests/server/test_scripts_csv_import.py
+++ b/tests/server/test_scripts_csv_import.py
@@ -39,10 +39,15 @@ def _write_sleep_csv(tmp_path: Path, rows: list[dict]) -> Path:
 
 
 @pytest.fixture
-def csv_export_dir(tmp_path, monkeypatch):
-    """Pointe le script import_samsung_csv vers tmp_path et reload le module."""
+def csv_export_dir(tmp_path, monkeypatch, db_session):
+    """Pointe le script import_samsung_csv vers tmp_path + injecte TARGET_USER_ID."""
     import scripts.import_samsung_csv as mod
+    from tests.server.conftest import _ensure_orm_default_user
+
     monkeypatch.setattr(mod, "EXPORT_DIR", tmp_path)
+    user_id = _ensure_orm_default_user(db_session.connection())
+    db_session.commit()
+    monkeypatch.setattr(mod, "TARGET_USER_ID", str(user_id))
     return tmp_path
 
 
@@ -123,8 +128,14 @@ class TestGenerateSample:
         from server.db.models import HeartRateHourly, SleepSession, StepsHourly
 
         # Override get_session du script pour pointer vers le testcontainer
+        import sys
         import scripts.generate_sample as mod
+        from tests.server.conftest import _ensure_orm_default_user, _ORM_DEFAULT_USER_EMAIL
+
+        _ensure_orm_default_user(db_session.connection())
+        db_session.commit()
         monkeypatch.setattr(mod, "get_session", lambda: db_session)
+        monkeypatch.setattr(sys, "argv", ["generate_sample.py", "--user-email", _ORM_DEFAULT_USER_EMAIL])
 
         mod.main()
 
@@ -140,8 +151,14 @@ class TestGenerateSample:
         # spec V2.1.2 §Tests d'acceptation #4
         from server.db.models import SleepSession
 
+        import sys
         import scripts.generate_sample as mod
+        from tests.server.conftest import _ensure_orm_default_user, _ORM_DEFAULT_USER_EMAIL
+
+        _ensure_orm_default_user(db_session.connection())
+        db_session.commit()
         monkeypatch.setattr(mod, "get_session", lambda: db_session)
+        monkeypatch.setattr(sys, "argv", ["generate_sample.py", "--user-email", _ORM_DEFAULT_USER_EMAIL])
 
         mod.main()
         count_first = len(db_session.execute(select(SleepSession)).scalars().all())


### PR DESCRIPTION
## Summary

Suite naturelle de V2.3 (PR #14). Ferme la fenêtre de tolérance NULL sur les 21 tables santé après backfill du legacy user.

- **alembic 0005** (`8c1d2e4f5a90`) — safety check (raise si rows orphelines détectées), `ALTER COLUMN user_id SET NOT NULL` sur 21 tables, drop des index partiels `WHERE user_id IS NULL`. Downgrade restaure l'état nullable + index partiel.
- **modèles SQLAlchemy** — 21 occurrences `Mapped[UUID | None]` → `Mapped[UUID]` + `nullable=False`. RefreshToken déjà NOT NULL, AuthEvent reste nullable (login_failure).
- **scripts CSV** — argparse `--user-email` (default `legacy@samsunghealth.local`), helper `_resolve_target_user_id`, injection serveur de `user_id` dans tous les `.values()`, drop des `index_where=text("user_id IS NULL")`. L'unique constraint matchée est désormais `(user_id, ...cols)`.
- **fix bug downgrade 0004** — l'upgrade créait des INDEX partiels mais le downgrade tentait `op.drop_constraint` (KO). Remplacé par `op.execute("DROP INDEX IF EXISTS ...")` + drop du nouveau `uq_<table>_user_window`. Bug pré-existant révélé par le downgrade chain 0005→0004.
- **conftest** — fixture `default_user_db` + autouse hook `_auto_inject_user_id_for_health_inserts` (event `before_insert` SQLAlchemy injecte un user_id par défaut si absent → évite de patcher 30+ inserts ORM dans les tests existants).

## Test plan

- [x] `alembic upgrade head` (0003 → 0004 → 0005) sur Postgres dev
- [x] `alembic downgrade -1` (0005 → 0004) — restaure nullable
- [x] Insert d'une row orpheline + retry upgrade → safety check raise avec détail (`sleep_sessions=1`)
- [x] Cleanup orphan + re-upgrade → OK
- [x] `pytest tests/server/` → 123 passed
- [x] Vérification structure : `\d sleep_sessions` montre `user_id uuid not null`
- [x] Test `test_alembic_downgrade_reverses` passe (régression fix downgrade 0004)

## Suite

V2.3.1 (reset password + email verification) ou V2.3.2 (Google OAuth) ou V2.3.3 (rate-limit + frontend Nightfall login form avec rebrand Data Saillance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)