### PR TITLE
fix(deploy): remove hardcoded exit 1 after smoke test SSH

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -129,8 +129,6 @@ jobs:
           echo "smoke test failed after 60s"
           exit 1
           EOF
-          echo "::error::smoke test failed after 60s"
-          exit 1
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -105,8 +105,6 @@ jobs:
           echo "smoke test failed after 60s"
           exit 1
           EOF
-          echo "::error::prod smoke failed"
-          exit 1
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'


### PR DESCRIPTION
## Problème

Le `exit 1` hardcodé après la heredoc SSH du smoke test s'exécute **même quand SSH exit 0** (curl a réussi). Résultat : le smoke test échoue toujours, même avec l'app qui répond correctement.

Avec `set -e` (GitHub Actions default), quand SSH exit 0 → bash continue → `exit 1` → step fails.

## Fix

Supprimer le `echo "::error::"` et `exit 1` après la heredoc. L'exit code de SSH se propage directement via `set -e` du runner.

Vérifié : l'app répond 200 sur `/healthz`, les logs uvicorn confirment les requêtes curl.