### PR TITLE
chore(vault): vault local-only — remove Windows PKM path, add .env.local.example

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,3 @@
+# Optionnel — miroir read-only vers un vault Obsidian local pour navigation
+# Le contenu de docs/vault/ sera copié dans ce dossier au pre-commit (sens unique).
+# CARTOGRAPHER_MIRROR_TO=/mnt/c/Users/<user>/Documents/Obsidian/SamsungHealth

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 
 # Environment
 .env
+.env.local
 
 # IDE
 .idea/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,14 @@ Never commit to `main` or `dev` directly. Always: `feat/<scope>`, `fix/<scope>`,
 
 ---
 
+## Vault
+
+`docs/vault/` is the canonical vault — versioned in git alongside the code. Never treat the Windows Obsidian folder as a source of truth.
+
+The Windows path (`/mnt/c/Users/<user>/Documents/Obsidian/SamsungHealth/`) is a read-only mirror updated by the pre-commit hook when `CARTOGRAPHER_MIRROR_TO` is set in `.env.local`. It is opt-in, not required for any workflow. See `.env.local.example`.
+
+---
+
 ## Agent/skill system
 
 Skills generate a `brief.json` using Pydantic schemas in `agents/contracts/`. Agents read this brief from `${CLAUDE_PROJECT_DIR}/${WORK_DIR}/brief.json`. Before modifying a skill invocation chain, check the relevant contract in `agents/contracts/`.

--- a/docs/vault/specs/2026-04-23-plan-v2-multi-agents-architecture.md
+++ b/docs/vault/specs/2026-04-23-plan-v2-multi-agents-architecture.md
@@ -22,7 +22,7 @@ viz_primary: mermaid-gitgraph
 
 > **Master plan de la refonte** : `docs/vault/specs/2026-04-23-plan-v2-refactor-master.md` (approuvé 2026-04-23)
 > Ce plan définit **comment** exécuter le master plan avec des agents à responsabilité unique.
-> Les specs vivent **dans le repo** (`docs/vault/specs/`) depuis Phase A.8 — vault Obsidian dédié `C:\Users\idsmf\Documents\Obsidian\SamsungHealth\` (séparé du PKM).
+> Les specs vivent **dans le repo** dans `docs/vault/` (source canonique, versionnée en git). Le dossier Windows est un miroir read-only optionnel pour navigation Obsidian (voir `.env.local.example`).
 
 ## Context
 


### PR DESCRIPTION
## Summary

- Removes the hardcoded `C:\Users\idsmf\Documents\Obsidian\SamsungHealth\` path from `docs/vault/specs/2026-04-23-plan-v2-multi-agents-architecture.md` — replaced with a note that `docs/vault/` is canonical
- Adds `.env.local` to `.gitignore` (was missing)
- Creates `.env.local.example` documenting the optional `CARTOGRAPHER_MIRROR_TO` mirror for Obsidian viewing
- Adds a `## Vault` section to `CLAUDE.md` clarifying that `docs/vault/` is canonical (versioned in git) and the Windows path is opt-in read-only

## Why

Closing the vault-local cleanup: the infrastructure was already local-first but a stale Windows path reference and missing `.gitignore` entry were inconsistent with that reality.

## Checklist
- [x] No code changes — doc/config only
- [x] `.env.local` gitignored
- [x] Windows path reference removed from specs
- [x] `CLAUDE.md` accurately describes vault setup for all future agents