### PR TITLE
chore(prod): WEB_PORT configurable + smoke test HTTPS

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -119,7 +119,7 @@ jobs:
         id: smoke
         run: |
           for i in $(seq 1 30); do
-            if curl -fs https://sh.datasaillance.fr/healthz; then
+            if curl -fs https://sh-dev.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -94,9 +94,8 @@ jobs:
       - name: Smoke test (loop — R-M2, pas single-shot)
         id: smoke
         run: |
-          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_PROD_HOST }}" bash << 'EOF'
           for i in $(seq 1 30); do
-            if curl -fs http://localhost:8001/healthz; then
+            if curl -fs https://sh-prod.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi
@@ -104,7 +103,6 @@ jobs:
           done
           echo "smoke test failed after 60s"
           exit 1
-          EOF
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8001:8001"
+      - "${WEB_PORT:-8001}:8001"
     restart: unless-stopped
     healthcheck:
       # urllib stdlib — pas de curl dans python:3.12-slim (R-L5)


### PR DESCRIPTION
- `docker-compose.prod.yml` : port `${WEB_PORT:-8001}:8001` — prod tourne sur 8002 sans conflit avec dev (8001)
- `deploy-prod.yml` : smoke test HTTPS direct depuis le runner sur `https://sh-prod.datasaillance.fr/healthz`