### PR TITLE
fix(deploy): move sed IMAGE_TAG before docker compose up -d

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -111,8 +111,8 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
-          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
+          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
           EOF
 
       - name: Smoke test (loop, 60s max)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -88,8 +88,8 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml run --rm web alembic upgrade head
-          docker compose -f docker-compose.prod.yml up -d web
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" .env.prod
+          docker compose -f docker-compose.prod.yml up -d web
           EOF
 
       - name: Smoke test (loop — R-M2, pas single-shot)


### PR DESCRIPTION
## Ce qui change

- `sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/"` déplacé **avant** `docker compose up -d web` dans `deploy-dev.yml` et `deploy-prod.yml`

## Pourquoi

Avec `set -euo pipefail`, si `up -d web` échoue (IMAGE_TAG=REPLACE_ME dans .env.prod), le script s'arrête avant le `sed` — le placeholder n'est jamais remplacé. Au prochain run, compose relit .env.prod avec REPLACE_ME → boucle infinie d'échec.

Fix : écrire la bonne valeur d'IMAGE_TAG dans .env.prod **avant** de lancer le container.