### PR TITLE
chore(deploy): git pull origin main pour sync docker-compose.prod.yml

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,6 +94,7 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << EOF
           set -euo pipefail
           cd /srv/samsunghealth-dev
+          git pull origin main
           # Write IMAGE_TAG first — --env-file .env.prod overrides shell env in compose interpolation
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
           docker compose -f docker-compose.prod.yml --env-file .env.prod pull web

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -73,6 +73,7 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_PROD_HOST }}" bash << EOF
           set -euo pipefail
           cd /srv/samsunghealth-prod
+          git pull origin main
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$TAG/" .env.prod
           docker compose -f docker-compose.prod.yml --env-file .env.prod pull web
           CURRENT=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print \$1}')


### PR DESCRIPTION
Ajoute `git pull origin main` au début du step deploy dans les deux workflows, pour que `docker-compose.prod.yml` soit toujours à jour sur le VPS sans passer par scp.