### PR TITLE
chore(deploy): smoke test HTTPS via sh.datasaillance.fr

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -118,9 +118,8 @@ jobs:
       - name: Smoke test (loop, 60s max)
         id: smoke
         run: |
-          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << 'EOF'
           for i in $(seq 1 30); do
-            if curl -fs http://localhost:8001/healthz; then
+            if curl -fs https://sh.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi
@@ -128,7 +127,6 @@ jobs:
           done
           echo "smoke test failed after 60s"
           exit 1
-          EOF
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'


### PR DESCRIPTION
## Ce qui change

- Smoke test dev : curl direct depuis le runner GitHub sur `https://sh.datasaillance.fr/healthz` au lieu de SSH → localhost:8001
- Caddy installé sur le VPS, Caddyfile configuré, TLS Let's Encrypt actif

Vérifié manuellement : `curl https://sh.datasaillance.fr/healthz` → `{"status":"ok"}`