### PR TITLE
release: prod deploy setup + HTTPS smoke tests

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -118,9 +118,8 @@ jobs:
       - name: Smoke test (loop, 60s max)
         id: smoke
         run: |
-          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << 'EOF'
           for i in $(seq 1 30); do
-            if curl -fs http://localhost:8001/healthz; then
+            if curl -fs https://sh.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi
@@ -128,7 +127,6 @@ jobs:
           done
           echo "smoke test failed after 60s"
           exit 1
-          EOF
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -119,7 +119,7 @@ jobs:
         id: smoke
         run: |
           for i in $(seq 1 30); do
-            if curl -fs https://sh.datasaillance.fr/healthz; then
+            if curl -fs https://sh-dev.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -94,9 +94,8 @@ jobs:
       - name: Smoke test (loop — R-M2, pas single-shot)
         id: smoke
         run: |
-          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_PROD_HOST }}" bash << 'EOF'
           for i in $(seq 1 30); do
-            if curl -fs http://localhost:8001/healthz; then
+            if curl -fs https://sh-prod.datasaillance.fr/healthz; then
               echo "healthz OK"
               exit 0
             fi
@@ -104,7 +103,6 @@ jobs:
           done
           echo "smoke test failed after 60s"
           exit 1
-          EOF
 
       - name: Auto-rollback on smoke failure (HIGH 4)
         if: failure() && steps.smoke.outcome == 'failure'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -32,7 +32,7 @@ services:
       postgres:
         condition: service_healthy
     ports:
-      - "8001:8001"
+      - "${WEB_PORT:-8001}:8001"
     restart: unless-stopped
     healthcheck:
       # urllib stdlib — pas de curl dans python:3.12-slim (R-L5)


### PR DESCRIPTION
## Ce qui entre en prod

- **#42** `chore(deploy)` — smoke test HTTPS via sh-dev.datasaillance.fr (Caddy reverse proxy)
- **#44** `chore(prod)` — WEB_PORT configurable (prod sur 8002) + smoke test HTTPS sh-prod.datasaillance.fr

## Migrations Alembic
Aucune migration Alembic

## Checklist déploiement
- [ ] CI verte
- [ ] Merge → main
- [ ] `deploy-prod.yml` workflow_dispatch avec le SHA du dernier commit main