### PR TITLE
feat(specs): Phase 4 Android — 4 specs + correction source de vérité design

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ android-app/app/release/
 # OS
 .DS_Store
 Thumbs.db
+*:Zone.Identifier
 
 # Design handoff exports
 *.zip

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Every Art.9 field must be AES-256-GCM encrypted at rest. Any new model field sto
 `pentester` agent runs on every spec and every PR via `/review`. A finding of severity ≥ HIGH blocks merge — it is not optional. Do not bypass with `--no-verify` or by skipping the review step.
 
 ### Design — DataSaillance tokens only
-No Nightfall original design (dark `#000`, neons, glows, cold palette). Use DataSaillance tokens from `../OpenDesign/apps/web/src/index.css`. Light **and** dark mode are both mandatory. Forbidden: `#6366f1` (indigo Tailwind), `linear-gradient` decorative, box-shadow glow effects, font other than Cairo.
+Token source of truth: `../Vectorizer/IdentiteVisuelle/` (logos + polices). OpenDesign is referenced for CSS structure only, not for color values. Dark mode palette: bg `#191e22`, surface `#232e32`, teal `#0e9eb0`, amber `#d37c04`, cyan `#3be5e7`. Light **and** dark mode are both mandatory. Forbidden: `#6366f1` (indigo Tailwind), `linear-gradient` decorative, box-shadow glow effects, font other than Cairo.
 
 ### No LLM on health data
 Nightfall is explicitly not an LLM wrapper. Do not add Claude/OpenAI/etc. calls that receive raw health fields as input. Visualization and pattern detection are algorithmic only.

--- a/VISION.md
+++ b/VISION.md
@@ -65,53 +65,57 @@ Pentester agent invoqué à chaque spec et chaque PR. Verdict bloquant si findin
 
 ## Design system — DataSaillance
 
-**Règle fondamentale** : Nightfall v2 abandonne son design original au profit des codes visuels standards DataSaillance. Cohérence avec l'écosystème (DataSaillance, HarnessGame, OpenDesign).
+**Règle fondamentale** : Nightfall v2 utilise la charte graphique DataSaillance issue de l'identité visuelle officielle. Cohérence avec l'écosystème (DataSaillance, HarnessGame).
 
 ### Référence
 
-- Palette et tokens : `../OpenDesign/apps/web/src/index.css`
-- Règles couleur : `../OpenDesign/craft/color.md`
-- Règles typo : `../OpenDesign/craft/typography.md`
-- Logos et polices : `../Vectorizer/IdentiteVisuelle/`
-- Méthodologie frontend : `../OpenDesign/` (global.css comme source d'autorité)
+- **Palette et logos (source de vérité)** : `../Vectorizer/IdentiteVisuelle/`
+- **Méthodologie CSS** : `../OpenDesign/` (structure global.css, organisation des fichiers) — pas les tokens couleur
+- **Polices** : `../Vectorizer/IdentiteVisuelle/Polices/` (Playfair Display) + Cairo via Google Fonts
 
-### Tokens (source of truth)
-
-**Light mode** :
-```css
---bg: #faf9f7          /* fond warm paper */
---bg-panel: #ffffff
---text: #1a1916
---text-muted: #74716b
---accent: #c96442      /* rust/burnt-sienna */
---border: #ebe8e1
-```
+### Tokens (source of truth — extraits des logos IdentiteVisuelle)
 
 **Dark mode** :
 ```css
---bg: #1a1917
---bg-panel: #222120
---text: #e8e4dc
---text-muted: #9a9690
---accent: #d97a56      /* rust éclairci */
---border: #333128
+--bg: #191e22           /* fond principal dark */
+--bg-panel: #232e32     /* surface / cards */
+--text: #e8eff2
+--text-muted: #7a9aaa
+--accent-teal: #0e9eb0  /* accent primaire */
+--accent-amber: #d37c04 /* accent secondaire / CTA */
+--accent-cyan: #3be5e7  /* accent tertiaire / highlights */
+--border: #2e3d44
+```
+
+**Light mode** :
+```css
+--bg: #ffffff
+--bg-panel: #f4f8fa
+--text: #191e22
+--text-muted: #81868b
+--accent-teal: #0e9eb0
+--accent-amber: #d37c04
+--accent-cyan: #3be5e7
+--border: #d0dde3
 ```
 
 ### Règles d'application
 
 - **Mode light ET dark obligatoires** — toggle utilisateur + respect du `prefers-color-scheme` OS
-- **Un seul accent** (`--accent` rust) — max 2 usages visibles par écran
+- **Accent teal** (`#0e9eb0`) pour les éléments primaires (liens, focus, sélection)
+- **Accent amber** (`#d37c04`) pour les CTA et actions principales
+- **Accent cyan** (`#3be5e7`) pour les highlights et visualisations de données
 - **Police** : Cairo (variable, 400/500/600/700) + fallback système
 - **Pas de gradients décoratifs** — surfaces plates, hiérarchie par poids et taille
 - **Pas de `#6366f1`** (indigo Tailwind) — anti-slop explicite
+- **Pas de glows/halos** — box-shadow décoratif interdit
 - Tracking uppercase : `letter-spacing: 0.06em` minimum — obligatoire
-- Headings 32px+ : tracking négatif (`-0.01em`)
 
 ### Ce que Nightfall v1 avait et qu'on abandonne
 
-- Fond noir pur `#000` / contrastes extrêmes → remplacé par neutrals chauds DataSaillance
+- Fond noir pur `#000` / contrastes extrêmes → remplacé par `#191e22`
 - Halos lumineux et glows décoratifs → supprimés
-- Palette propre à Nightfall (teintes froides, néon) → remplacée par accent rust DataSaillance
+- Couleurs aléatoires non issues de la charte → remplacées par tokens IdentiteVisuelle
 - Originalité visuelle du nom "Nightfall" → conservé comme nom produit, pas comme direction esthétique
 
 ---

--- a/docs/vault/assets/mockups/p4/p4-palette-compare.html
+++ b/docs/vault/assets/mockups/p4/p4-palette-compare.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nightfall — Comparatif palettes</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: #111;
+    font-family: 'Cairo', 'Inter', sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px 60px;
+    gap: 16px;
+    min-height: 100vh;
+  }
+
+  h1 {
+    color: #fff;
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-align: center;
+  }
+
+  .subtitle {
+    color: #888;
+    font-size: 13px;
+    text-align: center;
+    margin-top: 4px;
+  }
+
+  .compare-row {
+    display: flex;
+    gap: 48px;
+    align-items: flex-start;
+    margin-top: 24px;
+  }
+
+  .column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .label {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 6px 14px;
+    border-radius: 6px;
+    text-align: center;
+    line-height: 1.4;
+  }
+
+  .label-a {
+    background: #1e2a2f;
+    color: #07BCD3;
+    border: 1px solid #07BCD3;
+  }
+
+  .label-b {
+    background: #2a1f1a;
+    color: #d97a56;
+    border: 1px solid #d97a56;
+  }
+
+  .palette-chips {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .chip {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid rgba(255,255,255,0.15);
+  }
+
+  /* ── iPhone 15 Pro frame ── */
+  .phone-frame {
+    width: 320px;
+    height: 692px;
+    border-radius: 50px;
+    border: 2px solid rgba(255,255,255,0.12);
+    overflow: hidden;
+    position: relative;
+    box-shadow: 0 32px 64px rgba(0,0,0,0.6), inset 0 0 0 1px rgba(255,255,255,0.05);
+  }
+
+  .screen {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 48px 24px 32px;
+    gap: 0;
+  }
+
+  /* notch */
+  .phone-frame::before {
+    content: '';
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 30px;
+    background: #111;
+    border-radius: 20px;
+    z-index: 10;
+  }
+
+  /* ━━━━━━━━━━━━━━━━━━━━━
+     PALETTE A — Tech / Froid
+     bg #191E22  surface #232E32
+     accent #D37C04  cyan #07BCD3  teal #0E9EB0
+  ━━━━━━━━━━━━━━━━━━━━━ */
+  .screen-a {
+    background: #191E22;
+  }
+
+  .screen-a .logo-ring {
+    width: 64px; height: 64px;
+    border-radius: 50%;
+    border: 2px solid #0E9EB0;
+    display: flex; align-items: center; justify-content: center;
+    margin: 0 auto 16px;
+    box-shadow: 0 0 20px rgba(7,188,211,0.25);
+  }
+
+  .screen-a .logo-icon {
+    font-size: 24px; color: #07BCD3;
+  }
+
+  .screen-a .app-name {
+    color: #E8EFF2;
+    font-size: 26px;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 0.02em;
+  }
+
+  .screen-a .app-tagline {
+    color: #7A9AAA;
+    font-size: 12px;
+    text-align: center;
+    margin-top: 4px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .screen-a .field {
+    background: #232E32;
+    border: 1px solid #2E3D44;
+    border-radius: 10px;
+    padding: 14px 16px;
+    color: #E8EFF2;
+    font-size: 14px;
+    margin-top: 10px;
+  }
+
+  .screen-a .field-label {
+    color: #7A9AAA;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    margin-top: 16px;
+  }
+
+  .screen-a .field-placeholder {
+    color: #4A6272;
+  }
+
+  .screen-a .forgot {
+    color: #07BCD3;
+    font-size: 12px;
+    text-align: right;
+    margin-top: 8px;
+  }
+
+  .screen-a .btn-primary {
+    background: #D37C04;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    text-align: center;
+    padding: 16px;
+    border-radius: 12px;
+    margin-top: 24px;
+    letter-spacing: 0.04em;
+  }
+
+  .screen-a .divider {
+    display: flex; align-items: center; gap: 10px;
+    margin-top: 20px;
+  }
+
+  .screen-a .divider-line {
+    flex: 1; height: 1px; background: #2E3D44;
+  }
+
+  .screen-a .divider-text {
+    color: #4A6272; font-size: 11px;
+    letter-spacing: 0.06em; text-transform: uppercase;
+  }
+
+  .screen-a .btn-google {
+    border: 1px solid #2E3D44;
+    background: #232E32;
+    color: #E8EFF2;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    padding: 14px;
+    border-radius: 12px;
+    margin-top: 12px;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+  }
+
+  .screen-a .google-dot {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: conic-gradient(#4285F4 90deg, #EA4335 90deg 180deg, #FBBC05 180deg 270deg, #34A853 270deg);
+  }
+
+  .screen-a .register-link {
+    color: #7A9AAA;
+    font-size: 12px;
+    text-align: center;
+    margin-top: auto;
+  }
+
+  .screen-a .register-link span {
+    color: #07BCD3;
+  }
+
+  /* ━━━━━━━━━━━━━━━━━━━━━
+     PALETTE B — Rust / Chaud DataSaillance
+     bg #1a1917  surface #222120
+     accent light #c96442  accent dark #d97a56
+  ━━━━━━━━━━━━━━━━━━━━━ */
+  .screen-b {
+    background: #1a1917;
+  }
+
+  .screen-b .logo-ring {
+    width: 64px; height: 64px;
+    border-radius: 50%;
+    border: 2px solid #d97a56;
+    display: flex; align-items: center; justify-content: center;
+    margin: 0 auto 16px;
+    box-shadow: 0 0 20px rgba(217,122,86,0.2);
+  }
+
+  .screen-b .logo-icon {
+    font-size: 24px; color: #d97a56;
+  }
+
+  .screen-b .app-name {
+    color: #e8e4dc;
+    font-size: 26px;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 0.02em;
+  }
+
+  .screen-b .app-tagline {
+    color: #8a8278;
+    font-size: 12px;
+    text-align: center;
+    margin-top: 4px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .screen-b .field {
+    background: #222120;
+    border: 1px solid #302e2b;
+    border-radius: 10px;
+    padding: 14px 16px;
+    color: #e8e4dc;
+    font-size: 14px;
+    margin-top: 10px;
+  }
+
+  .screen-b .field-label {
+    color: #8a8278;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    margin-top: 16px;
+  }
+
+  .screen-b .field-placeholder {
+    color: #5a554f;
+  }
+
+  .screen-b .forgot {
+    color: #d97a56;
+    font-size: 12px;
+    text-align: right;
+    margin-top: 8px;
+  }
+
+  .screen-b .btn-primary {
+    background: #c96442;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    text-align: center;
+    padding: 16px;
+    border-radius: 12px;
+    margin-top: 24px;
+    letter-spacing: 0.04em;
+  }
+
+  .screen-b .divider {
+    display: flex; align-items: center; gap: 10px;
+    margin-top: 20px;
+  }
+
+  .screen-b .divider-line {
+    flex: 1; height: 1px; background: #302e2b;
+  }
+
+  .screen-b .divider-text {
+    color: #5a554f; font-size: 11px;
+    letter-spacing: 0.06em; text-transform: uppercase;
+  }
+
+  .screen-b .btn-google {
+    border: 1px solid #302e2b;
+    background: #222120;
+    color: #e8e4dc;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    padding: 14px;
+    border-radius: 12px;
+    margin-top: 12px;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+  }
+
+  .screen-b .google-dot {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: conic-gradient(#4285F4 90deg, #EA4335 90deg 180deg, #FBBC05 180deg 270deg, #34A853 270deg);
+  }
+
+  .screen-b .register-link {
+    color: #8a8278;
+    font-size: 12px;
+    text-align: center;
+    margin-top: auto;
+  }
+
+  .screen-b .register-link span {
+    color: #d97a56;
+  }
+
+  /* ── Token table ── */
+  .token-table {
+    display: flex;
+    gap: 48px;
+    margin-top: 32px;
+  }
+
+  .token-col {
+    width: 320px;
+  }
+
+  .token-col table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+  }
+
+  .token-col th {
+    color: #666;
+    text-align: left;
+    padding: 4px 8px;
+    border-bottom: 1px solid #222;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .token-col td {
+    padding: 5px 8px;
+    color: #aaa;
+    border-bottom: 1px solid #1a1a1a;
+  }
+
+  .token-col td:first-child {
+    color: #666;
+    width: 45%;
+  }
+
+  .swatch {
+    display: inline-block;
+    width: 12px; height: 12px;
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-right: 6px;
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+
+  @media (max-width: 780px) {
+    .compare-row, .token-table { flex-direction: column; gap: 32px; }
+  }
+</style>
+<link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+<h1>Nightfall — Comparatif palettes</h1>
+<p class="subtitle">Écran Login · même layout, deux identités visuelles</p>
+
+<div class="compare-row">
+
+  <!-- ── PALETTE A : Tech / Froid ── -->
+  <div class="column">
+    <div class="label label-a">A — Fork Nightfall<br>Tech / Froid</div>
+    <div class="palette-chips">
+      <div class="chip" style="background:#191E22" title="#191E22"></div>
+      <div class="chip" style="background:#232E32" title="#232E32"></div>
+      <div class="chip" style="background:#D37C04" title="#D37C04"></div>
+      <div class="chip" style="background:#07BCD3" title="#07BCD3"></div>
+      <div class="chip" style="background:#0E9EB0" title="#0E9EB0"></div>
+    </div>
+    <div class="phone-frame">
+      <div class="screen screen-a">
+        <!-- Logo -->
+        <div class="logo-ring"><span class="logo-icon">◐</span></div>
+        <div class="app-name">Nightfall</div>
+        <div class="app-tagline">Sleep analytics</div>
+
+        <!-- Form -->
+        <div style="margin-top:28px;">
+          <div class="field-label">Email</div>
+          <div class="field"><span class="field-placeholder">vous@exemple.fr</span></div>
+
+          <div class="field-label">Mot de passe</div>
+          <div class="field"><span class="field-placeholder">••••••••••</span></div>
+
+          <div class="forgot">Mot de passe oublié ?</div>
+
+          <div class="btn-primary">Se connecter</div>
+
+          <div class="divider">
+            <div class="divider-line"></div>
+            <div class="divider-text">ou</div>
+            <div class="divider-line"></div>
+          </div>
+
+          <div class="btn-google">
+            <div class="google-dot"></div>
+            Continuer avec Google
+          </div>
+        </div>
+
+        <div class="register-link">Pas encore de compte ? <span>Créer un compte</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── PALETTE B : Rust / Chaud DataSaillance ── -->
+  <div class="column">
+    <div class="label label-b">B — DataSaillance<br>Rust / Chaud</div>
+    <div class="palette-chips">
+      <div class="chip" style="background:#1a1917" title="#1a1917"></div>
+      <div class="chip" style="background:#222120" title="#222120"></div>
+      <div class="chip" style="background:#c96442" title="#c96442"></div>
+      <div class="chip" style="background:#d97a56" title="#d97a56"></div>
+      <div class="chip" style="background:#e8e4dc" title="#e8e4dc"></div>
+    </div>
+    <div class="phone-frame">
+      <div class="screen screen-b">
+        <!-- Logo -->
+        <div class="logo-ring"><span class="logo-icon">◐</span></div>
+        <div class="app-name">Nightfall</div>
+        <div class="app-tagline">Sleep analytics</div>
+
+        <!-- Form -->
+        <div style="margin-top:28px;">
+          <div class="field-label">Email</div>
+          <div class="field"><span class="field-placeholder">vous@exemple.fr</span></div>
+
+          <div class="field-label">Mot de passe</div>
+          <div class="field"><span class="field-placeholder">••••••••••</span></div>
+
+          <div class="forgot">Mot de passe oublié ?</div>
+
+          <div class="btn-primary">Se connecter</div>
+
+          <div class="divider">
+            <div class="divider-line"></div>
+            <div class="divider-text">ou</div>
+            <div class="divider-line"></div>
+          </div>
+
+          <div class="btn-google">
+            <div class="google-dot"></div>
+            Continuer avec Google
+          </div>
+        </div>
+
+        <div class="register-link">Pas encore de compte ? <span>Créer un compte</span></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<!-- Token comparison table -->
+<div class="token-table">
+  <div class="token-col">
+    <table>
+      <tr>
+        <th colspan="2">A — Tokens Nightfall Fork</th>
+      </tr>
+      <tr><td>Background</td><td><span class="swatch" style="background:#191E22"></span>#191E22</td></tr>
+      <tr><td>Surface</td><td><span class="swatch" style="background:#232E32"></span>#232E32</td></tr>
+      <tr><td>Accent / CTA</td><td><span class="swatch" style="background:#D37C04"></span>#D37C04</td></tr>
+      <tr><td>Accent cool</td><td><span class="swatch" style="background:#07BCD3"></span>#07BCD3</td></tr>
+      <tr><td>Accent teal</td><td><span class="swatch" style="background:#0E9EB0"></span>#0E9EB0</td></tr>
+      <tr><td>Text primary</td><td><span class="swatch" style="background:#E8EFF2"></span>#E8EFF2</td></tr>
+      <tr><td>Text muted</td><td><span class="swatch" style="background:#7A9AAA"></span>#7A9AAA</td></tr>
+      <tr><td>Border</td><td><span class="swatch" style="background:#2E3D44"></span>#2E3D44</td></tr>
+    </table>
+  </div>
+  <div class="token-col">
+    <table>
+      <tr>
+        <th colspan="2">B — Tokens DataSaillance (index.css)</th>
+      </tr>
+      <tr><td>Background</td><td><span class="swatch" style="background:#1a1917"></span>#1a1917</td></tr>
+      <tr><td>Surface</td><td><span class="swatch" style="background:#222120"></span>#222120</td></tr>
+      <tr><td>Accent / CTA</td><td><span class="swatch" style="background:#c96442"></span>#c96442 (light)</td></tr>
+      <tr><td>Accent dark</td><td><span class="swatch" style="background:#d97a56"></span>#d97a56 (dark)</td></tr>
+      <tr><td>–</td><td style="color:#444">pas de cyan / teal</td></tr>
+      <tr><td>Text primary</td><td><span class="swatch" style="background:#e8e4dc"></span>#e8e4dc</td></tr>
+      <tr><td>Text muted</td><td><span class="swatch" style="background:#8a8278"></span>#8a8278</td></tr>
+      <tr><td>Border</td><td><span class="swatch" style="background:#302e2b"></span>#302e2b</td></tr>
+    </table>
+  </div>
+</div>
+
+</body>
+</html>

--- a/docs/vault/code/docs/vault/assets/mockups/p4/p4-palette-compare.md
+++ b/docs/vault/code/docs/vault/assets/mockups/p4/p4-palette-compare.md
@@ -1,0 +1,585 @@
+---
+type: code-source
+language: html
+file_path: docs/vault/assets/mockups/p4/p4-palette-compare.html
+git_blob: f0c168e2d1b7dded5c849e2f6de729e9dfedf9c4
+last_synced: '2026-05-06T20:34:25Z'
+loc: 557
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- html
+---
+
+# docs/vault/assets/mockups/p4/p4-palette-compare.html
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`docs/vault/assets/mockups/p4/p4-palette-compare.html`](../../../docs/vault/assets/mockups/p4/p4-palette-compare.html).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```html
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Nightfall — Comparatif palettes</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: #111;
+    font-family: 'Cairo', 'Inter', sans-serif;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px 60px;
+    gap: 16px;
+    min-height: 100vh;
+  }
+
+  h1 {
+    color: #fff;
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-align: center;
+  }
+
+  .subtitle {
+    color: #888;
+    font-size: 13px;
+    text-align: center;
+    margin-top: 4px;
+  }
+
+  .compare-row {
+    display: flex;
+    gap: 48px;
+    align-items: flex-start;
+    margin-top: 24px;
+  }
+
+  .column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+  }
+
+  .label {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 6px 14px;
+    border-radius: 6px;
+    text-align: center;
+    line-height: 1.4;
+  }
+
+  .label-a {
+    background: #1e2a2f;
+    color: #07BCD3;
+    border: 1px solid #07BCD3;
+  }
+
+  .label-b {
+    background: #2a1f1a;
+    color: #d97a56;
+    border: 1px solid #d97a56;
+  }
+
+  .palette-chips {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .chip {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    border: 2px solid rgba(255,255,255,0.15);
+  }
+
+  /* ── iPhone 15 Pro frame ── */
+  .phone-frame {
+    width: 320px;
+    height: 692px;
+    border-radius: 50px;
+    border: 2px solid rgba(255,255,255,0.12);
+    overflow: hidden;
+    position: relative;
+    box-shadow: 0 32px 64px rgba(0,0,0,0.6), inset 0 0 0 1px rgba(255,255,255,0.05);
+  }
+
+  .screen {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 48px 24px 32px;
+    gap: 0;
+  }
+
+  /* notch */
+  .phone-frame::before {
+    content: '';
+    position: absolute;
+    top: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100px;
+    height: 30px;
+    background: #111;
+    border-radius: 20px;
+    z-index: 10;
+  }
+
+  /* ━━━━━━━━━━━━━━━━━━━━━
+     PALETTE A — Tech / Froid
+     bg #191E22  surface #232E32
+     accent #D37C04  cyan #07BCD3  teal #0E9EB0
+  ━━━━━━━━━━━━━━━━━━━━━ */
+  .screen-a {
+    background: #191E22;
+  }
+
+  .screen-a .logo-ring {
+    width: 64px; height: 64px;
+    border-radius: 50%;
+    border: 2px solid #0E9EB0;
+    display: flex; align-items: center; justify-content: center;
+    margin: 0 auto 16px;
+    box-shadow: 0 0 20px rgba(7,188,211,0.25);
+  }
+
+  .screen-a .logo-icon {
+    font-size: 24px; color: #07BCD3;
+  }
+
+  .screen-a .app-name {
+    color: #E8EFF2;
+    font-size: 26px;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 0.02em;
+  }
+
+  .screen-a .app-tagline {
+    color: #7A9AAA;
+    font-size: 12px;
+    text-align: center;
+    margin-top: 4px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .screen-a .field {
+    background: #232E32;
+    border: 1px solid #2E3D44;
+    border-radius: 10px;
+    padding: 14px 16px;
+    color: #E8EFF2;
+    font-size: 14px;
+    margin-top: 10px;
+  }
+
+  .screen-a .field-label {
+    color: #7A9AAA;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    margin-top: 16px;
+  }
+
+  .screen-a .field-placeholder {
+    color: #4A6272;
+  }
+
+  .screen-a .forgot {
+    color: #07BCD3;
+    font-size: 12px;
+    text-align: right;
+    margin-top: 8px;
+  }
+
+  .screen-a .btn-primary {
+    background: #D37C04;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    text-align: center;
+    padding: 16px;
+    border-radius: 12px;
+    margin-top: 24px;
+    letter-spacing: 0.04em;
+  }
+
+  .screen-a .divider {
+    display: flex; align-items: center; gap: 10px;
+    margin-top: 20px;
+  }
+
+  .screen-a .divider-line {
+    flex: 1; height: 1px; background: #2E3D44;
+  }
+
+  .screen-a .divider-text {
+    color: #4A6272; font-size: 11px;
+    letter-spacing: 0.06em; text-transform: uppercase;
+  }
+
+  .screen-a .btn-google {
+    border: 1px solid #2E3D44;
+    background: #232E32;
+    color: #E8EFF2;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    padding: 14px;
+    border-radius: 12px;
+    margin-top: 12px;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+  }
+
+  .screen-a .google-dot {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: conic-gradient(#4285F4 90deg, #EA4335 90deg 180deg, #FBBC05 180deg 270deg, #34A853 270deg);
+  }
+
+  .screen-a .register-link {
+    color: #7A9AAA;
+    font-size: 12px;
+    text-align: center;
+    margin-top: auto;
+  }
+
+  .screen-a .register-link span {
+    color: #07BCD3;
+  }
+
+  /* ━━━━━━━━━━━━━━━━━━━━━
+     PALETTE B — Rust / Chaud DataSaillance
+     bg #1a1917  surface #222120
+     accent light #c96442  accent dark #d97a56
+  ━━━━━━━━━━━━━━━━━━━━━ */
+  .screen-b {
+    background: #1a1917;
+  }
+
+  .screen-b .logo-ring {
+    width: 64px; height: 64px;
+    border-radius: 50%;
+    border: 2px solid #d97a56;
+    display: flex; align-items: center; justify-content: center;
+    margin: 0 auto 16px;
+    box-shadow: 0 0 20px rgba(217,122,86,0.2);
+  }
+
+  .screen-b .logo-icon {
+    font-size: 24px; color: #d97a56;
+  }
+
+  .screen-b .app-name {
+    color: #e8e4dc;
+    font-size: 26px;
+    font-weight: 700;
+    text-align: center;
+    letter-spacing: 0.02em;
+  }
+
+  .screen-b .app-tagline {
+    color: #8a8278;
+    font-size: 12px;
+    text-align: center;
+    margin-top: 4px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .screen-b .field {
+    background: #222120;
+    border: 1px solid #302e2b;
+    border-radius: 10px;
+    padding: 14px 16px;
+    color: #e8e4dc;
+    font-size: 14px;
+    margin-top: 10px;
+  }
+
+  .screen-b .field-label {
+    color: #8a8278;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+    margin-top: 16px;
+  }
+
+  .screen-b .field-placeholder {
+    color: #5a554f;
+  }
+
+  .screen-b .forgot {
+    color: #d97a56;
+    font-size: 12px;
+    text-align: right;
+    margin-top: 8px;
+  }
+
+  .screen-b .btn-primary {
+    background: #c96442;
+    color: #fff;
+    font-size: 15px;
+    font-weight: 700;
+    text-align: center;
+    padding: 16px;
+    border-radius: 12px;
+    margin-top: 24px;
+    letter-spacing: 0.04em;
+  }
+
+  .screen-b .divider {
+    display: flex; align-items: center; gap: 10px;
+    margin-top: 20px;
+  }
+
+  .screen-b .divider-line {
+    flex: 1; height: 1px; background: #302e2b;
+  }
+
+  .screen-b .divider-text {
+    color: #5a554f; font-size: 11px;
+    letter-spacing: 0.06em; text-transform: uppercase;
+  }
+
+  .screen-b .btn-google {
+    border: 1px solid #302e2b;
+    background: #222120;
+    color: #e8e4dc;
+    font-size: 14px;
+    font-weight: 600;
+    text-align: center;
+    padding: 14px;
+    border-radius: 12px;
+    margin-top: 12px;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
+  }
+
+  .screen-b .google-dot {
+    width: 16px; height: 16px; border-radius: 50%;
+    background: conic-gradient(#4285F4 90deg, #EA4335 90deg 180deg, #FBBC05 180deg 270deg, #34A853 270deg);
+  }
+
+  .screen-b .register-link {
+    color: #8a8278;
+    font-size: 12px;
+    text-align: center;
+    margin-top: auto;
+  }
+
+  .screen-b .register-link span {
+    color: #d97a56;
+  }
+
+  /* ── Token table ── */
+  .token-table {
+    display: flex;
+    gap: 48px;
+    margin-top: 32px;
+  }
+
+  .token-col {
+    width: 320px;
+  }
+
+  .token-col table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 11px;
+  }
+
+  .token-col th {
+    color: #666;
+    text-align: left;
+    padding: 4px 8px;
+    border-bottom: 1px solid #222;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .token-col td {
+    padding: 5px 8px;
+    color: #aaa;
+    border-bottom: 1px solid #1a1a1a;
+  }
+
+  .token-col td:first-child {
+    color: #666;
+    width: 45%;
+  }
+
+  .swatch {
+    display: inline-block;
+    width: 12px; height: 12px;
+    border-radius: 3px;
+    vertical-align: middle;
+    margin-right: 6px;
+    border: 1px solid rgba(255,255,255,0.1);
+  }
+
+  @media (max-width: 780px) {
+    .compare-row, .token-table { flex-direction: column; gap: 32px; }
+  }
+</style>
+<link href="https://fonts.googleapis.com/css2?family=Cairo:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+
+<h1>Nightfall — Comparatif palettes</h1>
+<p class="subtitle">Écran Login · même layout, deux identités visuelles</p>
+
+<div class="compare-row">
+
+  <!-- ── PALETTE A : Tech / Froid ── -->
+  <div class="column">
+    <div class="label label-a">A — Fork Nightfall<br>Tech / Froid</div>
+    <div class="palette-chips">
+      <div class="chip" style="background:#191E22" title="#191E22"></div>
+      <div class="chip" style="background:#232E32" title="#232E32"></div>
+      <div class="chip" style="background:#D37C04" title="#D37C04"></div>
+      <div class="chip" style="background:#07BCD3" title="#07BCD3"></div>
+      <div class="chip" style="background:#0E9EB0" title="#0E9EB0"></div>
+    </div>
+    <div class="phone-frame">
+      <div class="screen screen-a">
+        <!-- Logo -->
+        <div class="logo-ring"><span class="logo-icon">◐</span></div>
+        <div class="app-name">Nightfall</div>
+        <div class="app-tagline">Sleep analytics</div>
+
+        <!-- Form -->
+        <div style="margin-top:28px;">
+          <div class="field-label">Email</div>
+          <div class="field"><span class="field-placeholder">vous@exemple.fr</span></div>
+
+          <div class="field-label">Mot de passe</div>
+          <div class="field"><span class="field-placeholder">••••••••••</span></div>
+
+          <div class="forgot">Mot de passe oublié ?</div>
+
+          <div class="btn-primary">Se connecter</div>
+
+          <div class="divider">
+            <div class="divider-line"></div>
+            <div class="divider-text">ou</div>
+            <div class="divider-line"></div>
+          </div>
+
+          <div class="btn-google">
+            <div class="google-dot"></div>
+            Continuer avec Google
+          </div>
+        </div>
+
+        <div class="register-link">Pas encore de compte ? <span>Créer un compte</span></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── PALETTE B : Rust / Chaud DataSaillance ── -->
+  <div class="column">
+    <div class="label label-b">B — DataSaillance<br>Rust / Chaud</div>
+    <div class="palette-chips">
+      <div class="chip" style="background:#1a1917" title="#1a1917"></div>
+      <div class="chip" style="background:#222120" title="#222120"></div>
+      <div class="chip" style="background:#c96442" title="#c96442"></div>
+      <div class="chip" style="background:#d97a56" title="#d97a56"></div>
+      <div class="chip" style="background:#e8e4dc" title="#e8e4dc"></div>
+    </div>
+    <div class="phone-frame">
+      <div class="screen screen-b">
+        <!-- Logo -->
+        <div class="logo-ring"><span class="logo-icon">◐</span></div>
+        <div class="app-name">Nightfall</div>
+        <div class="app-tagline">Sleep analytics</div>
+
+        <!-- Form -->
+        <div style="margin-top:28px;">
+          <div class="field-label">Email</div>
+          <div class="field"><span class="field-placeholder">vous@exemple.fr</span></div>
+
+          <div class="field-label">Mot de passe</div>
+          <div class="field"><span class="field-placeholder">••••••••••</span></div>
+
+          <div class="forgot">Mot de passe oublié ?</div>
+
+          <div class="btn-primary">Se connecter</div>
+
+          <div class="divider">
+            <div class="divider-line"></div>
+            <div class="divider-text">ou</div>
+            <div class="divider-line"></div>
+          </div>
+
+          <div class="btn-google">
+            <div class="google-dot"></div>
+            Continuer avec Google
+          </div>
+        </div>
+
+        <div class="register-link">Pas encore de compte ? <span>Créer un compte</span></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<!-- Token comparison table -->
+<div class="token-table">
+  <div class="token-col">
+    <table>
+      <tr>
+        <th colspan="2">A — Tokens Nightfall Fork</th>
+      </tr>
+      <tr><td>Background</td><td><span class="swatch" style="background:#191E22"></span>#191E22</td></tr>
+      <tr><td>Surface</td><td><span class="swatch" style="background:#232E32"></span>#232E32</td></tr>
+      <tr><td>Accent / CTA</td><td><span class="swatch" style="background:#D37C04"></span>#D37C04</td></tr>
+      <tr><td>Accent cool</td><td><span class="swatch" style="background:#07BCD3"></span>#07BCD3</td></tr>
+      <tr><td>Accent teal</td><td><span class="swatch" style="background:#0E9EB0"></span>#0E9EB0</td></tr>
+      <tr><td>Text primary</td><td><span class="swatch" style="background:#E8EFF2"></span>#E8EFF2</td></tr>
+      <tr><td>Text muted</td><td><span class="swatch" style="background:#7A9AAA"></span>#7A9AAA</td></tr>
+      <tr><td>Border</td><td><span class="swatch" style="background:#2E3D44"></span>#2E3D44</td></tr>
+    </table>
+  </div>
+  <div class="token-col">
+    <table>
+      <tr>
+        <th colspan="2">B — Tokens DataSaillance (index.css)</th>
+      </tr>
+      <tr><td>Background</td><td><span class="swatch" style="background:#1a1917"></span>#1a1917</td></tr>
+      <tr><td>Surface</td><td><span class="swatch" style="background:#222120"></span>#222120</td></tr>
+      <tr><td>Accent / CTA</td><td><span class="swatch" style="background:#c96442"></span>#c96442 (light)</td></tr>
+      <tr><td>Accent dark</td><td><span class="swatch" style="background:#d97a56"></span>#d97a56 (dark)</td></tr>
+      <tr><td>–</td><td style="color:#444">pas de cyan / teal</td></tr>
+      <tr><td>Text primary</td><td><span class="swatch" style="background:#e8e4dc"></span>#e8e4dc</td></tr>
+      <tr><td>Text muted</td><td><span class="swatch" style="background:#8a8278"></span>#8a8278</td></tr>
+      <tr><td>Border</td><td><span class="swatch" style="background:#302e2b"></span>#302e2b</td></tr>
+    </table>
+  </div>
+</div>
+
+</body>
+</html>
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*

--- a/docs/vault/specs/2026-05-06-p4-android-auth.md
+++ b/docs/vault/specs/2026-05-06-p4-android-auth.md
@@ -1,0 +1,603 @@
+---
+title: "Phase 4 Android Auth Screens"
+slug: 2026-05-06-p4-android-auth
+status: draft
+created: 2026-05-06
+phase: P4
+spec_type: ui
+related_specs:
+  - 2026-05-06-p4-android-shell
+implements: []
+tested_by: []
+branch: feat/p4-android-auth
+tags: [phase4, android, compose, auth, jwt, oauth, google, login]
+---
+
+# Spec — Phase 4 Android Auth Screens
+
+## Vision
+
+Les écrans auth sont la porte d'entrée sécurisée de l'application Nightfall : ils permettent à l'utilisateur de s'authentifier par email/mot de passe ou via Google OAuth, sans jamais exposer les données santé à un tiers. Le JWT d'accès est stocké exclusivement dans `TokenDataStore` (EncryptedSharedPreferences AES-256-GCM), conformément à C2 — aucune valeur sensible ne transite par SharedPreferences en clair ou par des logs. Ces écrans s'emboîtent dans le `NavGraph.kt` défini par la spec `p4-android-shell` et délèguent toute la logique réseau à `AuthViewModel` via Hilt.
+
+---
+
+## Contexte et dépendances
+
+Cette spec est une couche applicative au-dessus du shell (`2026-05-06-p4-android-shell`). Elle consomme les éléments suivants déjà définis dans la spec shell :
+
+| Composant shell | Rôle dans cette spec |
+|-----------------|----------------------|
+| `NavGraph.kt` | Ajouter les routes `"login"`, `"register"`, `"forgot-password"`, `"auth-callback"` |
+| `TokenDataStore` | Seul point de stockage/lecture du JWT — `saveToken()`, `getToken()`, `clearToken()` |
+| `NightfallApi` (interface Retrofit vide) | Peupler avec les endpoints auth : `/auth/login`, `/auth/register`, `/auth/password/reset/request`, `/auth/google/start` |
+| `NightfallTheme` | Envelopper tous les composables auth |
+| `AuthInterceptor` / `RetrofitClient` | Injecté automatiquement — pas de manipulation directe du token dans les ViewModels |
+| `di/NetworkModule.kt` | Fournit le `Retrofit` singleton — `AuthViewModel` n'instancie pas de Retrofit |
+
+### Endpoints backend utilisés
+
+| Endpoint | Méthode | Contrat | Utilisé par |
+|----------|---------|---------|-------------|
+| `/auth/login` | POST | Body `{email, password}` → `{access_token, refresh_token, token_type, expires_in}` (HTTP 200) ou HTTP 401 `invalid_credentials` ou HTTP 403 `email_not_verified` | `LoginScreen` |
+| `/auth/register` | POST | Body `{email, password}` + header `X-Registration-Token` → `{id, email}` (HTTP 201) ou HTTP 409 `email_already_exists` ou HTTP 400 `weak_password` | `RegisterScreen` |
+| `/auth/password/reset/request` | POST | Body `{email}` → `{"status": "pending"}` (HTTP 202) — réponse toujours identique (anti-enum) | `ForgotPasswordScreen` |
+| `/auth/google/start` | POST | Body `{return_to?}` → `{authorize_url}` (HTTP 200) | `LoginScreen` (bouton Google OAuth) |
+| `/auth/google/callback` | GET | Géré côté backend — redirige vers `nightfall://auth/callback?token=<access_token>` | `AuthCallbackScreen` (deep link) |
+| `/auth/logout` | POST | Header `Authorization: Bearer <token>` + body `{refresh_token}` → HTTP 204 | `ProfileScreen` (bouton "Se déconnecter") |
+
+Note : le refresh token est géré en cookie httpOnly par le backend (`/auth/refresh`). Le client Android stocke uniquement l'`access_token` dans `TokenDataStore` ; le cookie de refresh est géré automatiquement par OkHttp `CookieJar` (voir décision D7 ci-dessous).
+
+---
+
+## Décisions techniques
+
+| # | Décision | Justification |
+|---|----------|---------------|
+| D1 | `AuthViewModel` unique pour les 3 écrans form (Login, Register, ForgotPassword) | Les états sont disjoints ; un ViewModel partagé simplifie la DI sans couplage entre écrans |
+| D2 | `LoginUiState` : sealed class `Idle / Loading / Success / Error(message: String)` | Pattern standard Compose ; évite les booleans multiples conflictuels |
+| D3 | Erreur 401 affichée inline sous les champs, pas en dialog | Les dialogs bloquent l'UX mobile ; l'inline error est la pratique Material 3 recommandée |
+| D4 | `AuthCallbackScreen` comme destination dédiée (pas un intercepteur Activity) | Le deep link `nightfall://auth/callback` est capturé par Navigation Compose via `deepLinks` — plus propre que `onNewIntent` dans `MainActivity` |
+| D5 | Custom Tabs pour le flow OAuth Google | Custom Tabs partage la session navigateur (cookies Google) sans ouvrir une WebView interne non sécurisée ; requis pour le PKCE implicit flow |
+| D6 | Appel `POST /auth/google/start` avant ouverture Custom Tabs | Le backend génère le state CSRF et l'URL Google avec nonce — le client ne forge pas l'URL lui-même |
+| D7 | `OkHttp CookieJar` (in-memory) pour le refresh cookie httpOnly | Le backend pose le cookie `refresh_token` sur `/auth/refresh` avec `httpOnly + SameSite=Strict` ; OkHttp doit pouvoir le renvoyer sur `/auth/refresh` sans que le code Kotlin y touche |
+| D8 | Pas de `refresh_token` dans `TokenDataStore` | Le refresh token est httpOnly et géré par le cookie jar OkHttp — le stocker en clair en SharedPreferences violerait C2 |
+| D9 | Validation côté client minimale (email non-vide, password ≥ 1 char) avant envoi | Évite les 400 inutiles ; la vraie validation (force du mot de passe) reste serveur (`validate_password_strength`) |
+| D10 | Timeout réseau hérité du shell : 30s connect + 30s read | Défini dans `NetworkModule.kt` — pas de surcharge dans `AuthViewModel` |
+| D11 | `RegisterScreen` protégé par header `X-Registration-Token` fourni dans les Settings | L'enregistrement auto-register peut être désactivé côté backend (`SAMSUNGHEALTH_REGISTRATION_TOKEN`) ; le client envoie le token depuis les Settings de l'app |
+| D12 | Aucun log Timber des valeurs JWT, email, password | C3 / C2 — `Timber.d` interdit sur toute valeur sensible ; seuls les codes d'erreur HTTP sont loggables |
+
+---
+
+## Architecture
+
+### Nouveaux fichiers à créer
+
+```
+android-app/app/src/main/java/fr/datasaillance/nightfall/
+  ui/
+    screens/
+      auth/
+        LoginScreen.kt              ← composable principal auth
+        RegisterScreen.kt           ← formulaire création de compte
+        ForgotPasswordScreen.kt     ← formulaire demande de reset
+        AuthCallbackScreen.kt       ← intercepte deep link OAuth, stocke JWT
+      auth/components/
+        AuthTextField.kt            ← TextField stylé NightfallTheme (email / password)
+        AuthPrimaryButton.kt        ← bouton CTA Amber600 (Se connecter, S'inscrire)
+        AuthErrorMessage.kt         ← texte d'erreur inline rouge/onError
+  viewmodel/
+    auth/
+      AuthViewModel.kt              ← @HiltViewModel, états LoginUiState
+      AuthUiState.kt                ← sealed class LoginUiState + RegisterUiState + ForgotUiState
+data/
+  http/
+    NightfallApi.kt                 ← peupler avec AuthService (voir ci-dessous)
+  auth/
+    TokenDataStore.kt               ← existant shell — pas modifié
+```
+
+### Interface Retrofit — AuthService
+
+```kotlin
+// data/http/NightfallApi.kt  (ajout dans l'interface existante)
+interface NightfallApi {
+
+    @POST("auth/login")
+    suspend fun login(@Body body: LoginRequest): LoginResponse
+
+    @POST("auth/register")
+    suspend fun register(
+        @Body body: RegisterRequest,
+        @Header("X-Registration-Token") registrationToken: String?
+    ): RegisterResponse
+
+    @POST("auth/password/reset/request")
+    suspend fun requestPasswordReset(@Body body: PasswordResetRequest): StatusResponse
+
+    @POST("auth/google/start")
+    suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
+}
+```
+
+### Data classes Kotlin
+
+```kotlin
+// data/http/auth/AuthModels.kt
+data class LoginRequest(val email: String, val password: String)
+data class LoginResponse(
+    val access_token: String,
+    val refresh_token: String,
+    val token_type: String,
+    val expires_in: Int
+)
+
+data class RegisterRequest(val email: String, val password: String)
+data class RegisterResponse(val id: String, val email: String)
+
+data class PasswordResetRequest(val email: String)
+data class StatusResponse(val status: String)
+
+data class GoogleStartRequest(val return_to: String? = null)
+data class GoogleStartResponse(val authorize_url: String)
+```
+
+Toutes ces classes sont annotées `@Serializable` (kotlinx.serialization).
+
+### States UI
+
+```kotlin
+// viewmodel/auth/AuthUiState.kt
+sealed class LoginUiState {
+    object Idle : LoginUiState()
+    object Loading : LoginUiState()
+    object Success : LoginUiState()
+    data class Error(val message: String) : LoginUiState()
+}
+
+sealed class RegisterUiState {
+    object Idle : RegisterUiState()
+    object Loading : RegisterUiState()
+    object Success : RegisterUiState()
+    data class Error(val message: String) : RegisterUiState()
+}
+
+sealed class ForgotPasswordUiState {
+    object Idle : ForgotPasswordUiState()
+    object Loading : ForgotPasswordUiState()
+    object Sent : ForgotPasswordUiState()           // affiche confirmation, pas de distinction
+    data class Error(val message: String) : ForgotPasswordUiState()
+}
+```
+
+### AuthViewModel
+
+```kotlin
+// viewmodel/auth/AuthViewModel.kt
+@HiltViewModel
+class AuthViewModel @Inject constructor(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore
+) : ViewModel() {
+
+    private val _loginState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
+    val loginState: StateFlow<LoginUiState> = _loginState.asStateFlow()
+
+    private val _registerState = MutableStateFlow<RegisterUiState>(RegisterUiState.Idle)
+    val registerState: StateFlow<RegisterUiState> = _registerState.asStateFlow()
+
+    private val _forgotState = MutableStateFlow<ForgotPasswordUiState>(ForgotPasswordUiState.Idle)
+    val forgotState: StateFlow<ForgotPasswordUiState> = _forgotState.asStateFlow()
+
+    fun login(email: String, password: String) {
+        viewModelScope.launch {
+            _loginState.value = LoginUiState.Loading
+            try {
+                val response = api.login(LoginRequest(email, password))
+                tokenDataStore.saveToken(response.access_token)
+                _loginState.value = LoginUiState.Success
+            } catch (e: HttpException) {
+                _loginState.value = LoginUiState.Error(mapHttpError(e.code()))
+            } catch (e: IOException) {
+                _loginState.value = LoginUiState.Error("Vérifiez votre connexion réseau")
+            }
+        }
+    }
+
+    fun register(email: String, password: String, registrationToken: String?) {
+        viewModelScope.launch {
+            _registerState.value = RegisterUiState.Loading
+            try {
+                api.register(RegisterRequest(email, password), registrationToken)
+                _registerState.value = RegisterUiState.Success
+            } catch (e: HttpException) {
+                _registerState.value = RegisterUiState.Error(mapHttpError(e.code()))
+            } catch (e: IOException) {
+                _registerState.value = RegisterUiState.Error("Vérifiez votre connexion réseau")
+            }
+        }
+    }
+
+    fun requestPasswordReset(email: String) {
+        viewModelScope.launch {
+            _forgotState.value = ForgotPasswordUiState.Loading
+            try {
+                api.requestPasswordReset(PasswordResetRequest(email))
+                _forgotState.value = ForgotPasswordUiState.Sent
+            } catch (e: Exception) {
+                // Anti-enum: le backend renvoie toujours 202 — on affiche Sent quoi qu'il arrive
+                _forgotState.value = ForgotPasswordUiState.Sent
+            }
+        }
+    }
+
+    suspend fun getGoogleStartUrl(): String? {
+        return try {
+            api.googleStart(GoogleStartRequest()).authorize_url
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    fun storeTokenFromCallback(token: String) {
+        tokenDataStore.saveToken(token)
+        _loginState.value = LoginUiState.Success
+    }
+
+    private fun mapHttpError(code: Int): String = when (code) {
+        401 -> "Email ou mot de passe incorrect"
+        403 -> "Email non vérifié — consultez votre boîte mail"
+        409 -> "Cette adresse email est déjà utilisée"
+        400 -> "Mot de passe trop faible (12 caractères minimum, majuscule, chiffre, symbole)"
+        else -> "Erreur serveur ($code)"
+    }
+}
+```
+
+Note : `mapHttpError` ne logue jamais les valeurs email/password — uniquement le code HTTP.
+
+---
+
+## Layout et design des écrans
+
+### Tokens design (référence `NightfallTheme`)
+
+| Rôle | Token Compose | Valeur hex |
+|------|--------------|------------|
+| Fond (dark) | `MaterialTheme.colorScheme.background` | `#191E22` |
+| Surface carte | `MaterialTheme.colorScheme.surface` | `#232E32` |
+| CTA principal | `MaterialTheme.colorScheme.secondary` (Amber600) | `#D37C04` |
+| Lien / accent | `MaterialTheme.colorScheme.tertiary` (Cyan500) | `#07BCD3` |
+| Texte principal | `MaterialTheme.colorScheme.onBackground` | `#E8E4DC` (dark) / `#1A1916` (light) |
+| Erreur | `MaterialTheme.colorScheme.error` | Material 3 default |
+| Police | Cairo (tous styles) | — |
+
+Couleurs interdites dans ces écrans : `#6366f1`, tout `linear-gradient` décoratif, tout `box-shadow` type glow, toute police autre que Cairo.
+
+### LoginScreen
+
+Structure verticale centrée (`Column` + `Arrangement.Center`) :
+
+1. Logo/titre "Nightfall" en `MaterialTheme.typography.headlineMedium` (Cairo SemiBold)
+2. `AuthTextField` email (type `KeyboardType.Email`, `ImeAction.Next`)
+3. `AuthTextField` password (type `KeyboardType.Password`, toggle visibilité, `ImeAction.Done`)
+4. `AuthErrorMessage` — visible uniquement si `LoginUiState.Error` ; texte en `MaterialTheme.colorScheme.error`
+5. `AuthPrimaryButton` "Se connecter" — `Amber600`, full width, désactivé si `Loading` + indicateur `CircularProgressIndicator`
+6. `TextButton` "Mot de passe oublié ?" — couleur `Cyan500`, navigue vers `"forgot-password"`
+7. `OutlinedButton` "Continuer avec Google" — icône Google + texte, couleur border `Cyan500`
+8. `TextButton` "Créer un compte" — couleur `Cyan500`, navigue vers `"register"`
+
+### RegisterScreen
+
+Structure verticale centrée :
+
+1. Titre "Créer un compte" en `headlineMedium`
+2. `AuthTextField` email
+3. `AuthTextField` password (toggle visibilité)
+4. `AuthTextField` confirmation mot de passe (type `KeyboardType.Password`)
+5. Validation inline : les 2 mots de passe doivent être identiques avant envoi (vérification locale, pas de requête)
+6. `AuthErrorMessage` si `RegisterUiState.Error`
+7. `AuthPrimaryButton` "S'inscrire" — désactivé si mots de passe différents ou `Loading`
+8. Après `RegisterUiState.Success` : message de confirmation "Compte créé — connectez-vous" + navigation automatique vers `"login"`
+
+### ForgotPasswordScreen
+
+Structure verticale centrée :
+
+1. Titre "Réinitialiser le mot de passe"
+2. Texte explicatif "Entrez votre email, vous recevrez un lien de réinitialisation."
+3. `AuthTextField` email
+4. `AuthPrimaryButton` "Envoyer le lien"
+5. Si `ForgotPasswordUiState.Sent` : remplacer le formulaire par un message "Un email a été envoyé si ce compte existe." — pas de distinction compte connu/inconnu (anti-enum)
+6. `TextButton` "Retour à la connexion" — navigue vers `"login"`
+
+### AuthCallbackScreen
+
+Écran de transition invisible à l'utilisateur (fond `background`, `CircularProgressIndicator` centré) :
+
+1. Lancé automatiquement par le deep link `nightfall://auth/callback?token=<access_token>`
+2. Lit le query param `token` depuis `NavBackStackEntry.arguments` ou `Uri`
+3. Appelle `authViewModel.storeTokenFromCallback(token)` sur `LaunchedEffect(Unit)`
+4. Si token présent et valide : navigue vers `"sleep"` en vidant le back stack
+5. Si token absent ou vide : navigue vers `"login"` avec message d'erreur `LoginUiState.Error("Authentification Google échouée")`
+
+---
+
+## Navigation — intégration dans NavGraph.kt
+
+Modifications à apporter dans `ui/navigation/NavGraph.kt` :
+
+```kotlin
+composable("login") {
+    LoginScreen(
+        viewModel = hiltViewModel(),
+        onLoginSuccess = { navController.navigate("sleep") {
+            popUpTo("login") { inclusive = true }
+        }},
+        onNavigateRegister = { navController.navigate("register") },
+        onNavigateForgotPassword = { navController.navigate("forgot-password") }
+    )
+}
+
+composable("register") {
+    RegisterScreen(
+        viewModel = hiltViewModel(),
+        onRegisterSuccess = { navController.navigate("login") {
+            popUpTo("register") { inclusive = true }
+        }}
+    )
+}
+
+composable("forgot-password") {
+    ForgotPasswordScreen(
+        viewModel = hiltViewModel(),
+        onBack = { navController.popBackStack() }
+    )
+}
+
+composable(
+    route = "auth-callback?token={token}",
+    arguments = listOf(navArgument("token") { nullable = true }),
+    deepLinks = listOf(navDeepLink {
+        uriPattern = "nightfall://auth/callback?token={token}"
+    })
+) { backStackEntry ->
+    AuthCallbackScreen(
+        token = backStackEntry.arguments?.getString("token"),
+        viewModel = hiltViewModel(),
+        onSuccess = { navController.navigate("sleep") {
+            popUpTo(0) { inclusive = true }
+        }},
+        onFailure = { navController.navigate("login") {
+            popUpTo(0) { inclusive = true }
+        }}
+    )
+}
+```
+
+`LoginScreen` et les écrans auth sont **hors bottom nav scaffold** — la `BottomNavBar` n'est pas rendue quand la route courante est l'une de `{"login", "register", "forgot-password", "auth-callback"}`.
+
+---
+
+## Sécurité
+
+### Google OAuth — flow Custom Tabs
+
+```
+LoginScreen
+  → authViewModel.getGoogleStartUrl()  [POST /auth/google/start → {authorize_url}]
+  → CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(authorize_url))
+  → Backend Google → GET /auth/google/callback?code=&state=
+  → Backend valide state+nonce, génère access_token, redirect vers nightfall://auth/callback?token=<access_token>
+  → AuthCallbackScreen capte le deep link, appelle storeTokenFromCallback(token)
+  → Navigation vers SleepScreen
+```
+
+Le deep link `nightfall://auth/callback` doit être déclaré dans `AndroidManifest.xml` :
+
+```xml
+<activity android:name=".MainActivity" ...>
+    <intent-filter android:autoVerify="true">
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="nightfall" android:host="auth" android:pathPrefix="/callback" />
+    </intent-filter>
+</activity>
+```
+
+### Règles de sécurité strictes
+
+- Aucun `Timber.d` / `Timber.v` / `Timber.i` contenant `email`, `password`, `token`, `access_token`, ou toute valeur de champ sensible — uniquement les codes HTTP sont loggables
+- `TokenDataStore.saveToken()` ne loggue pas la valeur du token
+- `network_security_config.xml` hérité du shell : cleartext autorisé uniquement pour `10.0.2.2`, TLS obligatoire en release
+- `CustomTabsIntent` hérite de la politique TLS du navigateur système — pas de bypass possible
+- Le refresh token n'est jamais stocké dans `TokenDataStore` — il est httpOnly et géré par `CookieJar` OkHttp (en mémoire, non persisté)
+
+### OkHttp CookieJar
+
+Ajouter dans `NetworkModule.kt` :
+
+```kotlin
+.cookieJar(JavaNetCookieJar(CookieManager().apply {
+    setCookiePolicy(CookiePolicy.ACCEPT_ALL)
+}))
+```
+
+Ceci permet au backend de poser et de relire le cookie `refresh_token` sur `/auth/refresh` sans intervention du code Kotlin.
+
+---
+
+## Accessibilité
+
+| Élément | Exigence |
+|---------|---------|
+| `AuthTextField` email | `contentDescription = "Adresse email"`, `testTag = "field_email"` |
+| `AuthTextField` password | `contentDescription = "Mot de passe"`, `testTag = "field_password"` ; bouton toggle visibilité doit avoir `contentDescription` |
+| `AuthPrimaryButton` | `testTag = "btn_login"` / `"btn_register"` / `"btn_reset"` |
+| Bouton Google OAuth | `contentDescription = "Se connecter avec Google"`, `testTag = "btn_google_oauth"` |
+| `AuthErrorMessage` | `semantics { liveRegion = LiveRegionMode.Polite }` pour annonce TalkBack automatique |
+| `CircularProgressIndicator` | `contentDescription = "Chargement en cours"` |
+| `TextButton` "Mot de passe oublié" | `testTag = "link_forgot_password"` |
+
+Touch target minimum : 48dp × 48dp pour tous les éléments interactifs (Material 3 guideline).
+
+---
+
+## États des composables
+
+### AuthTextField
+
+| Paramètre | Type | Valeur |
+|-----------|------|--------|
+| `value` | `String` | valeur courante |
+| `onValueChange` | `(String) -> Unit` | callback |
+| `label` | `String` | "Email" / "Mot de passe" / "Confirmer le mot de passe" |
+| `isPassword` | `Boolean` | `false` par défaut |
+| `isError` | `Boolean` | déclenche le style rouge Material 3 |
+| `enabled` | `Boolean` | `false` si `Loading` |
+| `keyboardOptions` | `KeyboardOptions` | voir layout |
+
+### AuthPrimaryButton
+
+| Paramètre | Type | Valeur |
+|-----------|------|--------|
+| `text` | `String` | libellé |
+| `onClick` | `() -> Unit` | callback |
+| `isLoading` | `Boolean` | remplace le texte par `CircularProgressIndicator` |
+| `enabled` | `Boolean` | `true` par défaut |
+
+---
+
+## Livrables
+
+### Fichiers à créer
+
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt` — composable `@Composable fun LoginScreen(viewModel: AuthViewModel, onLoginSuccess, onNavigateRegister, onNavigateForgotPassword)`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt` — composable `@Composable fun RegisterScreen(viewModel: AuthViewModel, onRegisterSuccess)`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt` — composable `@Composable fun ForgotPasswordScreen(viewModel: AuthViewModel, onBack)`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt` — composable `@Composable fun AuthCallbackScreen(token: String?, viewModel: AuthViewModel, onSuccess, onFailure)`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt` — `@HiltViewModel`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt` — sealed classes `LoginUiState`, `RegisterUiState`, `ForgotPasswordUiState`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/auth/AuthModels.kt` — data classes Kotlin `@Serializable`
+
+### Fichiers à modifier
+
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt` — ajouter les 4 endpoints auth (`login`, `register`, `requestPasswordReset`, `googleStart`)
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt` — ajouter les 4 routes auth + condition `hasToken()` pour `startDestination`
+- [ ] `android-app/app/src/main/AndroidManifest.xml` — ajouter `intent-filter` deep link `nightfall://auth/callback`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt` — ajouter `CookieJar` OkHttp pour gestion du cookie refresh httpOnly
+
+### Dépendances Gradle supplémentaires
+
+- [ ] `implementation("androidx.browser:browser:1.8.0")` — Custom Tabs pour OAuth Google
+
+---
+
+## Parité light / dark mode
+
+Les deux modes sont obligatoires (C4). Vérifications à couvrir par Paparazzi :
+
+| Composable | Dark | Light |
+|-----------|------|-------|
+| `LoginScreen` (état Idle) | Fond `#191E22`, champ sur `#232E32`, CTA `#D37C04` | Fond `#FAFAFA`, champ blanc, CTA `#D37C04` |
+| `LoginScreen` (état Error) | Message erreur rouge inline visible | Idem |
+| `RegisterScreen` (état Idle) | Idem `LoginScreen` | Idem |
+| `ForgotPasswordScreen` (état Sent) | Message de confirmation visible, fond dark | Idem light |
+| `AuthCallbackScreen` (état Loading) | `CircularProgressIndicator` sur fond dark | Idem light |
+
+---
+
+## Tests d'acceptation
+
+**TA-AUTH-01 — Login succès : JWT stocké et navigation vers dashboard**
+- Given : utilisateur non connecté sur `LoginScreen`, backend disponible
+- When : l'utilisateur entre un email et mot de passe valides et appuie sur "Se connecter"
+- Then : `POST /auth/login` est appelé ; `tokenDataStore.saveToken()` est appelé avec l'`access_token` reçu ; `NavController` navigue vers `"sleep"` ; `"login"` est retiré du back stack
+
+**TA-AUTH-02 — Login échec 401 : erreur inline, pas de dialog**
+- Given : utilisateur sur `LoginScreen`, backend retourne HTTP 401 `invalid_credentials`
+- When : l'utilisateur soumet le formulaire
+- Then : `LoginUiState.Error("Email ou mot de passe incorrect")` est affiché sous les champs de formulaire ; aucun Dialog n'est ouvert ; le champ password reste visible et éditable ; `tokenDataStore.saveToken()` n'est pas appelé
+
+**TA-AUTH-03 — Login email non vérifié : message adapté**
+- Given : backend retourne HTTP 403 `email_not_verified`
+- When : l'utilisateur soumet le formulaire de login
+- Then : `LoginUiState.Error("Email non vérifié — consultez votre boîte mail")` est affiché inline ; `tokenDataStore.saveToken()` n'est pas appelé
+
+**TA-AUTH-04 — Loading state : bouton désactivé et indicateur visible**
+- Given : `LoginUiState.Loading` est actif (requête en cours)
+- When : le composable `LoginScreen` est rendu
+- Then : `AuthPrimaryButton` a `enabled = false` ; un `CircularProgressIndicator` est affiché à la place du texte ; les champs `AuthTextField` ont `enabled = false`
+
+**TA-AUTH-05 — Register succès : navigation vers login**
+- Given : utilisateur sur `RegisterScreen`, backend retourne HTTP 201
+- When : l'utilisateur entre email + mot de passe + confirmation identique et appuie sur "S'inscrire"
+- Then : `RegisterUiState.Success` est émis ; un message de confirmation est affiché ; la navigation se fait vers `"login"` en retirant `"register"` du back stack
+
+**TA-AUTH-06 — Register mots de passe différents : blocage côté client**
+- Given : utilisateur sur `RegisterScreen`, champ password = "abc", champ confirmation = "xyz"
+- When : le composable est rendu
+- Then : `AuthPrimaryButton` a `enabled = false` ; aucun appel réseau n'est effectué
+
+**TA-AUTH-07 — ForgotPassword : réponse identique quelle que soit l'existence du compte**
+- Given : utilisateur sur `ForgotPasswordScreen`
+- When : l'utilisateur entre n'importe quel email et appuie sur "Envoyer le lien"
+- Then : le formulaire est remplacé par le message "Un email a été envoyé si ce compte existe." quelle que soit la réponse backend (200, 202, erreur réseau) — comportement anti-enum
+
+**TA-AUTH-08 — AuthCallbackScreen deep link : JWT stocké et navigation dashboard**
+- Given : le backend redirige vers `nightfall://auth/callback?token=valid_jwt_token`
+- When : `AuthCallbackScreen` est affiché avec `token = "valid_jwt_token"`
+- Then : `tokenDataStore.saveToken("valid_jwt_token")` est appelé ; le `NavController` navigue vers `"sleep"` en vidant le back stack complet
+
+**TA-AUTH-09 — AuthCallbackScreen deep link invalide : retour login avec erreur**
+- Given : deep link reçu est `nightfall://auth/callback?token=` (token vide)
+- When : `AuthCallbackScreen` est affiché avec `token = null` ou `token = ""`
+- Then : `tokenDataStore.saveToken()` n'est pas appelé ; `NavController` navigue vers `"login"` ; `LoginUiState.Error("Authentification Google échouée")` est émis
+
+**TA-AUTH-10 — Pas de log du JWT**
+- Given : `LoginUiState.Success` vient d'être émis après un login valide
+- When : les logs Timber sont inspectés
+- Then : aucune ligne de log ne contient la valeur de l'`access_token` ni la valeur du `password` soumis
+
+**TA-AUTH-11 — Token persisté entre redémarrages**
+- Given : `authViewModel.login()` a réussi, `tokenDataStore.saveToken("tok123")` a été appelé
+- When : une nouvelle instance de `TokenDataStore` est créée (simule redémarrage de l'app)
+- Then : `tokenDataStore.getToken()` retourne `"tok123"` ; `tokenDataStore.hasToken()` retourne `true` ; `NavGraph` démarre sur `"sleep"` sans repasser par `"login"`
+
+**TA-AUTH-12 — Paparazzi LoginScreen dark et light**
+- Given : `NightfallTheme(darkTheme = true)` et `NightfallTheme(darkTheme = false)` sur `LoginScreen(uiState = LoginUiState.Idle)`
+- When : Paparazzi génère les screenshots
+- Then : le screenshot dark correspond au snapshot de référence (fond `#191E22`, CTA `#D37C04`, lien `#07BCD3`) ; le screenshot light correspond au snapshot de référence (fond `#FAFAFA`, même CTA)
+
+---
+
+## Fichiers de test à créer
+
+- [ ] `android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt` — tests unitaires JUnit4 : login succès, login 401, login 403, register succès, register 409, forgotPassword (anti-enum), storeTokenFromCallback
+- [ ] `android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt` — Paparazzi screenshots : `Idle` dark, `Idle` light, `Error` dark, `Loading` dark
+- [ ] `android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt` — Paparazzi : `Idle`, `Error` (mots de passe différents), dark + light
+- [ ] `android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt` — Paparazzi : `Idle` + `Sent`
+
+---
+
+## Contraintes RGPD et sécurité (récapitulatif)
+
+| Contrainte | Application dans ces écrans |
+|------------|----------------------------|
+| **C1** Local-first | `POST /auth/google/start` frappe uniquement le backend VPS personnel — jamais les serveurs Google directement depuis le client |
+| **C2** Chiffrement | JWT stocké dans `EncryptedSharedPreferences` AES-256-GCM via `TokenDataStore` — pas de SharedPreferences en clair, pas de Room, pas de fichier |
+| **C3** Sécurité | Pas de log de valeurs sensibles ; Custom Tabs pour OAuth ; TLS obligatoire en release ; header `X-Registration-Token` requis pour `/auth/register` |
+| **C4** Design | Tokens DataSaillance uniquement — `Amber600` pour CTA, `Cyan500` pour liens, `Background #191E22` dark, police Cairo ; interdit : `#6366f1`, glow, gradient décoratif |
+| **C5** No LLM | Aucun appel LLM — l'auth est purement réseau REST |
+
+---
+
+## Suite naturelle
+
+| Spec | Slug | Dépendance sur cette spec |
+|------|------|--------------------------|
+| Import SAF Android | `p4-android-import` | `NightfallApi` peuplé, `TokenDataStore` opérationnel, `AuthViewModel` stable |
+| WebView Bridge | `p4-webview-bridge` | `tokenDataStore.getToken()` injecté en cookie dans la WebView ; flux déconnexion partagé |

--- a/docs/vault/specs/2026-05-06-p4-android-import.md
+++ b/docs/vault/specs/2026-05-06-p4-android-import.md
@@ -1,0 +1,576 @@
+---
+title: "Phase 4 Android Import SAF"
+slug: 2026-05-06-p4-android-import
+status: draft
+created: 2026-05-06
+phase: P4
+spec_type: feature
+related_specs:
+  - 2026-05-06-p4-android-shell
+  - 2026-04-24-v2-csv-import-sqlalchemy
+implements: []
+tested_by: []
+branch: feat/p4-android-import
+tags: [phase4, android, saf, import, samsung-health, csv, multipart, rgpd]
+---
+
+# Spec — Phase 4 Android Import SAF
+
+## Vision
+
+L'écran Import SAF permet à l'utilisateur de sélectionner son export Samsung Health (dossier ou ZIP) via le Storage Access Framework Android, et de l'envoyer directement vers son backend Nightfall self-hosted — sans aucun intermédiaire tiers. Le parcours est volontairement séquentiel et transparent : connexion vérifiée, notice RGPD obligatoire, sélection du fichier, upload progressif par type de données. C'est la seule voie d'entrée des données santé dans la Phase 4, et chaque décision technique y réduit la surface d'attaque et de fuite.
+
+---
+
+## Contexte et dépendances
+
+Ce module est une destination du NavGraph défini dans `p4-android-shell`. Il doit être intégré sans modifier l'architecture du shell.
+
+| Dépendance | Spec de référence | Point d'intégration |
+|---|---|---|
+| NavGraph + deep link `nightfall://import` | `2026-05-06-p4-android-shell` | `ImportScreen.kt` remplace le stub `Text("Import — p4-android-import")` |
+| `RetrofitClient` + `AuthInterceptor` | `2026-05-06-p4-android-shell` | `NightfallApi.kt` reçoit les nouveaux endpoints import |
+| `TokenDataStore` | `2026-05-06-p4-android-shell` | `ImportViewModel` lit l'URL backend via injection Hilt |
+| Endpoints REST `/api/sleep`, `/api/heartrate`, `/api/steps`, `/api/exercise` | `2026-04-24-v2-csv-import-sqlalchemy` | Acceptent actuellement du JSON ; cette spec ajoute un endpoint `/import` CSV multipart sur chaque router |
+
+---
+
+## Décisions techniques
+
+| # | Décision | Justification |
+|---|---|---|
+| D1 | Storage Access Framework (`ACTION_GET_CONTENT` ou `ACTION_OPEN_DOCUMENT_TREE`) — pas d'accès `READ_EXTERNAL_STORAGE` | SAF = permission par URI délégué, pas de permission large. Requis API 28+. Aucun accès au stockage en dehors du document sélectionné par l'utilisateur |
+| D2 | Lecture des CSV via `ContentResolver.openInputStream(uri)` — jamais de copie dans le stockage externe ou le cache de l'app | C2 : les données Art.9 ne doivent pas persister en clair sur l'appareil après import |
+| D3 | Upload via `OkHttp RequestBody` streamé (`RequestBody.create(contentType, inputStream)` + `CountingRequestBody`) — pas de lecture complète en mémoire | Les exports Samsung Health peuvent dépasser 50 Mo ; un `ByteArray` complet en mémoire causerait un `OutOfMemoryError`. Le streaming résout les deux contraintes |
+| D4 | `multipart/form-data` avec champ `file` pour chaque CSV | Cohérence avec l'upload de fichiers standard HTTP ; facilite les tests curl et la validation backend |
+| D5 | Nouveaux endpoints `/api/sleep/import`, `/api/heartrate/import`, `/api/steps/import`, `/api/exercise/import` côté backend — les POST existants (JSON) ne sont pas modifiés | Séparation nette JSON (scripts desktop) vs multipart CSV (mobile) ; évite une migration forcée des callers existants |
+| D6 | Vérification de connectivité via `GET /api/health` avant toute sélection | Échouer tôt avant que l'utilisateur sélectionne son fichier — meilleure UX qu'un timeout à mi-upload |
+| D7 | `ImportViewModel` (@HiltViewModel) avec `StateFlow<ImportUiState>` | Pattern Compose standard ; `collectAsStateWithLifecycle()` côté UI évite les fuites lifecycle |
+| D8 | Upload séquentiel par type (sleep → heartrate → steps → exercise) — pas de parallélisme | Simplifité du feedback par type ; évite la saturation de la connexion réseau sur VPS modeste |
+| D9 | Progress par fichier : `(bytesUploaded / totalBytes).toFloat()` via `CountingRequestBody` | Feedback utilisateur précis sans bibliothèque tierce |
+| D10 | Notice RGPD obligatoire (pas de skip) affichée avant la sélection SAF | Art. 13 RGPD : l'utilisateur doit être informé avant que ses données transitent, même vers son propre serveur |
+| D11 | TLS obligatoire pour toute URL qui n'est pas `10.0.2.2` — hérité de `network_security_config.xml` du shell | C1 + C3 : cleartext limité à l'émulateur dev local uniquement |
+| D12 | `ImportScreen.kt` dans `src/main` (pas dans un source set flavor) | L'import SAF est identique dans les deux flavors `webview` et `native` |
+
+---
+
+## Architecture
+
+### Structure des packages concernés
+
+```
+android-app/
+  app/
+    src/
+      main/
+        java/fr/datasaillance/nightfall/
+          ui/
+            screens/
+              import_/
+                ImportScreen.kt          ← composable principal du stepper
+                ImportStep.kt            ← sealed class des étapes du stepper
+          data/
+            http/
+              NightfallApi.kt            ← ajout des 4 méthodes @Multipart @POST
+              CountingRequestBody.kt     ← OkHttp RequestBody avec callback progress
+            import_/
+              ImportRepository.kt        ← logique upload, stream CSV, appel API
+          domain/
+            import_/
+              ImportUiState.kt           ← sealed class états UI
+              ImportResult.kt            ← data class résultat par type
+          viewmodel/
+            import_/
+              ImportViewModel.kt         ← @HiltViewModel, StateFlow<ImportUiState>
+      test/
+        java/fr/datasaillance/nightfall/
+          viewmodel/import_/
+            ImportViewModelTest.kt
+          data/http/
+            CountingRequestBodyTest.kt
+```
+
+### Sealed class ImportUiState
+
+```kotlin
+// domain/import_/ImportUiState.kt
+sealed class ImportUiState {
+    object Idle : ImportUiState()
+    object Connecting : ImportUiState()
+    data class ConnectionFailed(val message: String) : ImportUiState()
+    object Connected : ImportUiState()                         // ping OK, attente sélection
+    object Selecting : ImportUiState()                        // SAF picker ouvert
+    data class Uploading(
+        val currentType: ImportDataType,
+        val progress: Float,                                  // 0f..1f
+        val completedTypes: List<ImportDataType>,
+        val skippedTypes: List<ImportDataType>,
+    ) : ImportUiState()
+    data class Success(val results: List<ImportResult>) : ImportUiState()
+    data class Error(val message: String, val retryable: Boolean) : ImportUiState()
+}
+```
+
+### Enum ImportDataType
+
+```kotlin
+// domain/import_/ImportDataType.kt
+enum class ImportDataType(
+    val samsungFilenamePrefix: String,
+    val apiPath: String,
+    val labelRes: Int,
+    val iconRes: Int,
+) {
+    SLEEP(
+        samsungFilenamePrefix = "com.samsung.health.sleep",
+        apiPath = "/api/sleep/import",
+        labelRes = R.string.import_type_sleep,
+        iconRes = R.drawable.ic_import_sleep,
+    ),
+    HEART_RATE(
+        samsungFilenamePrefix = "com.samsung.health.heart_rate",
+        apiPath = "/api/heartrate/import",
+        labelRes = R.string.import_type_heartrate,
+        iconRes = R.drawable.ic_import_heartrate,
+    ),
+    STEPS(
+        samsungFilenamePrefix = "com.samsung.health.step_daily_trend",
+        apiPath = "/api/steps/import",
+        labelRes = R.string.import_type_steps,
+        iconRes = R.drawable.ic_import_steps,
+    ),
+    EXERCISE(
+        samsungFilenamePrefix = "com.samsung.health.exercise",
+        apiPath = "/api/exercise/import",
+        labelRes = R.string.import_type_exercise,
+        iconRes = R.drawable.ic_import_exercise,
+    ),
+}
+```
+
+### Data class ImportResult
+
+```kotlin
+// domain/import_/ImportResult.kt
+data class ImportResult(
+    val type: ImportDataType,
+    val inserted: Int,
+    val skipped: Int,
+    val errorMessage: String? = null,
+)
+```
+
+### ImportViewModel
+
+```kotlin
+// viewmodel/import_/ImportViewModel.kt
+@HiltViewModel
+class ImportViewModel @Inject constructor(
+    private val repository: ImportRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ImportUiState>(ImportUiState.Idle)
+    val uiState: StateFlow<ImportUiState> = _uiState.asStateFlow()
+
+    fun checkConnection() {
+        viewModelScope.launch {
+            _uiState.value = ImportUiState.Connecting
+            val ok = repository.pingBackend()
+            _uiState.value = if (ok) ImportUiState.Connected else ImportUiState.ConnectionFailed(
+                "Backend inaccessible — vérifiez l'URL dans les paramètres"
+            )
+        }
+    }
+
+    fun startUpload(contentResolver: ContentResolver, treeUri: Uri) {
+        viewModelScope.launch {
+            val csvEntries = repository.extractCsvEntries(contentResolver, treeUri)
+            if (csvEntries.isEmpty()) {
+                _uiState.value = ImportUiState.Error(
+                    "Aucun fichier Samsung Health reconnu dans l'archive.",
+                    retryable = true
+                )
+                return@launch
+            }
+            val results = mutableListOf<ImportResult>()
+            val completed = mutableListOf<ImportDataType>()
+            val skipped = mutableListOf<ImportDataType>()
+
+            for (type in ImportDataType.entries) {
+                val entry = csvEntries[type]
+                if (entry == null) {
+                    skipped.add(type)
+                    continue
+                }
+                try {
+                    _uiState.value = ImportUiState.Uploading(
+                        currentType = type,
+                        progress = 0f,
+                        completedTypes = completed.toList(),
+                        skippedTypes = skipped.toList(),
+                    )
+                    val result = repository.uploadCsv(
+                        contentResolver = contentResolver,
+                        uri = entry.uri,
+                        type = type,
+                        totalBytes = entry.size,
+                    ) { progress ->
+                        _uiState.value = ImportUiState.Uploading(
+                            currentType = type,
+                            progress = progress,
+                            completedTypes = completed.toList(),
+                            skippedTypes = skipped.toList(),
+                        )
+                    }
+                    results.add(result)
+                    completed.add(type)
+                } catch (e: Exception) {
+                    results.add(ImportResult(type = type, inserted = 0, skipped = 0, errorMessage = e.message))
+                    // upload continue pour les autres types — pas de fail global
+                }
+            }
+            _uiState.value = ImportUiState.Success(results)
+        }
+    }
+
+    fun reset() {
+        _uiState.value = ImportUiState.Idle
+    }
+}
+```
+
+### ImportRepository
+
+```kotlin
+// data/import_/ImportRepository.kt
+class ImportRepository @Inject constructor(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore,
+) {
+    // Retourne true si GET /api/health répond HTTP 200 dans les 10 s
+    suspend fun pingBackend(): Boolean
+
+    // Parcourt le treeUri (dossier SAF) ou décompresse le ZIP en mémoire (via ZipInputStream)
+    // Retourne Map<ImportDataType, CsvEntry> — CsvEntry = (uri: Uri, size: Long)
+    // Ne copie jamais les bytes sur disque
+    suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri
+    ): Map<ImportDataType, CsvEntry>
+
+    // Ouvre un InputStream streamé depuis ContentResolver, construit un CountingRequestBody,
+    // appelle l'endpoint multipart correspondant à `type`
+    // Invoque onProgress(Float) à chaque chunk OkHttp
+    suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult
+}
+
+data class CsvEntry(val uri: Uri, val size: Long)
+```
+
+### NightfallApi — ajouts Phase 4 import
+
+```kotlin
+// data/http/NightfallApi.kt  (ajouts dans l'interface existante)
+interface NightfallApi {
+    // ... méthodes existantes
+
+    @Multipart
+    @POST("api/sleep/import")
+    suspend fun importSleep(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/heartrate/import")
+    suspend fun importHeartRate(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/steps/import")
+    suspend fun importSteps(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/exercise/import")
+    suspend fun importExercise(@Part file: MultipartBody.Part): ImportApiResponse
+}
+
+@Serializable
+data class ImportApiResponse(
+    val inserted: Int,
+    val skipped: Int,
+)
+```
+
+### CountingRequestBody
+
+```kotlin
+// data/http/CountingRequestBody.kt
+class CountingRequestBody(
+    private val delegate: RequestBody,
+    private val totalBytes: Long,
+    private val onProgress: (Float) -> Unit,
+) : RequestBody() {
+    override fun contentType(): MediaType? = delegate.contentType()
+    override fun contentLength(): Long = totalBytes
+    override fun writeTo(sink: BufferedSink) {
+        val counted = CountingSink(sink)
+        val buffered = counted.buffer()
+        delegate.writeTo(buffered)
+        buffered.flush()
+    }
+
+    inner class CountingSink(delegate: Sink) : ForwardingSink(delegate) {
+        private var bytesWritten = 0L
+        override fun write(source: Buffer, byteCount: Long) {
+            super.write(source, byteCount)
+            bytesWritten += byteCount
+            onProgress((bytesWritten.toFloat() / totalBytes).coerceIn(0f, 1f))
+        }
+    }
+}
+```
+
+### ImportScreen — composable
+
+L'écran est un stepper à 3 étapes (1 = Connexion, 2 = Sélection, 3 = Import). Il est rendu depuis le NavGraph existant sur la route `"import"`.
+
+```kotlin
+// ui/screens/import_/ImportScreen.kt
+@Composable
+fun ImportScreen(
+    viewModel: ImportViewModel = hiltViewModel(),
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    // Launcher SAF
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let { viewModel.startUpload(LocalContext.current.contentResolver, it) }
+    }
+
+    Scaffold(
+        topBar = { /* TopAppBar "Importer des données" + bouton retour */ }
+    ) { padding ->
+        when (val state = uiState) {
+            is ImportUiState.Idle,
+            is ImportUiState.Connecting,
+            is ImportUiState.ConnectionFailed,
+            is ImportUiState.Connected -> StepConnectionContent(state, viewModel, padding)
+
+            is ImportUiState.Selecting -> { /* SAF ouvert — état intermédiaire */ }
+
+            is ImportUiState.Uploading -> StepUploadContent(state, padding)
+            is ImportUiState.Success -> StepSuccessContent(state, onNavigateBack, padding)
+            is ImportUiState.Error -> ImportErrorContent(state, viewModel, padding)
+        }
+    }
+}
+```
+
+Composables internes (dans le même fichier ou sous-fichiers privés) :
+- `StepConnectionContent` — affiche l'état ping, bouton "Vérifier la connexion", indicateur de progression si `Connecting`
+- `RgpdNoticeCard` — carte avec texte RGPD obligatoire (voir section RGPD)
+- `StepSelectionContent` — s'affiche après connexion confirmée ; `RgpdNoticeCard` + bouton "Sélectionner le dossier Samsung Health"
+- `StepUploadContent` — liste des 4 types (`ImportDataType.entries`) avec icône, label, état (en attente / en cours + LinearProgressIndicator / terminé / ignoré)
+- `StepSuccessContent` — résumé par type : lignes importées, doublons ignorés
+- `ImportErrorContent` — message d'erreur + bouton "Réessayer" si `retryable = true`
+
+### Sealed class ImportStep (pour le stepper visuel)
+
+```kotlin
+// ui/screens/import_/ImportStep.kt
+sealed class ImportStep(val index: Int, val label: String) {
+    object Connection : ImportStep(1, "Connexion")
+    object Selection  : ImportStep(2, "Sélection")
+    object Upload     : ImportStep(3, "Import")
+}
+```
+
+---
+
+## Contrat backend — nouveaux endpoints CSV
+
+Ces 4 endpoints sont à ajouter sur les routers FastAPI existants. Ils ne modifient pas les endpoints JSON actuels.
+
+### Contrat commun
+
+- Méthode : `POST`
+- Auth : Bearer JWT (via `get_current_user`)
+- Content-Type : `multipart/form-data`, champ `file`
+- Réponse 201 : `{"inserted": int, "skipped": int}`
+- Réponse 400 : `{"detail": "Invalid CSV format"}` si le fichier ne correspond pas au schéma attendu
+- Réponse 413 : si le fichier dépasse la limite configurée (recommandé : 50 Mo)
+
+| Endpoint | Router | Parsing CSV attendu |
+|---|---|---|
+| `POST /api/sleep/import` | `server/routers/sleep.py` | Colonnes : `sleep_start`, `sleep_end` (ISO 8601), `stage_type`, `stage_start`, `stage_end` |
+| `POST /api/heartrate/import` | `server/routers/heartrate.py` | Colonnes : `date` (YYYY-MM-DD), `hour` (int), `min_bpm`, `max_bpm`, `avg_bpm`, `sample_count` |
+| `POST /api/steps/import` | `server/routers/steps.py` | Colonnes : `date` (YYYY-MM-DD), `hour` (int), `step_count` |
+| `POST /api/exercise/import` | `server/routers/exercise.py` | Colonnes : `exercise_type`, `exercise_start`, `exercise_end` (ISO 8601), `duration_minutes` |
+
+Note : le CSV Samsung Health brut utilise des noms de colonnes différents (ex : `start_time`, `end_time`). Le mapping se fait dans `ImportRepository.extractCsvEntries` ou dans le parser backend — cette spec ne tranche pas ; le coder-android peut déléguer au backend (plus cohérent avec la logique de `scripts/import_samsung_csv.py` existante) ou normaliser côté Android. Le coder-android doit expliciter ce choix dans son PR.
+
+---
+
+## RGPD — Notice obligatoire
+
+La carte `RgpdNoticeCard` est affichée entre l'étape Connexion confirmée et le bouton de sélection SAF. Elle n'est pas dismissable. Texte exact :
+
+> "Ces données sont envoyées uniquement vers **[URL backend]**. Elles ne transitent par aucun serveur tiers. Aucune copie n'est conservée sur cet appareil après l'import."
+
+- L'URL backend est substituée dynamiquement depuis `TokenDataStore` / settings
+- `[URL backend]` est rendu en `fontWeight = FontWeight.SemiBold`, couleur `primary` (teal)
+- Fond de carte : `MaterialTheme.colorScheme.surfaceVariant` ; bordure gauche couleur `primary` (2dp)
+- Aucun bouton "Ignorer" ni "Plus tard" — c'est une information, pas un consentement (le consentement RGPD est recueilli à l'inscription)
+
+---
+
+## Design — tokens DataSaillance
+
+| Élément | Token |
+|---|---|
+| Fond page | `MaterialTheme.colorScheme.background` |
+| Carte RGPD | `colorScheme.surfaceVariant` + bordure `colorScheme.primary` |
+| Bouton CTA principal ("Vérifier", "Sélectionner", "Fermer") | `FilledButton` Material 3 — `containerColor = colorScheme.primary` (Teal700 `#0E9EB0`) |
+| Icône type import "en cours" | `colorScheme.primary` |
+| Icône type import "terminé" | `colorScheme.tertiary` (Cyan500 `#07BCD3`) |
+| Icône type import "ignoré" | `colorScheme.onSurface` opacité 38% |
+| `LinearProgressIndicator` | `color = colorScheme.primary`, `trackColor = colorScheme.surfaceVariant` |
+| Indicateur étape active | `colorScheme.secondary` (Amber600 `#D37C04`) |
+| Police | Cairo (héritée de `NightfallTheme`) |
+| Interdits | `#6366f1`, `linear-gradient` décoratif, `box-shadow` glow |
+
+Light et dark mode sont tous les deux couverts via `NightfallTheme` — aucun `if (darkTheme)` inline dans `ImportScreen.kt`.
+
+---
+
+## Livrables
+
+### Fichiers Android à créer
+
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt`
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` (remplace le stub du shell)
+
+### Fichiers Android à modifier
+
+- [ ] `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt` — ajout des 4 méthodes `@Multipart @POST`
+
+### Ressources Android à créer
+
+- [ ] `android-app/app/src/main/res/values/strings.xml` — ajout des clés : `import_type_sleep`, `import_type_heartrate`, `import_type_steps`, `import_type_exercise`, `import_rgpd_notice`, `import_step_connection`, `import_step_selection`, `import_step_upload`
+- [ ] `android-app/app/src/main/res/drawable/ic_import_sleep.xml` — icône vecteur lit / lune
+- [ ] `android-app/app/src/main/res/drawable/ic_import_heartrate.xml` — icône vecteur coeur / ECG
+- [ ] `android-app/app/src/main/res/drawable/ic_import_steps.xml` — icône vecteur pas
+- [ ] `android-app/app/src/main/res/drawable/ic_import_exercise.xml` — icône vecteur sport
+
+### Fichiers backend à créer ou modifier
+
+- [ ] `server/routers/sleep.py` — ajout endpoint `POST /api/sleep/import` (multipart CSV)
+- [ ] `server/routers/heartrate.py` — ajout endpoint `POST /api/heartrate/import`
+- [ ] `server/routers/steps.py` — ajout endpoint `POST /api/steps/import`
+- [ ] `server/routers/exercise.py` — ajout endpoint `POST /api/exercise/import`
+
+### Tests
+
+- [ ] `android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt` — JUnit4 + coroutines-test, tests des transitions d'état
+- [ ] `android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt` — vérifie que `onProgress` est appelé, que la progression atteint 1f
+- [ ] `tests/server/test_import_csv_multipart.py` — pytest, tests des 4 endpoints backend (upload CSV factice, idempotence, format invalide)
+
+---
+
+## Tests d'acceptation
+
+**TA-01 — Connexion réussie : progression vers étape Sélection**
+- Given : le backend répond `HTTP 200` sur `GET /api/health`
+- When : l'utilisateur appuie sur "Vérifier la connexion" depuis `ImportScreen`
+- Then : `ImportUiState` passe de `Connecting` à `Connected` ; le stepper affiche l'étape 1 cochée ; la `RgpdNoticeCard` et le bouton "Sélectionner le dossier" apparaissent
+
+**TA-02 — Connexion échouée : message d'erreur et retry**
+- Given : le backend est inaccessible (timeout 10s ou connexion refusée)
+- When : l'utilisateur appuie sur "Vérifier la connexion"
+- Then : `ImportUiState` passe à `ConnectionFailed` ; un message "Backend inaccessible — vérifiez l'URL dans les paramètres" est affiché ; le bouton "Réessayer" relance `checkConnection()`
+
+**TA-03 — Notice RGPD non bypassable**
+- Given : l'état est `Connected`
+- When : l'écran affiche l'étape Sélection
+- Then : la `RgpdNoticeCard` est visible ; il n'existe aucun bouton "Ignorer" ni "Passer" ; le bouton "Sélectionner" est le seul CTA disponible
+
+**TA-04 — Sélection SAF : lancement du picker**
+- Given : l'état est `Connected` et la notice RGPD est visible
+- When : l'utilisateur appuie sur "Sélectionner le dossier Samsung Health"
+- Then : `ActivityResultContracts.OpenDocumentTree` est lancé ; le sélecteur de fichiers système s'ouvre
+
+**TA-05 — Upload progressif : feedback par type**
+- Given : l'utilisateur a sélectionné un dossier contenant `com.samsung.health.sleep.*.csv` et `com.samsung.health.heart_rate.*.csv`
+- When : `startUpload()` est appelé
+- Then : l'état passe séquentiellement par `Uploading(currentType = SLEEP, ...)` puis `Uploading(currentType = HEART_RATE, ...)` ; `completedTypes` s'incrémente après chaque type ; `STEPS` et `EXERCISE` apparaissent dans `skippedTypes`
+
+**TA-06 — Progress 0 → 1 sur un fichier**
+- Given : un `CountingRequestBody` wrappant un `RequestBody` de 1000 bytes
+- When : `writeTo(sink)` est appelé en écrivant 500 bytes puis 500 bytes
+- Then : `onProgress` est appelé au moins deux fois ; la dernière valeur est `1.0f` ; aucune valeur dépasse `1.0f`
+
+**TA-07 — Fichier non reconnu : erreur explicite**
+- Given : l'utilisateur sélectionne un dossier qui ne contient aucun fichier dont le nom commence par `com.samsung.health.*`
+- When : `extractCsvEntries()` est appelé
+- Then : le résultat est une `Map` vide ; `ImportViewModel` passe à `ImportUiState.Error("Aucun fichier Samsung Health reconnu dans l'archive.", retryable = true)`
+
+**TA-08 — Erreur réseau à mi-upload : pas de blocage global**
+- Given : l'upload de SLEEP réussit ; l'upload de HEART_RATE lève une `IOException` (connexion coupée)
+- When : `startUpload()` traite les 4 types
+- Then : `results` contient un `ImportResult(HEART_RATE, inserted=0, skipped=0, errorMessage="...")` ; les types STEPS et EXERCISE (si présents) continuent à être uploadés ; l'état final est `Success` (avec erreur partielle dans les résultats)
+
+**TA-09 — Upload idempotent**
+- Given : l'utilisateur relance un import avec les mêmes fichiers qu'un import précédent
+- When : les CSV sont envoyés aux endpoints backend
+- Then : la réponse backend retourne `{"inserted": 0, "skipped": N}` ; `ImportResult.skipped` est non nul ; `ImportResult.inserted` est 0 ; aucune erreur n'est levée
+
+**TA-10 — Aucune copie fichier sur le disque**
+- Given : l'utilisateur sélectionne un dossier Samsung Health
+- When : `extractCsvEntries()` puis `uploadCsv()` s'exécutent
+- Then : aucun fichier CSV n'est écrit dans `context.cacheDir`, `context.filesDir` ou le stockage externe de l'app ; seuls des `InputStream` ouverts depuis `ContentResolver.openInputStream(uri)` sont utilisés
+
+**TA-11 — URL backend dans la notice RGPD**
+- Given : l'URL backend configurée est `https://sh-prod.datasaillance.fr`
+- When : `RgpdNoticeCard` est rendu
+- Then : le texte de la carte contient la chaîne `https://sh-prod.datasaillance.fr` en police SemiBold
+
+**TA-12 — Deep link nightfall://import avec token valide**
+- Given : l'app est installée, un JWT valide est présent dans `TokenDataStore`, l'app est en arrière-plan
+- When : le système Android résout l'intent `nightfall://import`
+- Then : l'app s'ouvre sur `ImportScreen` dans l'état `Idle` ; le bouton "Vérifier la connexion" est visible ; aucune erreur de navigation
+
+---
+
+## Contraintes RGPD et sécurité (C1–C5)
+
+| Contrainte | Application dans ce module |
+|---|---|
+| **C1** Local-first | `ImportRepository` ne cible que `backendUrl` de l'utilisateur. Aucun appel vers Firebase, S3, Supabase ou tout autre tiers. La vérification est testée via `TA-10` |
+| **C2** Chiffrement / pas de cache en clair | Aucune copie des CSV sur le stockage de l'app (`TA-10`). Transit TLS obligatoire sauf émulateur (`D11`). Les données Art.9 sont chiffrées à l'écriture côté backend (responsabilité des routers FastAPI existants) |
+| **C3** Sécurité | Pentester agent passe avant merge. Points d'attention : injection de chemin via URI SAF, dépassement mémoire via ZIP bomb (voir note ci-dessous), absence de validation de type MIME côté Android |
+| **C4** Design DataSaillance | Tokens teal/amber/cyan via `NightfallTheme`. Aucun `#6366f1`, aucun gradient décoratif. Police Cairo |
+| **C5** No LLM | Aucun appel LLM dans tout ce module |
+
+**Note sécurité ZIP bomb** : si le fichier sélectionné est un ZIP, `ImportRepository.extractCsvEntries` doit implémenter une limite de décompression (ex : 200 Mo décompressés max, ou 10 entrées max) pour éviter un `OutOfMemoryError` volontaire. Cette limite est à définir avec le coder-android et à documenter dans le PR.
+
+---
+
+## Suite naturelle
+
+| Spec | Slug | Relation |
+|---|---|---|
+| WebView Bridge | `p4-webview-bridge` | Étape suivante Phase 4 — injection JWT dans la WebView, `WebViewClient` SSL, cookies `httpOnly` |
+| Auth Android | `p4-android-auth` | Si `p4-android-auth` est implémenté avant cet écran, `ImportViewModel` peut déclencher un refresh token avant l'upload |
+| Compose Canvas (Phase 5) | `p5-compose-canvas` | Les données importées via ce module alimentent les visualisations natives |

--- a/docs/vault/specs/2026-05-06-p4-android-shell.md
+++ b/docs/vault/specs/2026-05-06-p4-android-shell.md
@@ -1,0 +1,548 @@
+---
+title: "Phase 4 Android Shell"
+slug: 2026-05-06-p4-android-shell
+status: draft
+created: 2026-05-06
+phase: P4
+spec_type: ui
+related_specs:
+  - 2026-04-26-nightfall-rebrand-data-saillance
+  - 2026-04-28-phase3-rgpd-endpoints
+  - 2026-04-30-phase6-cicd-mvp
+implements: []
+tested_by: []
+branch: feat/p4-android-shell
+tags: [phase4, android, compose, jetpack, shell, navigation, theme, hilt, retrofit, samsunghealth, spec]
+---
+
+# Spec — Phase 4 Android Shell
+
+## Vision
+
+L'Android Shell est la fondation navigable de l'application Nightfall sur Android : il pose l'architecture de navigation (Jetpack Navigation Compose + bottom nav à 4 destinations), le système de thème (NightfallTheme Material 3 avec tokens DataSaillance, light + dark), et l'infrastructure réseau sécurisée (Retrofit + intercepteur JWT + TokenDataStore chiffré). C'est un rewrite complet de l'app existante (`com.samsunghealth`) — le code actuel (SyncScreen / HealthConnectManager / PreferencesManager) est remplacé entièrement sans migration. Les specs `p4-android-auth`, `p4-android-import` et `p4-webview-bridge` sont les prochaines couches qui s'emboîtent dans ce shell.
+
+---
+
+## Contexte et état de l'existant
+
+L'app Android actuelle (`android-app/`) est un proto fonctionnel mais hors spec Phase 4 :
+- Package : `com.samsunghealth` (à remplacer par `fr.datasaillance.nightfall`)
+- Pas de navigation graph — navigation manuelle par `showSettings` booléen
+- `PreferencesManager` utilise `datastore-preferences` en clair (non chiffré) — violation C2
+- `ApiClient` : pas d'intercepteur JWT, pas de Hilt DI
+- `MaterialTheme {}` sans tokens DataSaillance
+- Pas de build flavors
+
+La Phase 4 est un clean rewrite. Le répertoire `android-app/` est conservé comme root du module Gradle mais tout le code source est remplacé.
+
+---
+
+## Décisions techniques
+
+| # | Décision | Justification |
+|---|----------|---------------|
+| D1 | Package root : `fr.datasaillance.nightfall` | Alignement écosystème DataSaillance ; `com.samsunghealth` est un nom proto |
+| D2 | Build flavors : `webview` (défaut dev) + `native` (Phase 5, stubs) | Permet livraison progressive sans bloquer ; WebView charge `static/` du backend |
+| D3 | Navigation Compose (`androidx.navigation:navigation-compose`) | Pas de Fragment, cohérent avec Compose-first ; deep links natifs |
+| D4 | Hilt (DI) | Standard Jetpack DI ; suppression des singletons `object` (ex : `ApiClient`) |
+| D5 | `EncryptedDataStore` (`androidx.security.crypto`) pour le JWT | Le JWT donne accès aux données Art.9 — C2 interdit SharedPreferences en clair |
+| D6 | Retrofit + OkHttp + `AuthInterceptor` | Intercepteur unique qui injecte `Authorization: Bearer <token>` sur toutes les requêtes |
+| D7 | `NightfallTheme` : MaterialTheme M3 wrappé, tokens DataSaillance | Cf. spec rebrand 2026-04-26 ; primary=teal, secondary=amber, tertiary=cyan |
+| D8 | Police Cairo bundlée via `downloadableFonts` ou assets | Cairo est la police DataSaillance pour Android ; fallback `sans-serif` si non disponible |
+| D9 | Timber pour le logging | Pas de `Log.d` directs ; Timber.plant en `DebugTree` uniquement dans `webview` debug build |
+| D10 | Paparazzi pour screenshot tests des composables | Tests offline (pas d'émulateur) ; couvre `NightfallTheme` light + dark, `BottomNavBar`, états écrans |
+| D11 | `minSdk = 28`, `targetSdk = 35`, `compileSdk = 35` | Conservé par rapport au proto ; `EncryptedDataStore` requiert API 23+ — OK |
+| D12 | `ProfileScreen` natif dans les 2 flavors | Paramètres app (URL backend, thème, déconnexion) ne dépendent pas du flavor WebView/native |
+
+---
+
+## Architecture
+
+### Build flavors
+
+```kotlin
+// android-app/app/build.gradle.kts
+android {
+    namespace = "fr.datasaillance.nightfall"
+    compileSdk = 35
+
+    defaultConfig {
+        applicationId = "fr.datasaillance.nightfall"
+        minSdk = 28
+        targetSdk = 35
+        versionCode = 1
+        versionName = "4.0.0"
+    }
+
+    flavorDimensions += "rendering"
+    productFlavors {
+        create("webview") {
+            dimension = "rendering"
+            // Dashboard chargé via WebView → URL backend configurée
+        }
+        create("native") {
+            dimension = "rendering"
+            // Dashboard Compose Canvas — Phase 5 ; stubs vides en Phase 4
+        }
+    }
+
+    buildTypes {
+        debug {
+            applicationIdSuffix = ".debug"
+        }
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+}
+```
+
+Les sources flavor-spécifiques se trouvent dans :
+- `app/src/webview/java/fr/datasaillance/nightfall/` — surcharges WebView
+- `app/src/native/java/fr/datasaillance/nightfall/` — stubs Phase 4 (corps vides), implémentations réelles Phase 5
+
+### Structure des packages
+
+```
+android-app/
+  app/
+    src/
+      main/
+        java/fr/datasaillance/nightfall/
+          NightfallApplication.kt          ← @HiltAndroidApp, Timber.plant
+          MainActivity.kt                  ← @AndroidEntryPoint, NavHost root
+          ui/
+            theme/
+              Color.kt                     ← constantes couleur DataSaillance
+              Type.kt                      ← Cairo typography scale
+              NightfallTheme.kt            ← MaterialTheme M3 wrappé light+dark
+            navigation/
+              NavGraph.kt                  ← NavHost + toutes les routes
+              BottomNavBar.kt              ← composable bottom navigation 4 tabs
+              NavDestination.kt            ← sealed class / enum des routes
+            screens/
+              sleep/
+                SleepScreen.kt             ← WebView (webview flavor) / stub (native)
+              trends/
+                TrendsScreen.kt            ← WebView (webview flavor) / stub (native)
+              activity/
+                ActivityScreen.kt          ← WebView (webview flavor) / stub (native)
+              profile/
+                ProfileScreen.kt           ← natif les 2 flavors
+              login/
+                LoginScreen.kt             ← natif (redirigé si pas de token)
+              import_/
+                ImportScreen.kt            ← SAF picker — spec p4-android-import
+              settings/
+                SettingsScreen.kt          ← URL backend, thème, déconnexion
+          data/
+            auth/
+              TokenDataStore.kt            ← EncryptedDataStore JWT
+            http/
+              RetrofitClient.kt            ← Retrofit + OkHttp factory (Hilt @Provides)
+              AuthInterceptor.kt           ← OkHttp Interceptor injecte Bearer token
+              NightfallApi.kt              ← interface Retrofit (vide en Phase 4 shell)
+          di/
+            AppModule.kt                   ← @Module @InstallIn(SingletonComponent)
+            NetworkModule.kt               ← @Provides RetrofitClient, OkHttpClient
+        res/
+          values/strings.xml
+          values/themes.xml                ← thème XML minimal requis par WindowManager
+          xml/network_security_config.xml
+        AndroidManifest.xml
+      webview/
+        java/fr/datasaillance/nightfall/
+          ui/screens/sleep/SleepScreen.kt  ← WebView réelle
+          ui/screens/trends/TrendsScreen.kt
+          ui/screens/activity/ActivityScreen.kt
+      native/
+        java/fr/datasaillance/nightfall/
+          ui/screens/sleep/SleepScreen.kt  ← stub @Composable { Text("Phase 5") }
+          ui/screens/trends/TrendsScreen.kt
+          ui/screens/activity/ActivityScreen.kt
+    src/test/java/fr/datasaillance/nightfall/
+      ui/theme/NightfallThemeTest.kt       ← Paparazzi screenshots
+      ui/navigation/BottomNavBarTest.kt
+```
+
+### Navigation graph
+
+```
+NavHost(startDestination = NavDestination.Login si pas de token, sinon Sleep)
+│
+├── LoginScreen        (route: "login")            ← hors bottom nav
+├── ImportScreen       (route: "import")           ← hors bottom nav, deep link nightfall://import
+├── SettingsScreen     (route: "settings")         ← hors bottom nav
+│
+└── bottom nav scaffold
+    ├── SleepScreen    (route: "sleep")     tab 0  ← icône : bed / lune
+    ├── TrendsScreen   (route: "trends")    tab 1  ← icône : trending_up
+    ├── ActivityScreen (route: "activity")  tab 2  ← icône : directions_run
+    └── ProfileScreen  (route: "profile")   tab 3  ← icône : person
+```
+
+`ProfileScreen` contient deux points d'entrée vers les destinations hors-nav :
+- Bouton "Importer données" → `navController.navigate("import")`
+- Bouton "Paramètres" → `navController.navigate("settings")`
+
+### Thème — NightfallTheme
+
+```kotlin
+// ui/theme/Color.kt
+val Teal700   = Color(0xFF0E9EB0)   // primary dark + light
+val Amber600  = Color(0xFFD37C04)   // secondary (accent chaud)
+val Cyan500   = Color(0xFF07BCD3)   // tertiary
+val Surface   = Color(0xFF232E32)   // surface dark
+val Background = Color(0xFF191E22)  // background dark
+val BackgroundLight = Color(0xFFFAFAFA)
+val SurfaceLight    = Color(0xFFFFFFFF)
+val NeutralGray     = Color(0xFF828587)
+```
+
+```kotlin
+// ui/theme/NightfallTheme.kt
+@Composable
+fun NightfallTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) darkColorScheme(
+        primary       = Teal700,
+        secondary     = Amber600,
+        tertiary      = Cyan500,
+        background    = Background,
+        surface       = Surface,
+        onBackground  = Color(0xFFE8E4DC),
+        onSurface     = Color(0xFFE8E4DC),
+    ) else lightColorScheme(
+        primary       = Teal700,
+        secondary     = Amber600,
+        tertiary      = Cyan500,
+        background    = BackgroundLight,
+        surface       = SurfaceLight,
+        onBackground  = Color(0xFF1A1916),
+        onSurface     = Color(0xFF1A1916),
+    )
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography  = NightfallTypography,
+        content     = content
+    )
+}
+```
+
+La police Cairo est chargée via `FontFamily` depuis les assets bundlés (`assets/fonts/Cairo-*.ttf`) ou `downloadableFonts`. Le fichier `ui/theme/Type.kt` définit `NightfallTypography: Typography` avec Cairo comme `fontFamily` pour tous les styles.
+
+### TokenDataStore
+
+```kotlin
+// data/auth/TokenDataStore.kt
+class TokenDataStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val encryptedPrefs = EncryptedSharedPreferences.create(
+        context,
+        "nightfall_secure_prefs",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun saveToken(token: String) {
+        encryptedPrefs.edit().putString(KEY_JWT, token).apply()
+    }
+
+    fun getToken(): String? = encryptedPrefs.getString(KEY_JWT, null)
+
+    fun clearToken() {
+        encryptedPrefs.edit().remove(KEY_JWT).apply()
+    }
+
+    fun hasToken(): Boolean = getToken() != null
+
+    companion object {
+        private const val KEY_JWT = "jwt_access_token"
+    }
+}
+```
+
+Note : `EncryptedSharedPreferences` (androidx.security.crypto) est le mécanisme retenu. L'API `EncryptedDataStore` (protobuf DataStore + tink) est une alternative documentée mais complexe — `EncryptedSharedPreferences` est suffisant et stable pour un token JWT (valeur scalaire). Si le modèle de données s'étend, migrer vers DataStore+tink via une migration explicite.
+
+### RetrofitClient + AuthInterceptor
+
+```kotlin
+// data/http/AuthInterceptor.kt
+class AuthInterceptor @Inject constructor(
+    private val tokenDataStore: TokenDataStore
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = tokenDataStore.getToken()
+        val request = if (token != null) {
+            chain.request().newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        } else {
+            chain.request()
+        }
+        return chain.proceed(request)
+    }
+}
+```
+
+```kotlin
+// di/NetworkModule.kt  (fragment — complet dans le livrable)
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkModule {
+    @Provides @Singleton
+    fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+    @Provides @Singleton
+    fun provideRetrofit(
+        okHttpClient: OkHttpClient,
+        @BackendUrl baseUrl: String
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(baseUrl.trimEnd('/') + "/")
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .build()
+}
+```
+
+L'URL backend (`baseUrl`) est lue depuis `TokenDataStore`/settings et injectée via qualifier `@BackendUrl`. La valeur par défaut pour le flavor `webview` debug est `http://10.0.2.2:8001` (émulateur → host machine).
+
+### Gestion du thème utilisateur
+
+`ProfileScreen` et `SettingsScreen` exposent un toggle dark/light. Le choix est persisté dans `EncryptedSharedPreferences` (clé `theme_preference`, valeurs `"system"` | `"dark"` | `"light"`). `MainActivity` lit cette préférence et passe `darkTheme` à `NightfallTheme`.
+
+---
+
+## Livrables
+
+### Gradle + projet
+
+- [ ] `android-app/app/build.gradle.kts` — `productFlavors` `webview` + `native`, namespace `fr.datasaillance.nightfall`, Hilt plugin, Paparazzi, dépendances complètes (Compose BOM, Navigation Compose, Hilt, Retrofit, OkHttp, androidx.security.crypto, Timber)
+- [ ] `android-app/build.gradle.kts` — Hilt classpath + Kotlin kapt / KSP plugin
+- [ ] `android-app/settings.gradle.kts` — `rootProject.name = "Nightfall"`, inclusion `:app`
+
+### Application + DI
+
+- [ ] `NightfallApplication.kt` — `@HiltAndroidApp`, `Timber.plant(Timber.DebugTree())` conditionnel `BuildConfig.DEBUG`
+- [ ] `di/AppModule.kt` — `@Provides @Singleton` `TokenDataStore`, qualifier `@BackendUrl`
+- [ ] `di/NetworkModule.kt` — `@Provides @Singleton` `OkHttpClient`, `Retrofit`, `NightfallApi`
+
+### Theme
+
+- [ ] `ui/theme/Color.kt` — constantes couleur DataSaillance (dark + light)
+- [ ] `ui/theme/Type.kt` — `NightfallTypography` avec Cairo
+- [ ] `ui/theme/NightfallTheme.kt` — `MaterialTheme` M3 wrappé, dark/light `colorScheme`, `typography`
+
+### Navigation
+
+- [ ] `ui/navigation/NavDestination.kt` — `sealed class` ou `enum` avec routes string et labels/icons
+- [ ] `ui/navigation/NavGraph.kt` — `NavHost` avec toutes les destinations (login, sleep, trends, activity, profile, import, settings) ; startDestination conditionnel sur `tokenDataStore.hasToken()`
+- [ ] `ui/navigation/BottomNavBar.kt` — `NavigationBar` M3 avec 4 `NavigationBarItem` (Sommeil, Tendances, Activité, Profil)
+
+### Screens
+
+- [ ] `ui/screens/login/LoginScreen.kt` — stub `@Composable` avec `Text("Login — p4-android-auth")` + `onLoginSuccess: () -> Unit` callback
+- [ ] `ui/screens/sleep/SleepScreen.kt` (main) — signature uniquement, implémentation dans flavor source sets
+- [ ] `ui/screens/sleep/SleepScreen.kt` (webview) — `AndroidView` wrapping `WebView`, charge `${backendUrl}/` ; cookies HTTP-only, `settings.javaScriptEnabled = true`, `settings.domStorageEnabled = true`
+- [ ] `ui/screens/sleep/SleepScreen.kt` (native) — `@Composable { Text("Phase 5 — Compose Canvas") }`
+- [ ] `ui/screens/trends/TrendsScreen.kt` — même pattern webview/native
+- [ ] `ui/screens/activity/ActivityScreen.kt` — même pattern webview/native
+- [ ] `ui/screens/profile/ProfileScreen.kt` — natif, liste : URL backend (éditable), toggle thème (system/dark/light), bouton "Importer données" → `ImportScreen`, bouton "Se déconnecter" (clear token + navigate login)
+- [ ] `ui/screens/import_/ImportScreen.kt` — stub `@Composable { Text("Import — p4-android-import") }` + deep link `nightfall://import`
+- [ ] `ui/screens/settings/SettingsScreen.kt` — accès depuis ProfileScreen ; URL backend configurable
+
+### Auth + Réseau
+
+- [ ] `data/auth/TokenDataStore.kt` — `EncryptedSharedPreferences` AES256-GCM, `saveToken`, `getToken`, `clearToken`, `hasToken`
+- [ ] `data/http/AuthInterceptor.kt` — `Interceptor` OkHttp qui lit `TokenDataStore.getToken()`
+- [ ] `data/http/RetrofitClient.kt` — factory fonction (remplacée par Hilt en prod, conservée pour tests unitaires)
+- [ ] `data/http/NightfallApi.kt` — interface Retrofit vide en Phase 4 shell (à peupler par p4-android-auth et p4-android-import)
+
+### Entrée
+
+- [ ] `MainActivity.kt` — `@AndroidEntryPoint`, `setContent { NightfallTheme { NavGraph() } }`, gestion `darkTheme` depuis préférence utilisateur
+
+### Manifeste + Ressources
+
+- [ ] `AndroidManifest.xml` — package `fr.datasaillance.nightfall`, `NightfallApplication`, permissions INTERNET, deep link intent-filter `nightfall://import`, `android:networkSecurityConfig`
+- [ ] `res/xml/network_security_config.xml` — cleartext autorisé uniquement pour `10.0.2.2` (émulateur dev) ; tout le reste TLS
+- [ ] `assets/fonts/` — fichiers Cairo bundlés (Cairo-Regular.ttf, Cairo-Medium.ttf, Cairo-SemiBold.ttf, Cairo-Bold.ttf)
+
+### Tests
+
+- [ ] `src/test/ui/theme/NightfallThemeTest.kt` — Paparazzi screenshot `NightfallTheme(darkTheme = false)` + `(darkTheme = true)` sur un composable de référence ; les snapshots servent de régression visuelle
+- [ ] `src/test/ui/navigation/BottomNavBarTest.kt` — Paparazzi : 4 états `selectedRoute` (un par tab), dark + light
+
+---
+
+## Contraintes RGPD et sécurité (C1–C5)
+
+| Contrainte | Application dans ce shell |
+|------------|--------------------------|
+| **C1** Local-first | Aucun appel vers un service tiers — Retrofit cible uniquement `backendUrl` configurable par l'utilisateur (VPS personnel) |
+| **C2** Chiffrement | JWT stocké dans `EncryptedSharedPreferences` AES256-GCM — pas de `SharedPreferences` en clair, pas de `datastore-preferences` non chiffré |
+| **C3** Sécurité | `network_security_config.xml` : cleartext limité à `10.0.2.2` ; TLS requis partout ailleurs. Pentester agent passe avant merge |
+| **C4** Design | Tokens DataSaillance uniquement — `NightfallTheme` sans `#6366f1`, sans neons, sans `linear-gradient` décoratif, police Cairo |
+| **C5** No LLM | Aucun appel LLM — le shell ne traite aucune donnée santé directement |
+
+---
+
+## Tests d'acceptation
+
+Les tests d'acceptation suivants sont given/when/then et servent de critères de validation pour l'agent `tdd` puis l'agent `coder-android`.
+
+**TA-01 — Démarrage sans token : redirection login**
+- Given : application fraîchement installée, `TokenDataStore` vide
+- When : l'utilisateur lance l'app
+- Then : `NavHost` démarre sur `LoginScreen` ; la bottom navigation n'est pas visible
+
+**TA-02 — Démarrage avec token valide : accès dashboard**
+- Given : `TokenDataStore` contient un JWT valide (`hasToken() == true`)
+- When : l'utilisateur lance l'app
+- Then : `NavHost` démarre sur `SleepScreen` ; la bottom navigation est visible avec 4 tabs ; tab "Sommeil" est sélectionné
+
+**TA-03 — Navigation bottom nav : switch entre tabs**
+- Given : l'app est sur `SleepScreen`
+- When : l'utilisateur tape sur l'onglet "Tendances"
+- Then : `TrendsScreen` est affiché ; tab "Tendances" est en état `selected` ; les autres tabs ne sont pas `selected` ; aucun back stack n'est empilé (tap retour ne boucle pas entre tabs)
+
+**TA-04 — Dark mode : tokens appliqués**
+- Given : `NightfallTheme(darkTheme = true)` actif
+- When : le composable `BottomNavBar` est rendu
+- Then : `NavigationBar` a pour `containerColor` la valeur `Surface` (`#232E32`) ; les icônes des tabs non sélectionnés ont la couleur `onSurface` avec opacité 60% (M3 spec inactive)
+
+**TA-05 — Light mode : tokens appliqués**
+- Given : `NightfallTheme(darkTheme = false)` actif
+- When : le composable `BottomNavBar` est rendu
+- Then : le fond de la `NavigationBar` est `SurfaceLight` (`#FFFFFF`) ; les textes sont en `onSurface` (`#1A1916`)
+
+**TA-06 — JWT injecté dans chaque requête Retrofit**
+- Given : `TokenDataStore.getToken()` retourne `"test-jwt-token"`
+- When : `NightfallApi` (via Retrofit) effectue n'importe quel appel HTTP
+- Then : la requête OkHttp interceptée par `AuthInterceptor` contient le header `Authorization: Bearer test-jwt-token`
+
+**TA-07 — Absence de token : aucun header Authorization**
+- Given : `TokenDataStore.getToken()` retourne `null`
+- When : `NightfallApi` effectue un appel HTTP
+- Then : la requête ne contient pas le header `Authorization` (l'intercepteur ne forge pas de header vide)
+
+**TA-08 — Navigation vers ImportScreen depuis ProfileScreen**
+- Given : l'utilisateur est sur `ProfileScreen`
+- When : il appuie sur "Importer données"
+- Then : `navController` navigue vers `"import"` ; `ImportScreen` est affiché ; le bouton retour physique revient à `ProfileScreen`
+
+**TA-09 — Deep link import**
+- Given : l'app est installée et un token est présent
+- When : le système Android résout `nightfall://import`
+- Then : l'app s'ouvre directement sur `ImportScreen`
+
+**TA-10 — TokenDataStore : persistance chiffrée**
+- Given : `TokenDataStore.saveToken("abc123")` a été appelé
+- When : une nouvelle instance de `TokenDataStore` est créée (simule redémarrage de l'app)
+- Then : `getToken()` retourne `"abc123"` ; le fichier de préférences sur disque n'est pas lisible en clair
+
+**TA-11 — Déconnexion : clear token + redirection login**
+- Given : l'utilisateur est connecté, token présent
+- When : il appuie sur "Se déconnecter" dans `ProfileScreen`
+- Then : `TokenDataStore.clearToken()` est appelé ; `navController` navigue vers `"login"` en vidant le back stack (`popUpTo(NavDestination.Sleep) { inclusive = true }`)
+
+**TA-12 — Paparazzi snapshot NightfallTheme light**
+- Given : `NightfallTheme(darkTheme = false)` sur composable de référence
+- When : Paparazzi génère le screenshot
+- Then : le screenshot correspond au snapshot de référence (test de régression visuelle)
+
+**TA-13 — Paparazzi snapshot NightfallTheme dark**
+- Given : `NightfallTheme(darkTheme = true)` sur composable de référence
+- When : Paparazzi génère le screenshot
+- Then : fond `#191E22`, `NavigationBar` couleur `#232E32`, accent primary `#0E9EB0`
+
+---
+
+## Dépendances Gradle (versions cibles)
+
+```kotlin
+// Compose
+implementation(platform("androidx.compose:compose-bom:2024.12.01"))
+implementation("androidx.compose.ui:ui")
+implementation("androidx.compose.material3:material3")
+implementation("androidx.compose.ui:ui-tooling-preview")
+implementation("androidx.activity:activity-compose:1.9.3")
+implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+
+// Navigation
+implementation("androidx.navigation:navigation-compose:2.8.5")
+
+// Hilt
+implementation("com.google.dagger:hilt-android:2.52")
+kapt("com.google.dagger:hilt-android-compiler:2.52")
+implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+
+// Réseau
+implementation("com.squareup.retrofit2:retrofit:2.11.0")
+implementation("com.squareup.okhttp3:okhttp:4.12.0")
+implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
+
+// Sécurité / stockage chiffré
+implementation("androidx.security:security-crypto:1.1.0-alpha06")
+
+// Logging
+implementation("com.jakewharton.timber:timber:5.0.1")
+
+// Tests
+testImplementation("app.cash.paparazzi:paparazzi:1.3.4")
+testImplementation("junit:junit:4.13.2")
+androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+```
+
+Note : Hilt requiert `kapt`. Si le projet migre vers KSP, remplacer `kapt` par `ksp` et ajouter `ksp("com.google.dagger:hilt-android-compiler:2.52")`.
+
+---
+
+## Fichiers à supprimer (ancien proto)
+
+Le clean rewrite implique la suppression des fichiers suivants du proto :
+- `android-app/app/src/main/java/com/samsunghealth/ui/SyncScreen.kt`
+- `android-app/app/src/main/java/com/samsunghealth/ui/SettingsScreen.kt`
+- `android-app/app/src/main/java/com/samsunghealth/viewmodel/SyncViewModel.kt`
+- `android-app/app/src/main/java/com/samsunghealth/data/HealthConnectManager.kt`
+- `android-app/app/src/main/java/com/samsunghealth/data/ApiClient.kt`
+- `android-app/app/src/main/java/com/samsunghealth/data/PreferencesManager.kt`
+- `android-app/app/src/main/java/com/samsunghealth/MainActivity.kt` (remplacé)
+
+Health Connect (permissions, sync) est remis en scope dans `p4-android-import`.
+
+---
+
+## Suite naturelle
+
+Ce shell est la fondation des 3 specs Phase 4 suivantes, à développer dans cet ordre :
+
+| Spec | Slug | Dépendance sur ce shell |
+|------|------|------------------------|
+| Auth Android | `p4-android-auth` | `LoginScreen`, `TokenDataStore`, `NightfallApi` (endpoint `/auth/login`) |
+| Import SAF | `p4-android-import` | `ImportScreen`, deep link, `NightfallApi` (endpoints bulk upload), Health Connect |
+| WebView Bridge | `p4-webview-bridge` | `SleepScreen` / `TrendsScreen` / `ActivityScreen` flavor `webview`, injection URL + cookie JWT |
+
+La spec `p4-webview-bridge` précisera comment la WebView passe le JWT au backend (cookie `httpOnly` vs header JS) et les contraintes de `WebViewClient` (interception SSL, `shouldOverrideUrlLoading`, ClearText network policy).
+
+Phase 5 (`p5-compose-canvas`) consommera les stubs `native` et remplacera les `Text("Phase 5")` par des composables Canvas réels (hypnogramme, radial clock, timeline).

--- a/docs/vault/specs/2026-05-06-p4-webview-bridge.md
+++ b/docs/vault/specs/2026-05-06-p4-webview-bridge.md
@@ -1,0 +1,657 @@
+---
+title: "Phase 4 WebView Bridge"
+slug: 2026-05-06-p4-webview-bridge
+status: draft
+created: 2026-05-06
+phase: P4
+spec_type: feature
+related_specs:
+  - 2026-05-06-p4-android-shell
+  - 2026-04-27-v2.3.3.2-frontend-nightfall
+implements: []
+tested_by: []
+branch: feat/p4-webview-bridge
+tags: [phase4, android, webview, bridge, javascript, security, theme]
+---
+
+# Spec — Phase 4 WebView Bridge
+
+## Vision
+
+Le WebView Bridge est le contrat d'intégration entre le runtime Android natif (flavor `webview`) et le frontend web (`static/`) servi par le backend FastAPI. Il garantit que chaque `WebViewScreen` charge exclusivement l'URL du backend self-hosted de l'utilisateur, que l'authentification JWT transite sans jamais toucher une URL, et que le thème système est reflété dans le frontend via l'injection d'un attribut `data-theme` au chargement de page. Ce pont est la couche de confiance entre le monde natif et le monde web — sa surface d'attaque est délibérément minimale et entièrement auditée.
+
+---
+
+## Contexte et état de l'existant
+
+La spec `2026-05-06-p4-android-shell` établit la fondation :
+- Package root : `fr.datasaillance.nightfall`
+- Build flavor `webview` : `SleepScreen`, `TrendsScreen`, `ActivityScreen` sont des composables dans `app/src/webview/java/fr/datasaillance/nightfall/ui/screens/`
+- `TokenDataStore` (EncryptedSharedPreferences AES256-GCM) : source unique du JWT
+- `SettingsDataStore` (EncryptedSharedPreferences) : URL backend configurable, clé `backend_url`
+- `RetrofitClient` cible `backendUrl` — la même URL est utilisée dans la WebView
+
+La spec `2026-04-27-v2.3.3.2-frontend-nightfall` documente que le frontend web (`static/`) est du vanilla JS/HTML/CSS sans framework, sans build step. Les données sont chargées via `fetch("/api/sleep")` etc. Le frontend ne gère pas le flow d'authentification WebView — il s'attend à trouver un JWT déjà disponible dans `window.__AUTH_TOKEN__` ou dans le cookie de session.
+
+L'ancien `network_security_config.xml` autorisait cleartext globalement — la Phase 4 le restreint à `10.0.2.2` uniquement (décision D6 de cette spec).
+
+---
+
+## Décisions techniques
+
+| # | Décision | Justification |
+|---|----------|---------------|
+| D1 | Injection JWT via `evaluateJavascript("window.__AUTH_TOKEN__='$token'", null)` au `onPageFinished` | Interdit l'exposition du JWT dans l'URL (query param = présent dans les logs serveur, cache browser, historique) ; les cookies httpOnly ne sont pas accessibles depuis `evaluateJavascript` et nécessiteraient une synchronisation cookie jar complexe ; le header HTTP ne peut pas être injecté rétroactivement après chargement initial de page |
+| D2 | `NightfallWebViewClient` : `shouldOverrideUrlLoading` bloque toute URL hors `backendUrl` | Empêche l'exfiltration du JWT si le frontend charge un lien externe — C1 + C3. Liens externes ouverts en Chrome Custom Tabs (pas dans la WebView) |
+| D3 | `setAllowFileAccess(false)` + `setAllowContentAccess(false)` | Ferme les vecteurs `file://` et `content://` — la WebView n'a aucune raison de lire le filesystem ou le content provider de l'app |
+| D4 | `mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW` | Interdit les ressources HTTP depuis une page HTTPS — pas de downgrade silencieux |
+| D5 | `onReceivedSslError` : appel `handler.cancel()` sans bypass | Tout certificat invalide = connexion refusée. Pas de `handler.proceed()` en production — sinon MITM transparent |
+| D6 | `network_security_config.xml` : cleartext autorisé uniquement pour `10.0.2.2` | Émulateur → localhost WSL2 ; tout autre domaine requiert TLS |
+| D7 | `NightfallJsInterface` annoté `@JavascriptInterface` : surface exhaustivement listée | Chaque méthode exposée est une surface d'attaque JS → natif. La liste fermée (3 méthodes Phase 4 + 1 prévu Phase 5) est documentée dans cette spec et auditée par `pentester` |
+| D8 | Thème injecté via `document.documentElement.setAttribute('data-theme', 'dark'|'light')` au `onPageFinished` | Compatible avec le mécanisme `prefers-color-scheme` déjà présent dans `static/css/ds-tokens.css` ; pas besoin de modifier le frontend |
+| D9 | URL backend lue depuis `SettingsDataStore` (clé `backend_url`, EncryptedSharedPreferences) | Cohérence avec le shell (`NetworkModule.kt` utilise la même clé) ; pas de doublon de stockage |
+| D10 | `SettingsDataStore` distinct de `TokenDataStore` | `TokenDataStore` = JWT (courte durée, rotation fréquente) ; `SettingsDataStore` = configuration stable. Séparation des responsabilités |
+| D11 | `webView.addJavascriptInterface(NightfallJsInterface(...), "NightfallBridge")` | Nom du binding côté JS : `window.NightfallBridge` — préfixe `Nightfall` évite les collisions avec des libs tierces éventuelles |
+| D12 | `onReceivedHttpError` sur 401/403 : `TokenDataStore.clearToken()` + navigation vers `LoginScreen` | JWT expiré ou révoqué → logout automatique plutôt que boucle de 401 silencieuse |
+| D13 | `cacheMode = WebSettings.LOAD_DEFAULT` (réseau disponible) / `LOAD_CACHE_ELSE_NETWORK` (hors ligne) | Détection réseau via `ConnectivityManager` au `onPageStarted` ; dégradation gracieuse sans cache applicatif custom |
+
+---
+
+## Architecture
+
+### Vue d'ensemble
+
+```
+Android Runtime (flavor webview)
+│
+├── MainActivity → NavGraph → SleepScreen / TrendsScreen / ActivityScreen
+│       │
+│       └── WebViewScreen(url = backendUrl + path, modifier)
+│               │
+│               ├── AndroidView { WebView }
+│               │       ├── NightfallWebViewClient  (URL guard + SSL + 401/403)
+│               │       └── NightfallJsInterface    (@JavascriptInterface bridge)
+│               │
+│               └── au onPageFinished :
+│                       ├── evaluateJavascript("window.__AUTH_TOKEN__='$token'")
+│                       └── evaluateJavascript("document.documentElement.setAttribute('data-theme','$theme')")
+│
+Backend FastAPI (static/ servi par le serveur)
+│
+├── GET /           → static/index.html
+├── GET /api/sleep  → JSON (auth via Bearer ou window.__AUTH_TOKEN__ injecté côté JS)
+└── ...
+```
+
+### Structure des fichiers
+
+```
+android-app/
+  app/src/webview/java/fr/datasaillance/nightfall/
+    ui/
+      screens/
+        sleep/
+          SleepScreen.kt          ← WebViewScreen(url = backendUrl + "/", ...)
+        trends/
+          TrendsScreen.kt         ← WebViewScreen(url = backendUrl + "/trends", ...)
+        activity/
+          ActivityScreen.kt       ← WebViewScreen(url = backendUrl + "/activity", ...)
+    webview/
+      WebViewScreen.kt            ← composable générique réutilisé par les 3 screens
+      NightfallWebViewClient.kt   ← WebViewClient sécurisé
+      NightfallJsInterface.kt     ← @JavascriptInterface bridge JS → natif
+    data/
+      settings/
+        SettingsDataStore.kt      ← EncryptedSharedPreferences, clés backend_url + theme_preference
+```
+
+### WebViewScreen composable
+
+```kotlin
+// android-app/app/src/webview/java/fr/datasaillance/nightfall/webview/WebViewScreen.kt
+
+@Composable
+fun WebViewScreen(
+    url: String,
+    modifier: Modifier = Modifier,
+    tokenDataStore: TokenDataStore,
+    settingsDataStore: SettingsDataStore,
+    onOpenImport: () -> Unit,
+    onLogout: () -> Unit,
+) {
+    val context = LocalContext.current
+    val isDarkTheme = isSystemInDarkTheme()
+    val themeValue = if (isDarkTheme) "dark" else "light"
+
+    AndroidView(
+        factory = { ctx ->
+            WebView(ctx).apply {
+                settings.apply {
+                    javaScriptEnabled = true
+                    domStorageEnabled = true
+                    setAllowFileAccess(false)
+                    setAllowContentAccess(false)
+                    mixedContentMode = WebSettings.MIXED_CONTENT_NEVER_ALLOW
+                    cacheMode = WebSettings.LOAD_DEFAULT
+                }
+                val backendOrigin = settingsDataStore.getBackendUrl()
+                    .trimEnd('/').let { URI(it).run { "$scheme://$host${if (port != -1) ":$port" else ""}" } }
+
+                webViewClient = NightfallWebViewClient(
+                    allowedOrigin  = backendOrigin,
+                    tokenDataStore = tokenDataStore,
+                    onLogout       = onLogout,
+                )
+                addJavascriptInterface(
+                    NightfallJsInterface(
+                        context        = ctx,
+                        onOpenImport   = onOpenImport,
+                    ),
+                    "NightfallBridge"
+                )
+                loadUrl(url)
+            }
+        },
+        update = { webView ->
+            // Réinjection si le thème change sans rechargement de page
+            val token = tokenDataStore.getToken() ?: ""
+            webView.evaluateJavascript(
+                "document.documentElement.setAttribute('data-theme','$themeValue')", null
+            )
+        },
+        modifier = modifier.fillMaxSize()
+    )
+}
+```
+
+Paramètres :
+- `url: String` — URL complète incluant le path (ex : `https://sh-prod.datasaillance.fr/`)
+- `tokenDataStore: TokenDataStore` — injecté via Hilt dans les screens parents
+- `settingsDataStore: SettingsDataStore` — pour lire `backend_url` et calculer l'origine autorisée
+- `onOpenImport: () -> Unit` — callback natif déclenché par `NightfallBridge.openImport()`
+- `onLogout: () -> Unit` — callback déclenché sur 401/403
+
+### NightfallWebViewClient
+
+```kotlin
+// android-app/app/src/webview/java/fr/datasaillance/nightfall/webview/NightfallWebViewClient.kt
+
+class NightfallWebViewClient(
+    private val allowedOrigin: String,       // ex : "https://sh-prod.datasaillance.fr"
+    private val tokenDataStore: TokenDataStore,
+    private val onLogout: () -> Unit,
+) : WebViewClient() {
+
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        val url = request.url.toString()
+        return if (url.startsWith(allowedOrigin)) {
+            false  // laisser la WebView charger
+        } else {
+            // Ouvrir Chrome Custom Tab pour les URL externes
+            CustomTabsIntent.Builder().build().launchUrl(view.context, request.url)
+            true   // bloquer la navigation dans la WebView
+        }
+    }
+
+    override fun onPageFinished(view: WebView, url: String) {
+        super.onPageFinished(view, url)
+        injectAuth(view)
+        injectTheme(view)
+    }
+
+    private fun injectAuth(view: WebView) {
+        val token = tokenDataStore.getToken() ?: return
+        // Injection sécurisée : échappement JSON pour éviter injection de guillemets dans le token
+        val safeToken = JSONObject.quote(token).removeSurrounding("\"")
+        view.evaluateJavascript("window.__AUTH_TOKEN__='$safeToken';", null)
+    }
+
+    private fun injectTheme(view: WebView) {
+        val isDark = (view.context.resources.configuration.uiMode
+                and Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+        val themeVal = if (isDark) "dark" else "light"
+        view.evaluateJavascript(
+            "document.documentElement.setAttribute('data-theme','$themeVal');", null
+        )
+    }
+
+    @SuppressLint("WebViewClientOnReceivedSslError")
+    override fun onReceivedSslError(view: WebView, handler: SslErrorHandler, error: SslError) {
+        handler.cancel()  // Refuse tout certificat invalide — pas de bypass
+        Timber.e("WebView SSL error code=${error.primaryError} url=${view.url}")
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView,
+        request: WebResourceRequest,
+        errorResponse: WebResourceResponse
+    ) {
+        if (request.isForMainFrame && errorResponse.statusCode in listOf(401, 403)) {
+            Timber.w("WebView HTTP ${errorResponse.statusCode} on main frame — clearing token, logout")
+            tokenDataStore.clearToken()
+            onLogout()
+        }
+    }
+}
+```
+
+Règles d'URL :
+- Toute URL dont le préfixe correspond à `allowedOrigin` (scheme + host + port) est autorisée dans la WebView.
+- Toute autre URL déclenche l'ouverture d'un Chrome Custom Tab et bloque la navigation WebView.
+- L'`allowedOrigin` est calculé à partir de `SettingsDataStore.getBackendUrl()` en extrayant uniquement `scheme://host:port` — pas de path dans l'origine.
+
+### NightfallJsInterface
+
+```kotlin
+// android-app/app/src/webview/java/fr/datasaillance/nightfall/webview/NightfallJsInterface.kt
+
+class NightfallJsInterface(
+    private val context: Context,
+    private val onOpenImport: () -> Unit,
+) {
+
+    /**
+     * Retourne la version de l'app Android.
+     * Appelable depuis JS : window.NightfallBridge.getAppVersion()
+     */
+    @JavascriptInterface
+    fun getAppVersion(): String = BuildConfig.VERSION_NAME
+
+    /**
+     * Déclenche l'ouverture de ImportScreen (SAF picker) depuis JS.
+     * Appelable depuis JS : window.NightfallBridge.openImport()
+     * Usage prévu Phase 4 : bouton "Importer" dans le dashboard web.
+     */
+    @JavascriptInterface
+    fun openImport() {
+        // Doit s'exécuter sur le main thread — Handler pour thread safety
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            onOpenImport()
+        }
+    }
+
+    /**
+     * Réservé Phase 5 — hook pour événements analytiques JS → natif.
+     * @param eventJson JSON string : {"type": "...", "payload": {...}}
+     * Appelable depuis JS : window.NightfallBridge.onNightfallEvent(json)
+     */
+    @JavascriptInterface
+    fun onNightfallEvent(eventJson: String) {
+        // Phase 4 : no-op avec log Timber
+        Timber.d("NightfallBridge.onNightfallEvent: $eventJson")
+    }
+}
+```
+
+Surface `@JavascriptInterface` exhaustive (Phase 4) :
+
+| Méthode | Signature Kotlin | Retour | Thread safe | Usage |
+|---------|-----------------|--------|-------------|-------|
+| `getAppVersion` | `(): String` | `String` | oui (lecture seule) | Version string pour affichage dans UI web |
+| `openImport` | `(): Unit` | void | via `Handler(Looper.main)` | Ouvre `ImportScreen` natif depuis JS |
+| `onNightfallEvent` | `(eventJson: String): Unit` | void | oui (no-op Phase 4) | Hook Phase 5 — log uniquement en Phase 4 |
+
+Aucune méthode supplémentaire ne doit être ajoutée sans mise à jour de cette spec et re-audit `pentester`.
+
+### SettingsDataStore
+
+```kotlin
+// android-app/app/src/main/java/fr/datasaillance/nightfall/data/settings/SettingsDataStore.kt
+
+class SettingsDataStore @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    companion object {
+        private const val KEY_BACKEND_URL   = "backend_url"
+        private const val KEY_THEME_PREF    = "theme_preference"
+        private const val DEFAULT_BACKEND   = "http://10.0.2.2:8001"  // émulateur → WSL2
+    }
+
+    private val masterKey = MasterKey.Builder(context)
+        .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+        .build()
+
+    private val prefs = EncryptedSharedPreferences.create(
+        context,
+        "nightfall_settings_prefs",
+        masterKey,
+        EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+        EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+    )
+
+    fun getBackendUrl(): String =
+        prefs.getString(KEY_BACKEND_URL, DEFAULT_BACKEND) ?: DEFAULT_BACKEND
+
+    fun setBackendUrl(url: String) {
+        require(url.startsWith("http://") || url.startsWith("https://")) {
+            "backend_url must start with http:// or https://"
+        }
+        prefs.edit().putString(KEY_BACKEND_URL, url).apply()
+    }
+
+    fun getThemePreference(): String =
+        prefs.getString(KEY_THEME_PREF, "system") ?: "system"
+
+    fun setThemePreference(value: String) {
+        require(value in listOf("system", "dark", "light")) {
+            "theme_preference must be 'system', 'dark', or 'light'"
+        }
+        prefs.edit().putString(KEY_THEME_PREF, value).apply()
+    }
+}
+```
+
+Note : `SettingsDataStore` utilise le fichier de préférences `nightfall_settings_prefs` — distinct de `nightfall_secure_prefs` (utilisé par `TokenDataStore`). Cette séparation est intentionnelle (D10).
+
+### Diagramme de séquence — chargement initial
+
+```
+MainActivity → NavGraph → SleepScreen (webview flavor)
+    │
+    └── WebViewScreen.AndroidView.factory()
+            │
+            ├── WebView.settings configured (D3, D4, D6)
+            ├── webViewClient = NightfallWebViewClient(allowedOrigin, tokenDataStore, onLogout)
+            ├── addJavascriptInterface(NightfallJsInterface, "NightfallBridge")
+            └── webView.loadUrl("https://sh-prod.datasaillance.fr/")
+                    │
+                    ├── [réseau] GET https://sh-prod.datasaillance.fr/
+                    │       │
+                    │       └── FastAPI → static/index.html (+ JS, CSS)
+                    │
+                    └── NightfallWebViewClient.onPageFinished()
+                            ├── injectAuth()
+                            │       └── evaluateJavascript("window.__AUTH_TOKEN__='<jwt>'")
+                            └── injectTheme()
+                                    └── evaluateJavascript("document.documentElement.setAttribute('data-theme','dark')")
+
+    [JS frontend]
+        ├── fetch("/api/sleep", { headers: { Authorization: `Bearer ${window.__AUTH_TOKEN__}` } })
+        └── render dashboard
+```
+
+### Diagramme de séquence — 401 (token expiré)
+
+```
+WebView GET /api/sleep
+    │
+    └── FastAPI → HTTP 401
+            │
+            └── NightfallWebViewClient.onReceivedHttpError(statusCode=401, isForMainFrame=true)
+                    ├── tokenDataStore.clearToken()
+                    └── onLogout()  ← callback → navController.navigate("login") { popUpTo(...) }
+```
+
+### Diagramme de séquence — lien externe
+
+```
+JS frontend → window.location = "https://example.com"
+    │
+    └── NightfallWebViewClient.shouldOverrideUrlLoading("https://example.com")
+            ├── "https://example.com" ne commence pas par allowedOrigin
+            ├── CustomTabsIntent.Builder().build().launchUrl(context, uri)
+            └── return true  ← navigation WebView bloquée
+```
+
+---
+
+## Gestion du thème
+
+### Injection initiale
+
+Au `onPageFinished`, `NightfallWebViewClient.injectTheme()` :
+1. Lit `Configuration.UI_MODE_NIGHT_MASK` du contexte courant
+2. Injecte `document.documentElement.setAttribute('data-theme', 'dark' | 'light')`
+
+Le frontend web (`static/css/ds-tokens.css`) utilise `[data-theme="dark"]` et `[data-theme="light"]` comme sélecteurs — pas `@media (prefers-color-scheme)` seul. L'attribut injecté a donc la priorité.
+
+### Observation des changements de thème
+
+`MainActivity` observe `isSystemInDarkTheme()` via `collectAsState` depuis un `Flow<Boolean>` dérivé des préférences système. Quand le thème change :
+1. `NightfallTheme` se recompose avec le nouveau `darkTheme`
+2. Le bloc `update` de `AndroidView` est rappelé
+3. `evaluateJavascript("document.documentElement.setAttribute('data-theme', '$themeValue')", null)` est réexécuté sans rechargement de page
+
+Ce mécanisme évite le rechargement complet de la WebView pour un simple changement de thème.
+
+### Priorité des préférences
+
+| Source | Priorité | Mécanisme |
+|--------|----------|-----------|
+| Préférence utilisateur `"dark"` dans `SettingsDataStore` | 1 (haute) | Passe `darkTheme = true` à `NightfallTheme` + `WebViewScreen` |
+| Préférence utilisateur `"light"` | 1 | Passe `darkTheme = false` |
+| Préférence utilisateur `"system"` | 2 | Lit `isSystemInDarkTheme()` |
+| Thème système Android | 3 (fallback) | `Configuration.UI_MODE_NIGHT_*` |
+
+---
+
+## Injection du JWT côté frontend
+
+Le frontend web (`static/api.js` ou `static/js/api-client.js`) doit lire `window.__AUTH_TOKEN__` et l'injecter dans les requêtes `fetch`. Ce contrat est documenté ici — l'implémentation côté JS est dans la spec `2026-04-27-v2.3.3.2-frontend-nightfall`.
+
+Pattern attendu côté JS (à implémenter dans `static/api.js`) :
+
+```javascript
+function getAuthHeaders() {
+    const token = window.__AUTH_TOKEN__;
+    if (!token) return {};
+    return { 'Authorization': `Bearer ${token}` };
+}
+
+// Chaque fetch vers /api/* inclut ce header
+const response = await fetch('/api/sleep', {
+    headers: { ...getAuthHeaders(), 'Content-Type': 'application/json' }
+});
+```
+
+Contrainte : `window.__AUTH_TOKEN__` est **toujours** une string ou `undefined` — jamais passé en query param, jamais loggué par `console.log` dans le code de production.
+
+---
+
+## Configuration réseau et sécurité Android
+
+### network_security_config.xml (mis à jour Phase 4)
+
+```xml
+<!-- android-app/app/src/main/res/xml/network_security_config.xml -->
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Cleartext uniquement pour l'émulateur Android (10.0.2.2 = host WSL2) -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+    <!-- Tout autre domaine : TLS requis -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>
+```
+
+Ce fichier remplace la version proto qui autorisait cleartext globalement (`cleartextTrafficPermitted="true"` dans `base-config`).
+
+### AndroidManifest.xml — ajouts nécessaires
+
+```xml
+<!-- Dans <application> -->
+<uses-permission android:name="android.permission.INTERNET" />
+
+<!-- Chrome Custom Tabs -->
+<queries>
+    <intent>
+        <action android:name="android.intent.action.VIEW" />
+        <data android:scheme="https" />
+    </intent>
+</queries>
+```
+
+---
+
+## Livrables
+
+### Fichiers nouveaux (flavor `webview`)
+
+- [ ] `app/src/webview/java/fr/datasaillance/nightfall/webview/WebViewScreen.kt` — composable générique avec `AndroidView`, configuration WebView sécurisée, injection JWT + thème au `onPageFinished`
+- [ ] `app/src/webview/java/fr/datasaillance/nightfall/webview/NightfallWebViewClient.kt` — `WebViewClient` avec `shouldOverrideUrlLoading` (origine allowlist), `onReceivedSslError` (cancel), `onReceivedHttpError` (401/403 → logout), `onPageFinished` (inject auth + theme)
+- [ ] `app/src/webview/java/fr/datasaillance/nightfall/webview/NightfallJsInterface.kt` — interface JS→natif : `getAppVersion()`, `openImport()`, `onNightfallEvent(String)` ; toutes annotées `@JavascriptInterface`
+
+### Fichiers nouveaux (main source set)
+
+- [ ] `app/src/main/java/fr/datasaillance/nightfall/data/settings/SettingsDataStore.kt` — `EncryptedSharedPreferences` pour `backend_url` (défaut `http://10.0.2.2:8001`) et `theme_preference` (défaut `"system"`) ; validations de format
+
+### Fichiers modifiés
+
+- [ ] `app/src/webview/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt` — `WebViewScreen(url = backendUrl + "/", ...)` avec injection `tokenDataStore`, `settingsDataStore`, `onOpenImport`, `onLogout`
+- [ ] `app/src/webview/java/fr/datasaillance/nightfall/ui/screens/trends/TrendsScreen.kt` — `WebViewScreen(url = backendUrl + "/trends", ...)`
+- [ ] `app/src/webview/java/fr/datasaillance/nightfall/ui/screens/activity/ActivityScreen.kt` — `WebViewScreen(url = backendUrl + "/activity", ...)`
+- [ ] `app/src/main/res/xml/network_security_config.xml` — remplacer cleartext global par cleartext restreint à `10.0.2.2`
+- [ ] `app/src/main/AndroidManifest.xml` — `<queries>` pour Chrome Custom Tabs
+- [ ] `di/AppModule.kt` — `@Provides @Singleton SettingsDataStore`
+- [ ] `static/api.js` — ajout de `getAuthHeaders()` qui lit `window.__AUTH_TOKEN__` ; injection dans chaque `fetch` vers `/api/*` (coordination avec spec `2026-04-27-v2.3.3.2-frontend-nightfall`)
+
+### Dépendances Gradle (ajouts à `build.gradle.kts`)
+
+- [ ] `implementation("androidx.browser:browser:1.8.0")` — Chrome Custom Tabs
+- [ ] Vérifier que `androidx.security:security-crypto:1.1.0-alpha06` est déjà dans les dépendances shell (oui, per spec p4-android-shell)
+
+### Tests
+
+- [ ] `app/src/test/java/fr/datasaillance/nightfall/webview/NightfallWebViewClientTest.kt` — tests unitaires : shouldOverrideUrlLoading (URL autorisée, URL externe), onReceivedHttpError (401, 403, 200), onReceivedSslError (cancel vérifié)
+- [ ] `app/src/test/java/fr/datasaillance/nightfall/webview/NightfallJsInterfaceTest.kt` — tests unitaires : `getAppVersion()` retourne `BuildConfig.VERSION_NAME` ; `openImport()` déclenche callback ; `onNightfallEvent()` ne crash pas
+- [ ] `app/src/test/java/fr/datasaillance/nightfall/data/settings/SettingsDataStoreTest.kt` — `getBackendUrl()` retourne défaut si non défini ; `setBackendUrl()` valide le format ; `setThemePreference()` rejette valeurs invalides
+- [ ] `app/src/androidTest/java/fr/datasaillance/nightfall/webview/WebViewScreenTest.kt` — test instrumenté : WebView charge l'URL attendue ; `window.__AUTH_TOKEN__` est injecté après `onPageFinished` ; `data-theme` est `dark` ou `light`
+
+---
+
+## Tests d'acceptation
+
+**TA-WV-01 — JWT injecté au chargement de page**
+- Given : `TokenDataStore.getToken()` retourne `"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test"`
+- When : la WebView déclenche `onPageFinished` pour une URL dont l'origine correspond à `allowedOrigin`
+- Then : `NightfallWebViewClient.onPageFinished` appelle `evaluateJavascript` avec `window.__AUTH_TOKEN__='eyJ...'` ; le JWT n'apparaît jamais dans l'URL chargée ni dans les paramètres de requête
+
+**TA-WV-02 — URL externe bloquée et ouverte en Custom Tab**
+- Given : la WebView est chargée sur `https://sh-prod.datasaillance.fr/`
+- When : le frontend JS tente de naviguer vers `https://external-site.example.com`
+- Then : `shouldOverrideUrlLoading` retourne `true` (navigation bloquée dans la WebView) ; `CustomTabsIntent` est lancé avec l'URL externe ; aucun contenu de `external-site.example.com` n'est chargé dans la WebView
+
+**TA-WV-03 — Erreur HTTP 401 déclenche logout**
+- Given : la WebView charge `https://sh-prod.datasaillance.fr/` (main frame)
+- When : le serveur répond `401 Unauthorized` sur la main frame request
+- Then : `onReceivedHttpError` efface le token (`TokenDataStore.clearToken()`) ; le callback `onLogout` est invoqué ; la navigation revient à `LoginScreen` avec back stack vidé
+
+**TA-WV-04 — Erreur SSL refusée sans bypass**
+- Given : le backend utilise un certificat auto-signé ou expiré
+- When : la WebView tente d'établir la connexion TLS
+- Then : `onReceivedSslError` appelle `handler.cancel()` — jamais `handler.proceed()` ; la page ne se charge pas ; Timber.e log avec `primaryError` code
+
+**TA-WV-05 — Thème dark injecté**
+- Given : le système Android est en mode `UI_MODE_NIGHT_YES`
+- When : la WebView déclenche `onPageFinished`
+- Then : `evaluateJavascript` est appelé avec `document.documentElement.setAttribute('data-theme','dark')` ; l'attribut `data-theme` du `documentElement` vaut `"dark"`
+
+**TA-WV-06 — Thème light injecté**
+- Given : le système Android est en mode `UI_MODE_NIGHT_NO`
+- When : la WebView déclenche `onPageFinished`
+- Then : `evaluateJavascript` est appelé avec `document.documentElement.setAttribute('data-theme','light')` ; l'attribut `data-theme` du `documentElement` vaut `"light"`
+
+**TA-WV-07 — `openImport()` ouvre ImportScreen**
+- Given : `NightfallJsInterface` est attaché à la WebView avec binding `"NightfallBridge"`
+- When : le frontend JS appelle `window.NightfallBridge.openImport()`
+- Then : le callback `onOpenImport` est déclenché sur le main thread Android ; `NavController` navigue vers `"import"` ; `ImportScreen` est affiché
+
+**TA-WV-08 — URL externe ne contient pas le JWT**
+- Given : `TokenDataStore.getToken()` retourne un JWT valide
+- When : `shouldOverrideUrlLoading` intercepte une URL externe
+- Then : le JWT n'est pas inclus dans l'URL ouverte en Custom Tab (pas de paramètre `token=`, `auth=`, ou similaire)
+
+**TA-WV-09 — Token absent : pas d'injection**
+- Given : `TokenDataStore.getToken()` retourne `null`
+- When : la WebView déclenche `onPageFinished`
+- Then : `injectAuth()` retourne sans appel à `evaluateJavascript` ; aucun `window.__AUTH_TOKEN__` n'est défini dans le contexte JS de la page
+
+**TA-WV-10 — URL backend configurable**
+- Given : `SettingsDataStore.getBackendUrl()` retourne `"https://sh-dev.datasaillance.fr"`
+- When : `SleepScreen` instancie `WebViewScreen`
+- Then : `WebView.loadUrl` est appelé avec `"https://sh-dev.datasaillance.fr/"` ; `NightfallWebViewClient.allowedOrigin` vaut `"https://sh-dev.datasaillance.fr"` (sans trailing slash)
+
+**TA-WV-11 — cleartext interdit hors émulateur**
+- Given : l'app est en build release, URL backend = `"http://sh-prod.datasaillance.fr"` (HTTP, non TLS)
+- When : la WebView tente de charger l'URL
+- Then : Android OS bloque la connexion via `network_security_config.xml` (cleartext non autorisé hors `10.0.2.2`) ; la page ne se charge pas
+
+**TA-WV-12 — Changement de thème sans rechargement de page**
+- Given : la WebView a chargé le dashboard en thème `dark`
+- When : l'utilisateur change la préférence thème vers `light` dans `SettingsScreen`
+- Then : le bloc `update` de `AndroidView` est invoqué ; `evaluateJavascript("document.documentElement.setAttribute('data-theme','light')", null)` est appelé ; la WebView ne se rechargée pas (pas d'appel à `loadUrl` ou `reload`)
+
+---
+
+## Contraintes de sécurité
+
+### Surface d'attaque `@JavascriptInterface`
+
+Chaque méthode annotée `@JavascriptInterface` est appelable par n'importe quel JS exécuté dans la WebView. Le vecteur d'attaque classique est : XSS dans le frontend web → appel arbitraire à `NightfallBridge.*`.
+
+Mesures de mitigation :
+1. **Origine allowlist** (`NightfallWebViewClient.shouldOverrideUrlLoading`) : seul le contenu de `allowedOrigin` est chargé dans la WebView. Pas de contenu tiers injecté.
+2. **`setAllowFileAccess(false)` + `setAllowContentAccess(false)`** : ferme les vecteurs `file://` et `content://` qui pourraient charger du JS local non contrôlé.
+3. **Surface minimale** : 3 méthodes en Phase 4. `onNightfallEvent` est un no-op intentionnel — son seul effet est un log Timber. `openImport` est sans paramètre (pas d'injection de path). `getAppVersion` est en lecture seule.
+4. **Thread safety** : `openImport` redirige vers `Looper.getMainLooper()` — évite les race conditions sur `NavController` depuis un thread WebView.
+5. **Pas de méthode retournant des données santé** : aucune méthode `@JavascriptInterface` ne lit depuis `TokenDataStore`, `NightfallApi`, ou les données Art.9.
+
+### Politique SSL
+
+| Scénario | Comportement |
+|----------|-------------|
+| Certificat valide (CA système) | Connexion autorisée |
+| Certificat auto-signé | `handler.cancel()` — connexion refusée |
+| Certificat expiré | `handler.cancel()` — connexion refusée |
+| Certificat révoqué | `handler.cancel()` — connexion refusée |
+| HTTP (non TLS) hors `10.0.2.2` | Bloqué par `network_security_config.xml` avant même TLS |
+
+Aucune exception en production. Le bypass `handler.proceed()` est explicitement interdit — toute PR qui l'introduit est bloquée par `pentester` (severity HIGH).
+
+### Protection du JWT
+
+| Vecteur | Protection |
+|---------|-----------|
+| JWT dans URL query param | Interdit par conception — jamais passé dans `loadUrl(url?token=...)` |
+| JWT dans les logs système (`logcat`) | `injectAuth()` ne log pas le token. Timber uniquement sur erreurs |
+| JWT exfiltré via URL externe | `shouldOverrideUrlLoading` bloque les navigations hors origine ; le JWT n'est pas inclus dans les Custom Tab URLs |
+| JWT dans cache WebView | La WebView ne met pas en cache les réponses d'API (headers `Cache-Control: no-store` côté FastAPI) |
+| JWT lisible via `content://` ou `file://` | `setAllowFileAccess(false)` + `setAllowContentAccess(false)` |
+
+### Éléments à auditer par `pentester`
+
+- Liste exhaustive des méthodes `@JavascriptInterface` (toute addition non documentée = finding HIGH)
+- `shouldOverrideUrlLoading` : vérifier que la comparaison d'origine résiste à `https://allowedorigin.attacker.com` (startsWith doit matcher scheme+host+port, pas seulement un préfixe de string — implémenter via `URI` parsing, pas `String.startsWith`)
+- `injectAuth` : vérifier l'échappement du token avant interpolation dans le JS string (JSONObject.quote ou équivalent)
+- `onReceivedSslError` : vérifier l'absence de tout `handler.proceed()` dans les variantes de build
+- `network_security_config.xml` : vérifier que `base-config cleartextTrafficPermitted="false"` est bien en place
+
+---
+
+## Dépendances inter-specs
+
+| Spec | Nature de la dépendance |
+|------|------------------------|
+| `2026-05-06-p4-android-shell` | Fournit `TokenDataStore`, flavor `webview` source set, `NightfallTheme`, `isSystemInDarkTheme()` |
+| `2026-04-27-v2.3.3.2-frontend-nightfall` | Le frontend JS doit lire `window.__AUTH_TOKEN__` et l'injecter dans les `fetch` — contrat côté web |
+| `2026-05-06-p4-android-auth` | `LoginScreen` est la destination de `onLogout` callback ; le token est sauvegardé dans `TokenDataStore` après login |
+| `2026-05-06-p4-android-import` | `ImportScreen` est la destination de `NightfallBridge.openImport()` via `onOpenImport` callback |
+
+---
+
+## Suite naturelle
+
+Ce composant est la dernière pièce du flavor `webview` de Phase 4. Une fois livré et audité, la roadmap Phase 4 → 5 est :
+
+| Spec | Slug | Lien avec WebView Bridge |
+|------|------|--------------------------|
+| Auth Android | `p4-android-auth` | `onLogout` callback reçoit le token depuis `TokenDataStore.saveToken()` |
+| Import SAF | `p4-android-import` | `onOpenImport` callback de `NightfallJsInterface.openImport()` |
+| Compose Canvas natif | `p5-compose-canvas` | Remplace les `WebViewScreen` du flavor `native` par des composables Canvas réels ; le WebView Bridge reste intact dans le flavor `webview` comme fallback |
+
+Phase 5 (`p5-compose-canvas`) sera la spec qui retire la dépendance WebView pour le flavor `native` en reimplémantant hypnogramme, radial clock et timeline en Compose Canvas pur. Le WebView Bridge restera opérationnel comme fallback et pour les fonctionnalités qui n'ont pas encore d'équivalent natif.


### PR DESCRIPTION
## Ce qui entre

- **`2026-05-06-p4-android-shell`** — fondation Android : NavGraph, NightfallTheme M3, build flavors `webview`/`native`, EncryptedDataStore JWT, Retrofit + AuthInterceptor, Hilt DI (8 sections, 13 tests d'acceptation)
- **`2026-05-06-p4-android-auth`** — écrans Login / Register / ForgotPassword / AuthCallbackScreen : flow OAuth Google Custom Tabs, CookieJar httpOnly, AuthViewModel (12 sections, 12 tests d'acceptation)
- **`2026-05-06-p4-android-import`** — parcours SAF import Samsung Health : streaming OkHttp, 4 types de données, notice RGPD non-bypassable, guard ZIP bomb (12 sections, 12 tests d'acceptation)
- **`2026-05-06-p4-webview-bridge`** — pont WebView ↔ natif : injection JWT via `evaluateJavascript`, NightfallWebViewClient URL guard + SSL policy, NightfallJsInterface surface auditée, thème system (13 sections, 12 tests d'acceptation)
- **`p4-palette-compare.html`** — comparatif visuel des deux palettes (archivé, décision prise)
- **`VISION.md` + `CLAUDE.md`** — correction source de vérité design : `../Vectorizer/IdentiteVisuelle/` remplace la référence erronée à `../OpenDesign/apps/web/src/index.css` ; tokens corrigés (teal `#0e9eb0`, amber `#d37c04`, bg `#191e22`)

## Contexte

Les 4 specs sont la couche planification avant l'implémentation Phase 4. Elles s'appuient sur les 7 mockups HTML validés dans la PR #50. Le bloc shell → auth + import + webview-bridge est conçu pour être implémenté dans cet ordre (`/tdd` + `/impl` par spec).

La correction des tokens design est structurelle : la confusion entre la palette web DataSaillance (rust, OpenDesign) et la charte graphique DataSaillance/Nightfall (teal/amber/cyan, IdentiteVisuelle) aurait pollué toutes les implémentations futures.

## Checklist
- [ ] 4 specs lisibles dans `docs/vault/specs/`
- [ ] Tokens design vérifiés contre `../Vectorizer/IdentiteVisuelle/Logo/DarkMode/logo-dark.web.svg`
- [ ] Aucune dépendance circulaire entre specs (shell → auth/import/bridge, pas l'inverse)