### PR TITLE
fix(deploy): write IMAGE_TAG to .env.prod before docker compose commands

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,8 +94,9 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << EOF
           set -euo pipefail
           cd /srv/samsunghealth-dev
-          export IMAGE_TAG="$IMAGE_TAG"
-          docker compose -f docker-compose.prod.yml pull web
+          # Write IMAGE_TAG first — --env-file .env.prod overrides shell env in compose interpolation
+          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
+          docker compose -f docker-compose.prod.yml --env-file .env.prod pull web
           # Use run --rm (not exec) — works even if web container not yet started
           CURRENT=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print \$1}')
           EXPECTED=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic heads 2>/dev/null | awk 'NR==1{print \$1}')
@@ -111,7 +112,6 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
-          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
           docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
           EOF
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -111,8 +111,8 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
-          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
+          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
           EOF
 
       - name: Smoke test (loop, 60s max)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -73,8 +73,8 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_PROD_HOST }}" bash << EOF
           set -euo pipefail
           cd /srv/samsunghealth-prod
-          export IMAGE_TAG="$TAG"
-          docker compose -f docker-compose.prod.yml pull web
+          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" .env.prod
+          docker compose -f docker-compose.prod.yml --env-file .env.prod pull web
           CURRENT=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print \$1}')
           EXPECTED=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic heads 2>/dev/null | awk 'NR==1{print \$1}')
           if [ -z "\$EXPECTED" ]; then
@@ -87,9 +87,8 @@ jobs:
             echo "::error::Alembic drift — current=\$CURRENT expected=\$EXPECTED"
             exit 1
           fi
-          docker compose -f docker-compose.prod.yml run --rm web alembic upgrade head
-          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" .env.prod
-          docker compose -f docker-compose.prod.yml up -d web
+          docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
+          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
           EOF
 
       - name: Smoke test (loop — R-M2, pas single-shot)

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -88,8 +88,8 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml run --rm web alembic upgrade head
-          docker compose -f docker-compose.prod.yml up -d web
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" .env.prod
+          docker compose -f docker-compose.prod.yml up -d web
           EOF
 
       - name: Smoke test (loop — R-M2, pas single-shot)


### PR DESCRIPTION
## Problème

`--env-file .env.prod` prend le dessus sur les variables shell pour l'interpolation du compose file. L'`export IMAGE_TAG` dans le heredoc SSH était donc ignoré — docker compose utilisait `REPLACE_ME_WITH_DEV_OR_PROD_SHA_TAG` de `.env.prod`, l'image ne pouvait pas être pullée, les commandes alembic échouaient silencieusement, et le container web n'était jamais créé.

## Fix

Écrire `sed -i IMAGE_TAG` dans `.env.prod` **en premier** dans le script deploy, avant tout appel `docker compose`. Tous les appels suivants utilisent `--env-file .env.prod` avec le bon tag.

Vérifié manuellement sur le VPS : migrations OK (9 versions), `healthz OK`.