### PR TITLE
release: Caddy HTTPS + smoke test sh.datasaillance.fr

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -118,9 +118,8 @@ jobs:
       - name: Smoke test (loop, 60s max)
         id: smoke
         run: |
-          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << 'EOF'
           for i in $(seq 1 30); do
-            if curl -fs http://localhost:8001/healthz; then
+            if curl -fs https://sh.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi
@@ -128,7 +127,6 @@ jobs:
           done
           echo "smoke test failed after 60s"
           exit 1
-          EOF
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'


### PR DESCRIPTION
## Ce qui entre en prod

- **#42** \`chore(deploy)\` — smoke test HTTPS depuis le runner GitHub sur \`https://sh.datasaillance.fr/healthz\` (Caddy reverse proxy, TLS Let's Encrypt)

## Infra VPS (hors workflow)

- Caddy installé, Caddyfile : \`sh.datasaillance.fr → localhost:8001\`
- DNS \`A sh.datasaillance.fr → 51.38.190.100\` (Cloudflare, DNS only)
- UFW ports 80/443 déjà ouverts

## Migrations Alembic

Aucune.

## Checklist déploiement
- [ ] CI verte
- [ ] Merge → main
- [ ] Deploy dev auto — smoke test HTTPS doit passer vert