### PR TITLE
feat(android): Phase 4 import SAF — stepper, CountingRequestBody, ZIP

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,13 +26,13 @@
 | Project scaffolding | `.gitignore`, `README.md`, `NOTES.md`, `HISTORY.md`, `ROADMAP.md` | [`6cc83dc`](#2026-02-16-6cc83dc) |
 | Phase 4 Android Shell | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/theme/NightfallTheme.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/auth/TokenDataStore.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/network/BackendUrlStore.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt`, `android-app/app/build.gradle.kts` | [`7a71b2b`](#2026-05-07-7a71b2b) |
 | Phase 4 Android Auth Screens | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt` | [`e89d409`](#2026-05-07-e89d409) |
-| Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`pending`](#2026-05-07-pending) |
+| Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`4dcf071`](#2026-05-07-4dcf071) |
 
 ---
 
 ## Changelog
 
-### 2026-05-07 `pending`
+### 2026-05-07 `4dcf071`
 feat: android: Phase 4 import SAF — ImportViewModel, CountingRequestBody, ImportRepository, ImportScreen stepper
 - ImportUiState.kt : sealed class Idle/Connecting/ConnectionFailed/Connected/Selecting/Uploading/Success/Error
 - ImportDataType.kt : enum SLEEP/HEART_RATE/STEPS/EXERCISE avec samsungFilenamePrefix, apiPath, labelRes, iconRes

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,10 +25,46 @@
 | Phase 1: Backend + DB + UI + Scripts | `server/`, `static/`, `scripts/`, `requirements.txt` | [`6200a93`](#2026-02-16-6200a93) |
 | Project scaffolding | `.gitignore`, `README.md`, `NOTES.md`, `HISTORY.md`, `ROADMAP.md` | [`6cc83dc`](#2026-02-16-6cc83dc) |
 | Phase 4 Android Shell | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/theme/NightfallTheme.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/auth/TokenDataStore.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/network/BackendUrlStore.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt`, `android-app/app/build.gradle.kts` | [`7a71b2b`](#2026-05-07-7a71b2b) |
+| Phase 4 Android Auth Screens | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt` | [`e89d409`](#2026-05-07-e89d409) |
+| Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`pending`](#2026-05-07-pending) |
 
 ---
 
 ## Changelog
+
+### 2026-05-07 `pending`
+feat: android: Phase 4 import SAF — ImportViewModel, CountingRequestBody, ImportRepository, ImportScreen stepper
+- ImportUiState.kt : sealed class Idle/Connecting/ConnectionFailed/Connected/Selecting/Uploading/Success/Error
+- ImportDataType.kt : enum SLEEP/HEART_RATE/STEPS/EXERCISE avec samsungFilenamePrefix, apiPath, labelRes, iconRes
+- ImportResult.kt : data class par type (inserted, skipped, errorMessage?)
+- CountingRequestBody.kt : OkHttp RequestBody avec CountingSink — onProgress(0f) appelé en début de writeTo (≥2 appels garantis pour petits payloads < segment OkIO)
+- ImportRepository.kt : interface mockable ; CsvEntry(uri, size) ; uploadCsv @Throws(IOException)
+- ImportRepositoryImpl.kt : extractCsvEntries via ZipInputStream avec ZIP bomb protection (200 Mo / 100 entrées max, IOException Archive trop grande) ; uploadCsv streamé via CountingRequestBody + dispatch Retrofit par type
+- ImportViewModel.kt : plain ViewModel (no Hilt — issue #52) ; checkConnection() set Connecting AVANT viewModelScope.launch (StandardTestDispatcher) ; startUpload() catch CancellationException re-throw + catch Exception par type pour succès partiel
+- ImportScreen.kt : SAF launcher rememberLauncherForActivityResult(OpenDocumentTree) → viewModel.startUpload ; ConnectedContent avec RgpdNoticeCard (surfaceVariant + border primary 4dp + AnnotatedString SemiBold URL) + bouton Sélectionner dossier ; collectAsStateWithLifecycle
+- ImportStep.kt : sealed class Connection/Selection/Upload pour stepper visuel
+- NightfallApi.kt : 4 endpoints @Multipart @POST ajoutés (importSleep/importHeartRate/importSteps/importExercise) + ImportApiResponse @Serializable
+- NavGraph.kt : route import construisant ImportViewModel(ImportRepositoryImpl(api))
+- build.gradle.kts : androidx.lifecycle:lifecycle-runtime-compose:2.8.7
+- 16 tests RED → GREEN (ImportViewModelTest 9 + CountingRequestBodyTest 7) ; 63/63 total GREEN
+- Spec p4-android-import.md : status ready, tested_by peuplé, backend endpoints hors scope Android PR
+
+### 2026-05-07 `e89d409`
+feat: android: Phase 4 auth — AuthViewModel, LoginScreen, RegisterScreen, ForgotPasswordScreen, OAuth Custom Tabs, accessibility
+- AuthViewModel (plain ViewModel, no Hilt — issue #52) : login/register/requestPasswordReset/storeTokenFromCallback/setLoginError ; Loading state synchrone avant viewModelScope.launch ; mapHttpError 401/403/409/400
+- AuthUiState.kt : sealed classes LoginUiState / RegisterUiState / ForgotPasswordUiState (Idle/Loading/Success/Error + Sent pour forgot) ; ForgotPasswordUiState.Error intentionnellement mort (anti-enum)
+- LoginScreen : AuthTextField email+password avec testTag field_email/field_password + contentDescription ; AuthPrimaryButton Se connecter testTag btn_login ; OutlinedButton Google OAuth (border Cyan500) testTag btn_google_oauth ; TextButton Mot de passe oublié testTag link_forgot_password
+- RegisterScreen : paramètre registrationToken: String? = null (injectable depuis Settings) ; validation inline mots de passe
+- ForgotPasswordScreen : formulaire remplacé par confirmation anti-enum sur ForgotPasswordUiState.Sent
+- AuthCallbackScreen : deep link nightfall://auth/callback ; setLoginError(Authentification Google échouée) + onFailure() si token absent
+- AuthTextField : toggle visibilité password (Icons.Filled.Visibility/VisibilityOff, contentDescription Afficher/Masquer)
+- AuthPrimaryButton : CircularProgressIndicator avec contentDescription Chargement en cours
+- NightfallApi : 4 endpoints auth ajoutés (login, register, requestPasswordReset, googleStart)
+- NetworkModule : CookieJar inline in-memory (JavaNetCookieJar non dispo sans okhttp-urlconnection)
+- AndroidManifest : intent-filter deep link nightfall://auth/callback autoVerify=true
+- build.gradle.kts : androidx.browser:browser:1.8.0 (Custom Tabs)
+- 20 tests RED → GREEN (AuthViewModelTest 11 + LoginScreenTest 4 + RegisterScreenTest 3 + ForgotPasswordScreenTest 2) ; 47/47 total GREEN
+- Spec p4-android-auth.md : status ready, tested_by peuplé, D7 CookieJar note, AuthModels package note, ForgotPasswordUiState.Error note, Cairo → Inter/Playfair Display
 
 ### 2026-05-07 `021ab8e`
 fix: android: Inter + Playfair Display — remplace Cairo (non DS), fonts bundlées depuis static/assets/fonts

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,10 +24,30 @@
 | Phase 2: Sleep stages + color-coded calendar + Android app | `server/`, `static/`, `scripts/`, `android-app/` | [`8d5cfb0`](#2026-02-16-8d5cfb0) |
 | Phase 1: Backend + DB + UI + Scripts | `server/`, `static/`, `scripts/`, `requirements.txt` | [`6200a93`](#2026-02-16-6200a93) |
 | Project scaffolding | `.gitignore`, `README.md`, `NOTES.md`, `HISTORY.md`, `ROADMAP.md` | [`6cc83dc`](#2026-02-16-6cc83dc) |
+| Phase 4 Android Shell | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/theme/NightfallTheme.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/auth/TokenDataStore.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/network/BackendUrlStore.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt`, `android-app/app/build.gradle.kts` | [`7a71b2b`](#2026-05-07-7a71b2b) |
 
 ---
 
 ## Changelog
+
+### 2026-05-07 `021ab8e`
+fix: android: Inter + Playfair Display — remplace Cairo (non DS), fonts bundlées depuis static/assets/fonts
+- Cairo n'est pas dans le système typographique DataSaillance — remplacé par Inter (body/UI) + Playfair Display (titres) conformément à Vectorizer/design-system/typography.md
+- Variable fonts copiées depuis static/assets/fonts/ vers android-app/app/src/main/res/font/ (inter_variable.ttf + playfair_display_variable.ttf, licence OFL)
+- FontLoadingStrategy.OptionalLocal : fallback système si R.font ne peut pas être résolu (Paparazzi JVM renderer) — évite le crash, production non affectée
+- Spec p4-android-shell.md corrigée : D8 Cairo → Playfair Display + Inter, livrables et contrainte C4 mis à jour
+
+### 2026-05-07 `7a71b2b`
+feat: android: Phase 4 shell — fr.datasaillance.nightfall, navigation, theme, EncryptedSharedPreferences, configurable backend URL
+- Clean rewrite of android-app/ from com.samsunghealth → fr.datasaillance.nightfall (7 legacy files deleted)
+- NightfallTheme: Material3 dark/light color schemes with DataSaillance tokens (teal #0E9EB0, amber #D37C04, cyan #07BCD3)
+- NavGraph: Scaffold + NavHost with 7 destinations (login, sleep, trends, activity, profile, import, settings); startDestination conditional on hasToken
+- BottomNavBar: 4-tab NavigationBar (Sommeil, Tendances, Activité, Profil) + ProfileScreen with Paramètres nav entry
+- TokenDataStore: EncryptedSharedPreferences AES256-GCM; Robolectric-only plaintext path guarded by Build.FINGERPRINT check (unreachable in production — spec C2)
+- BackendUrlStore: EncryptedSharedPreferences-backed configurable backend URL, defaults to BuildConfig.DEFAULT_BACKEND_URL (http://10.0.2.2:8001 for debug)
+- NetworkModule.provideRetrofit() reads base URL from BackendUrlStore; SettingsScreen exposes URL editing UI
+- Build: namespace fr.datasaillance.nightfall, versionName 4.0.0, flavors webview+native (rendering dimension), security-crypto + timber + okhttp-logging deps added
+- 27/27 unit tests GREEN (Paparazzi, Robolectric, MockWebServer); Hilt deferred → issue #52 (Kotlin 2.x kapt incompatibility)
 
 ### 2026-05-06 `523a981`
 chore(project): CLAUDE.md — stack, contraintes C1/C2/C3, design DataSaillance, skill chain

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
 
     // Navigation
     implementation("androidx.navigation:navigation-compose:2.8.5")

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -94,6 +94,9 @@ dependencies {
     // Logging
     implementation("com.jakewharton.timber:timber:5.0.1")
 
+    // Browser (Custom Tabs for OAuth)
+    implementation("androidx.browser:browser:1.8.0")
+
     // Core
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="nightfall" android:host="import" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="nightfall" android:host="auth" android:pathPrefix="/callback" />
+            </intent-filter>
         </activity>
     </application>
 

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt
@@ -1,0 +1,12 @@
+package fr.datasaillance.nightfall.data.http
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class LoginRequest(val email: String, val password: String)
+@Serializable data class LoginResponse(val access_token: String, val refresh_token: String, val token_type: String, val expires_in: Int)
+@Serializable data class RegisterRequest(val email: String, val password: String)
+@Serializable data class RegisterResponse(val id: String, val email: String)
+@Serializable data class PasswordResetRequest(val email: String)
+@Serializable data class StatusResponse(val status: String)
+@Serializable data class GoogleStartRequest(val return_to: String? = null)
+@Serializable data class GoogleStartResponse(val authorize_url: String)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt
@@ -1,0 +1,38 @@
+package fr.datasaillance.nightfall.data.http
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.Buffer
+import okio.BufferedSink
+import okio.ForwardingSink
+import okio.Sink
+import okio.buffer
+
+class CountingRequestBody(
+    private val delegate: RequestBody,
+    private val totalBytes: Long,
+    private val onProgress: (Float) -> Unit,
+) : RequestBody() {
+
+    override fun contentType(): MediaType? = delegate.contentType()
+
+    override fun contentLength(): Long = totalBytes
+
+    override fun writeTo(sink: BufferedSink) {
+        onProgress(0f)
+        val counted = CountingSink(sink)
+        val buffered = counted.buffer()
+        delegate.writeTo(buffered)
+        buffered.flush()
+    }
+
+    inner class CountingSink(delegate: Sink) : ForwardingSink(delegate) {
+        private var bytesWritten = 0L
+
+        override fun write(source: Buffer, byteCount: Long) {
+            super.write(source, byteCount)
+            bytesWritten += byteCount
+            onProgress((bytesWritten.toFloat() / totalBytes).coerceIn(0f, 1f))
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
@@ -1,10 +1,16 @@
 package fr.datasaillance.nightfall.data.http
 
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
+
+@kotlinx.serialization.Serializable
+data class ImportApiResponse(val inserted: Int, val skipped: Int)
 
 interface NightfallApi {
     @GET("health")
@@ -21,4 +27,20 @@ interface NightfallApi {
 
     @POST("auth/google/start")
     suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
+
+    @Multipart
+    @POST("api/sleep/import")
+    suspend fun importSleep(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/heartrate/import")
+    suspend fun importHeartRate(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/steps/import")
+    suspend fun importSteps(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/exercise/import")
+    suspend fun importExercise(@Part file: MultipartBody.Part): ImportApiResponse
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
@@ -1,9 +1,24 @@
 package fr.datasaillance.nightfall.data.http
 
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
 
 interface NightfallApi {
     @GET("health")
     suspend fun health(): Response<Unit>
+
+    @POST("auth/login")
+    suspend fun login(@Body body: LoginRequest): LoginResponse
+
+    @POST("auth/register")
+    suspend fun register(@Body body: RegisterRequest, @Header("X-Registration-Token") registrationToken: String?): RegisterResponse
+
+    @POST("auth/password/reset/request")
+    suspend fun requestPasswordReset(@Body body: PasswordResetRequest): StatusResponse
+
+    @POST("auth/google/start")
+    suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt
@@ -1,0 +1,27 @@
+package fr.datasaillance.nightfall.data.import_
+
+import android.content.ContentResolver
+import android.net.Uri
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
+import java.io.IOException
+
+data class CsvEntry(val uri: Uri, val size: Long)
+
+interface ImportRepository {
+    suspend fun pingBackend(): Boolean
+
+    suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry>
+
+    @Throws(IOException::class)
+    suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
@@ -1,0 +1,124 @@
+package fr.datasaillance.nightfall.data.import_
+
+import android.content.ContentResolver
+import android.net.Uri
+import fr.datasaillance.nightfall.data.http.CountingRequestBody
+import fr.datasaillance.nightfall.data.http.ImportApiResponse
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.zip.ZipInputStream
+
+private const val MAX_UNCOMPRESSED_BYTES = 200_000_000L
+private const val MAX_ZIP_ENTRIES = 100
+
+class ImportRepositoryImpl(
+    private val api: NightfallApi,
+) : ImportRepository {
+
+    override suspend fun pingBackend(): Boolean {
+        return try {
+            val response = api.health()
+            response.isSuccessful
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private val zipEntryCache = mutableMapOf<ImportDataType, ByteArray>()
+
+    override suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry> {
+        zipEntryCache.clear()
+        return try {
+            extractFromZip(contentResolver, treeUri)
+        } catch (e: IOException) {
+            emptyMap()
+        }
+    }
+
+    private fun extractFromZip(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry> {
+        val result = mutableMapOf<ImportDataType, CsvEntry>()
+        val inputStream = contentResolver.openInputStream(treeUri)
+            ?: throw IOException("Cannot open URI")
+
+        var totalUncompressed = 0L
+        var entryCount = 0
+
+        ZipInputStream(inputStream).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                if (entryCount >= MAX_ZIP_ENTRIES) {
+                    throw IOException("Archive trop grande: dépasse $MAX_ZIP_ENTRIES entrées")
+                }
+                entryCount++
+
+                val name = entry.name.substringAfterLast('/')
+                val matchingType = ImportDataType.entries.firstOrNull { type ->
+                    name.startsWith(type.samsungFilenamePrefix) && name.endsWith(".csv")
+                }
+
+                if (matchingType != null && matchingType !in result) {
+                    val baos = ByteArrayOutputStream()
+                    val buffer = ByteArray(8192)
+                    var read: Int
+                    while (zis.read(buffer).also { read = it } != -1) {
+                        totalUncompressed += read
+                        if (totalUncompressed > MAX_UNCOMPRESSED_BYTES) {
+                            throw IOException("Archive trop grande: dépasse ${MAX_UNCOMPRESSED_BYTES / 1_000_000} Mo décompressés")
+                        }
+                        baos.write(buffer, 0, read)
+                    }
+                    val bytes = baos.toByteArray()
+                    zipEntryCache[matchingType] = bytes
+                    result[matchingType] = CsvEntry(uri = treeUri, size = bytes.size.toLong())
+                }
+
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+        return result
+    }
+
+    override suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult {
+        val bytes = zipEntryCache[type]
+            ?: run {
+                contentResolver.openInputStream(uri)?.readBytes()
+                    ?: throw IOException("Cannot read file for $type")
+            }
+
+        val mediaType = "text/csv".toMediaType()
+        val requestBody = bytes.toRequestBody(mediaType)
+        val countingBody = CountingRequestBody(
+            delegate = requestBody,
+            totalBytes = totalBytes,
+            onProgress = onProgress,
+        )
+        val part = MultipartBody.Part.createFormData("file", "${type.samsungFilenamePrefix}.csv", countingBody)
+
+        val response: ImportApiResponse = when (type) {
+            ImportDataType.SLEEP -> api.importSleep(part)
+            ImportDataType.HEART_RATE -> api.importHeartRate(part)
+            ImportDataType.STEPS -> api.importSteps(part)
+            ImportDataType.EXERCISE -> api.importExercise(part)
+        }
+        return ImportResult(type = type, inserted = response.inserted, skipped = response.skipped)
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt
@@ -6,6 +6,9 @@ import fr.datasaillance.nightfall.data.http.AuthInterceptor
 import fr.datasaillance.nightfall.data.http.NightfallApi
 import fr.datasaillance.nightfall.data.network.BackendUrlStore
 import kotlinx.serialization.json.Json
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -19,6 +22,14 @@ object NetworkModule {
     fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient =
         OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
+            .cookieJar(object : CookieJar {
+                private val cookieStore = mutableMapOf<String, List<Cookie>>()
+                override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+                    cookieStore[url.host] = cookies
+                }
+                override fun loadForRequest(url: HttpUrl): List<Cookie> =
+                    cookieStore[url.host] ?: emptyList()
+            })
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .build()

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
@@ -1,0 +1,35 @@
+package fr.datasaillance.nightfall.domain.import_
+
+import fr.datasaillance.nightfall.R
+
+enum class ImportDataType(
+    val samsungFilenamePrefix: String,
+    val apiPath: String,
+    val labelRes: Int,
+    val iconRes: Int,
+) {
+    SLEEP(
+        samsungFilenamePrefix = "com.samsung.health.sleep",
+        apiPath = "api/sleep/import",
+        labelRes = R.string.import_type_sleep,
+        iconRes = R.drawable.ic_import_sleep,
+    ),
+    HEART_RATE(
+        samsungFilenamePrefix = "com.samsung.health.heart_rate",
+        apiPath = "api/heartrate/import",
+        labelRes = R.string.import_type_heartrate,
+        iconRes = R.drawable.ic_import_heartrate,
+    ),
+    STEPS(
+        samsungFilenamePrefix = "com.samsung.health.step_daily_trend",
+        apiPath = "api/steps/import",
+        labelRes = R.string.import_type_steps,
+        iconRes = R.drawable.ic_import_steps,
+    ),
+    EXERCISE(
+        samsungFilenamePrefix = "com.samsung.health.exercise",
+        apiPath = "api/exercise/import",
+        labelRes = R.string.import_type_exercise,
+        iconRes = R.drawable.ic_import_exercise,
+    ),
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt
@@ -1,0 +1,8 @@
+package fr.datasaillance.nightfall.domain.import_
+
+data class ImportResult(
+    val type: ImportDataType,
+    val inserted: Int,
+    val skipped: Int,
+    val errorMessage: String? = null,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
@@ -1,0 +1,17 @@
+package fr.datasaillance.nightfall.domain.import_
+
+sealed class ImportUiState {
+    object Idle : ImportUiState()
+    object Connecting : ImportUiState()
+    data class ConnectionFailed(val message: String) : ImportUiState()
+    object Connected : ImportUiState()
+    object Selecting : ImportUiState()
+    data class Uploading(
+        val currentType: ImportDataType,
+        val progress: Float,
+        val completedTypes: List<ImportDataType>,
+        val skippedTypes: List<ImportDataType>,
+    ) : ImportUiState()
+    data class Success(val results: List<ImportResult>) : ImportUiState()
+    data class Error(val message: String, val retryable: Boolean) : ImportUiState()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -1,16 +1,25 @@
 package fr.datasaillance.nightfall.ui.navigation
 
+import android.content.ContentResolver
+import android.net.Uri
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.DialogNavigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.ComposeNavigator
-import androidx.navigation.compose.DialogNavigator
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.import_.CsvEntry
+import fr.datasaillance.nightfall.data.import_.ImportRepository
+import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
 import fr.datasaillance.nightfall.ui.screens.import_.ImportScreen
 import fr.datasaillance.nightfall.ui.screens.login.LoginScreen
@@ -18,13 +27,15 @@ import fr.datasaillance.nightfall.ui.screens.profile.ProfileScreen
 import fr.datasaillance.nightfall.ui.screens.settings.SettingsScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
 import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
+import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
 
 @Composable
 fun NavGraph(
     navController: NavHostController,
     hasToken: Boolean,
     backendUrl: String = "",
-    onSaveUrl: (String) -> Unit = {}
+    onSaveUrl: (String) -> Unit = {},
+    api: NightfallApi? = null,
 ) {
     val startDestination = if (hasToken) NavDestination.Sleep.route else NavDestination.Login.route
 
@@ -80,7 +91,20 @@ fun NavGraph(
                     }
                 )
             }
-            composable(NavDestination.Import.route) { ImportScreen() }
+            composable(NavDestination.Import.route) {
+                val repository: ImportRepository = remember {
+                    if (api != null) {
+                        ImportRepositoryImpl(api)
+                    } else {
+                        NoOpImportRepository()
+                    }
+                }
+                val viewModel = remember { ImportViewModel(repository) }
+                ImportScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = { navController.popBackStack() },
+                )
+            }
             composable(NavDestination.Settings.route) {
                 SettingsScreen(
                     currentUrl = backendUrl,
@@ -89,6 +113,23 @@ fun NavGraph(
             }
         }
     }
+}
+
+private class NoOpImportRepository : ImportRepository {
+    override suspend fun pingBackend(): Boolean = false
+
+    override suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry> = emptyMap()
+
+    override suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult = throw UnsupportedOperationException("No-op repository")
 }
 
 /**

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt
@@ -1,0 +1,35 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+
+@Composable
+fun AuthCallbackScreen(
+    token: String?,
+    viewModel: AuthViewModel,
+    onSuccess: () -> Unit,
+    onFailure: () -> Unit
+) {
+    LaunchedEffect(Unit) {
+        if (!token.isNullOrBlank()) {
+            viewModel.storeTokenFromCallback(token)
+            onSuccess()
+        } else {
+            viewModel.setLoginError("Authentification Google échouée")
+            onFailure()
+        }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt
@@ -1,0 +1,106 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.collectAsState
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthPrimaryButton
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthTextField
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+import fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState
+
+@Composable
+fun ForgotPasswordScreen(
+    viewModel: AuthViewModel,
+    onBack: () -> Unit
+) {
+    val forgotState by viewModel.forgotState.collectAsState()
+
+    var email by remember { mutableStateOf("") }
+
+    val isLoading = forgotState is ForgotPasswordUiState.Loading
+    val isSent = forgotState is ForgotPasswordUiState.Sent
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (isSent) {
+                Text(
+                    text = "Un email a été envoyé si ce compte existe.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                TextButton(onClick = onBack) {
+                    Text(
+                        text = "Retour à la connexion",
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+            } else {
+                Text(
+                    text = "Réinitialiser le mot de passe",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                AuthTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = "Email",
+                    enabled = !isLoading,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                AuthPrimaryButton(
+                    text = "Envoyer le lien",
+                    onClick = { viewModel.requestPasswordReset(email) },
+                    isLoading = isLoading,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TextButton(onClick = onBack) {
+                    Text(
+                        text = "Retour à la connexion",
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
@@ -1,0 +1,170 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthErrorMessage
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthPrimaryButton
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthTextField
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+import fr.datasaillance.nightfall.viewmodel.auth.LoginUiState
+import kotlinx.coroutines.launch
+
+@Composable
+fun LoginScreen(
+    viewModel: AuthViewModel,
+    onLoginSuccess: () -> Unit,
+    onNavigateRegister: () -> Unit,
+    onNavigateForgotPassword: () -> Unit
+) {
+    val loginState by viewModel.loginState.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    LaunchedEffect(loginState) {
+        if (loginState is LoginUiState.Success) {
+            onLoginSuccess()
+        }
+    }
+
+    val isLoading = loginState is LoginUiState.Loading
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Connexion",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            AuthTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = "Email",
+                enabled = !isLoading,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                modifier = Modifier.fillMaxWidth().semantics {
+                    testTag = "field_email"
+                    contentDescription = "Adresse email"
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = "Mot de passe",
+                isPassword = true,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth().semantics {
+                    testTag = "field_password"
+                    contentDescription = "Mot de passe"
+                }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (loginState is LoginUiState.Error) {
+                AuthErrorMessage(
+                    message = (loginState as LoginUiState.Error).message,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthPrimaryButton(
+                text = "Se connecter",
+                onClick = { viewModel.login(email, password) },
+                isLoading = isLoading,
+                modifier = Modifier.fillMaxWidth().semantics { testTag = "btn_login" }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val url = viewModel.getGoogleStartUrl()
+                        if (url != null) {
+                            CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(url))
+                        }
+                    }
+                },
+                enabled = !isLoading,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.tertiary
+                ),
+                modifier = Modifier.fillMaxWidth().semantics { testTag = "btn_google_oauth" }
+            ) {
+                Text("Continuer avec Google")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            TextButton(
+                onClick = onNavigateForgotPassword,
+                modifier = Modifier.semantics { testTag = "link_forgot_password" }
+            ) {
+                Text(
+                    text = "Mot de passe oublié ?",
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            }
+
+            TextButton(onClick = onNavigateRegister) {
+                Text(
+                    text = "Créer un compte",
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt
@@ -1,0 +1,130 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.collectAsState
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthErrorMessage
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthPrimaryButton
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthTextField
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+import fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState
+
+@Composable
+fun RegisterScreen(
+    viewModel: AuthViewModel,
+    onRegisterSuccess: () -> Unit,
+    registrationToken: String? = null
+) {
+    val registerState by viewModel.registerState.collectAsState()
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
+
+    LaunchedEffect(registerState) {
+        if (registerState is RegisterUiState.Success) {
+            onRegisterSuccess()
+        }
+    }
+
+    val isLoading = registerState is RegisterUiState.Loading
+    val passwordsMatch = password == confirmPassword && password.isNotEmpty()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Créer un compte",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            AuthTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = "Email",
+                enabled = !isLoading,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = "Mot de passe",
+                isPassword = true,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthTextField(
+                value = confirmPassword,
+                onValueChange = { confirmPassword = it },
+                label = "Confirmer le mot de passe",
+                isPassword = true,
+                isError = confirmPassword.isNotEmpty() && !passwordsMatch,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            if (confirmPassword.isNotEmpty() && !passwordsMatch) {
+                Spacer(modifier = Modifier.height(8.dp))
+                AuthErrorMessage(
+                    message = "Les mots de passe ne correspondent pas",
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            if (registerState is RegisterUiState.Error) {
+                Spacer(modifier = Modifier.height(8.dp))
+                AuthErrorMessage(
+                    message = (registerState as RegisterUiState.Error).message,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            AuthPrimaryButton(
+                text = "S'inscrire",
+                onClick = { viewModel.register(email, password, registrationToken = registrationToken) },
+                isLoading = isLoading,
+                enabled = passwordsMatch,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt
@@ -1,0 +1,23 @@
+package fr.datasaillance.nightfall.ui.screens.auth.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+
+@Composable
+fun AuthErrorMessage(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = message,
+        color = MaterialTheme.colorScheme.error,
+        modifier = modifier.semantics {
+            liveRegion = LiveRegionMode.Polite
+        }
+    )
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt
@@ -1,0 +1,38 @@
+package fr.datasaillance.nightfall.ui.screens.auth.components
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+
+@Composable
+fun AuthPrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled && !isLoading,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondary
+        )
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.onSecondary,
+                modifier = Modifier.semantics { contentDescription = "Chargement en cours" }
+            )
+        } else {
+            Text(text)
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt
@@ -1,0 +1,54 @@
+package fr.datasaillance.nightfall.ui.screens.auth.components
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+
+@Composable
+fun AuthTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    isPassword: Boolean = false,
+    isError: Boolean = false,
+    enabled: Boolean = true,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default
+) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        modifier = modifier,
+        isError = isError,
+        enabled = enabled,
+        visualTransformation = if (isPassword && !passwordVisible) PasswordVisualTransformation() else VisualTransformation.None,
+        keyboardOptions = keyboardOptions,
+        singleLine = true,
+        trailingIcon = if (isPassword) {
+            {
+                val icon = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                val desc = if (passwordVisible) "Masquer le mot de passe" else "Afficher le mot de passe"
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(imageVector = icon, contentDescription = desc)
+                }
+            }
+        } else null
+    )
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt
@@ -1,9 +1,365 @@
 package fr.datasaillance.nightfall.ui.screens.import_
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.datasaillance.nightfall.R
+import fr.datasaillance.nightfall.domain.import_.ImportUiState
+import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportScreen(
+    viewModel: ImportViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let { viewModel.startUpload(context.contentResolver, it) }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.import_step_upload)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Retour")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val state = uiState) {
+            is ImportUiState.Idle -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                IdleContent(onCheckConnection = { viewModel.checkConnection() })
+            }
+            is ImportUiState.Connecting -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ConnectingContent()
+            }
+            is ImportUiState.ConnectionFailed -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ConnectionFailedContent(
+                    message = state.message,
+                    onRetry = { viewModel.checkConnection() },
+                )
+            }
+            is ImportUiState.Connected -> ConnectedContent(
+                onSelectFolder = { launcher.launch(null) },
+                padding = padding,
+            )
+            is ImportUiState.Selecting -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                SelectingContent()
+            }
+            is ImportUiState.Uploading -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                UploadingContent(
+                    currentType = stringResource(state.currentType.labelRes),
+                    progress = state.progress,
+                    completedCount = state.completedTypes.size,
+                    totalCount = state.completedTypes.size + state.skippedTypes.size + 1,
+                )
+            }
+            is ImportUiState.Success -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                SuccessContent(
+                    results = state.results,
+                    onDone = {
+                        viewModel.reset()
+                        onNavigateBack()
+                    },
+                )
+            }
+            is ImportUiState.Error -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ErrorContent(
+                    message = state.message,
+                    retryable = state.retryable,
+                    onRetry = { viewModel.reset() },
+                    onBack = onNavigateBack,
+                )
+            }
+        }
+    }
+}
 
 @Composable
-fun ImportScreen() {
-    Text("Import — p4-android-import")
+private fun IdleContent(onCheckConnection: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Importer des données Samsung Health",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onCheckConnection) {
+            Text("Vérifier la connexion")
+        }
+    }
+}
+
+@Composable
+private fun ConnectingContent() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Connexion au serveur…")
+    }
+}
+
+@Composable
+private fun ConnectionFailedContent(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onRetry) {
+            Text("Réessayer")
+        }
+    }
+}
+
+@Composable
+private fun ConnectedContent(
+    onSelectFolder: () -> Unit,
+    padding: PaddingValues,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            "Connexion établie",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        RgpdNoticeCard()
+        Button(
+            onClick = onSelectFolder,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Sélectionner le dossier Samsung Health")
+        }
+    }
+}
+
+@Composable
+private fun RgpdNoticeCard() {
+    val primary = MaterialTheme.colorScheme.primary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.small,
+            )
+            .drawBehind {
+                drawRect(color = primary, size = size.copy(width = 4.dp.toPx()))
+            }
+            .padding(start = 12.dp, top = 12.dp, end = 12.dp, bottom = 12.dp),
+    ) {
+        Text(
+            text = buildAnnotatedString {
+                append("Ces données sont envoyées uniquement vers ")
+                withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = primary)) {
+                    append("votre serveur")
+                }
+                append(". Elles ne transitent par aucun serveur tiers. Aucune copie n'est conservée sur cet appareil après l'import.")
+            },
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun SelectingContent() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("Sélectionnez le dossier Samsung Health…")
+    }
+}
+
+@Composable
+private fun UploadingContent(
+    currentType: String,
+    progress: Float,
+    completedCount: Int,
+    totalCount: Int,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Import en cours : $currentType",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "$completedCount / $totalCount types traités",
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun SuccessContent(
+    results: List<fr.datasaillance.nightfall.domain.import_.ImportResult>,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Import terminé",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        results.forEach { result ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(result.type.name)
+                if (result.errorMessage != null) {
+                    Text("Erreur", color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("${result.inserted} insérés, ${result.skipped} ignorés")
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onDone) {
+            Text("Terminer")
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    retryable: Boolean,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        if (retryable) {
+            Button(onClick = onRetry) {
+                Text("Réessayer")
+            }
+        } else {
+            Button(onClick = onBack) {
+                Text("Retour")
+            }
+        }
+    }
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt
@@ -1,0 +1,7 @@
+package fr.datasaillance.nightfall.ui.screens.import_
+
+sealed class ImportStep(val index: Int, val label: String) {
+    object Connection : ImportStep(1, "Connexion")
+    object Selection  : ImportStep(2, "Sélection")
+    object Upload     : ImportStep(3, "Import")
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt
@@ -1,0 +1,22 @@
+package fr.datasaillance.nightfall.viewmodel.auth
+
+sealed class LoginUiState {
+    object Idle : LoginUiState()
+    object Loading : LoginUiState()
+    object Success : LoginUiState()
+    data class Error(val message: String) : LoginUiState()
+}
+
+sealed class RegisterUiState {
+    object Idle : RegisterUiState()
+    object Loading : RegisterUiState()
+    object Success : RegisterUiState()
+    data class Error(val message: String) : RegisterUiState()
+}
+
+sealed class ForgotPasswordUiState {
+    object Idle : ForgotPasswordUiState()
+    object Loading : ForgotPasswordUiState()
+    object Sent : ForgotPasswordUiState()
+    data class Error(val message: String) : ForgotPasswordUiState()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt
@@ -1,0 +1,94 @@
+package fr.datasaillance.nightfall.viewmodel.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.GoogleStartRequest
+import fr.datasaillance.nightfall.data.http.LoginRequest
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.http.PasswordResetRequest
+import fr.datasaillance.nightfall.data.http.RegisterRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+class AuthViewModel(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore
+) : ViewModel() {
+
+    private val _loginState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
+    val loginState: StateFlow<LoginUiState> = _loginState.asStateFlow()
+
+    private val _registerState = MutableStateFlow<RegisterUiState>(RegisterUiState.Idle)
+    val registerState: StateFlow<RegisterUiState> = _registerState.asStateFlow()
+
+    private val _forgotState = MutableStateFlow<ForgotPasswordUiState>(ForgotPasswordUiState.Idle)
+    val forgotState: StateFlow<ForgotPasswordUiState> = _forgotState.asStateFlow()
+
+    fun login(email: String, password: String) {
+        _loginState.value = LoginUiState.Loading
+        viewModelScope.launch {
+            try {
+                val response = api.login(LoginRequest(email, password))
+                tokenDataStore.saveToken(response.access_token)
+                _loginState.value = LoginUiState.Success
+            } catch (e: retrofit2.HttpException) {
+                _loginState.value = LoginUiState.Error(mapHttpError(e.code()))
+            } catch (e: IOException) {
+                _loginState.value = LoginUiState.Error("Vérifiez votre connexion réseau")
+            }
+        }
+    }
+
+    fun register(email: String, password: String, registrationToken: String?) {
+        _registerState.value = RegisterUiState.Loading
+        viewModelScope.launch {
+            try {
+                api.register(RegisterRequest(email, password), registrationToken)
+                _registerState.value = RegisterUiState.Success
+            } catch (e: retrofit2.HttpException) {
+                _registerState.value = RegisterUiState.Error(mapHttpError(e.code()))
+            } catch (e: IOException) {
+                _registerState.value = RegisterUiState.Error("Vérifiez votre connexion réseau")
+            }
+        }
+    }
+
+    fun requestPasswordReset(email: String) {
+        _forgotState.value = ForgotPasswordUiState.Loading
+        viewModelScope.launch {
+            try {
+                api.requestPasswordReset(PasswordResetRequest(email))
+            } catch (e: Exception) {
+                // intentional fall-through — anti-enum: always emit Sent
+            }
+            _forgotState.value = ForgotPasswordUiState.Sent
+        }
+    }
+
+    suspend fun getGoogleStartUrl(): String? = try {
+        api.googleStart(GoogleStartRequest()).authorize_url
+    } catch (e: Exception) {
+        null
+    }
+
+    fun storeTokenFromCallback(token: String) {
+        tokenDataStore.saveToken(token)
+        _loginState.value = LoginUiState.Success
+    }
+
+    fun setLoginError(message: String) {
+        _loginState.value = LoginUiState.Error(message)
+    }
+
+    private fun mapHttpError(code: Int): String = when (code) {
+        401 -> "Email ou mot de passe incorrect"
+        403 -> "Email non vérifié — consultez votre boîte mail"
+        409 -> "Cette adresse email est déjà utilisée"
+        400 -> "Mot de passe trop faible (12 caractères minimum, majuscule, chiffre, symbole)"
+        else -> "Erreur serveur ($code)"
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
@@ -1,0 +1,99 @@
+package fr.datasaillance.nightfall.viewmodel.import_
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.import_.ImportRepository
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
+import fr.datasaillance.nightfall.domain.import_.ImportUiState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ImportViewModel(
+    private val repository: ImportRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ImportUiState>(ImportUiState.Idle)
+    val uiState: StateFlow<ImportUiState> = _uiState.asStateFlow()
+
+    fun checkConnection() {
+        _uiState.value = ImportUiState.Connecting
+        viewModelScope.launch {
+            val ok = repository.pingBackend()
+            _uiState.value = if (ok) {
+                ImportUiState.Connected
+            } else {
+                ImportUiState.ConnectionFailed("Backend inaccessible — vérifiez l'URL dans les paramètres")
+            }
+        }
+    }
+
+    fun startUpload(contentResolver: ContentResolver, treeUri: Uri) {
+        viewModelScope.launch {
+            val csvEntries = repository.extractCsvEntries(contentResolver, treeUri)
+            if (csvEntries.isEmpty()) {
+                _uiState.value = ImportUiState.Error(
+                    message = "Aucun fichier Samsung Health reconnu dans l'archive.",
+                    retryable = true,
+                )
+                return@launch
+            }
+            val results = mutableListOf<ImportResult>()
+            val completed = mutableListOf<ImportDataType>()
+            val skipped = mutableListOf<ImportDataType>()
+
+            for (type in ImportDataType.entries) {
+                val entry = csvEntries[type]
+                if (entry == null) {
+                    skipped.add(type)
+                    continue
+                }
+                try {
+                    _uiState.value = ImportUiState.Uploading(
+                        currentType = type,
+                        progress = 0f,
+                        completedTypes = completed.toList(),
+                        skippedTypes = skipped.toList(),
+                    )
+                    val result = repository.uploadCsv(
+                        contentResolver = contentResolver,
+                        uri = entry.uri,
+                        type = type,
+                        totalBytes = entry.size,
+                        onProgress = { progress ->
+                            _uiState.value = ImportUiState.Uploading(
+                                currentType = type,
+                                progress = progress,
+                                completedTypes = completed.toList(),
+                                skippedTypes = skipped.toList(),
+                            )
+                        },
+                    )
+                    results.add(result)
+                    completed.add(type)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    results.add(
+                        ImportResult(
+                            type = type,
+                            inserted = 0,
+                            skipped = 0,
+                            errorMessage = e.message,
+                        )
+                    )
+                }
+            }
+            _uiState.value = ImportUiState.Success(results)
+        }
+    }
+
+    fun reset() {
+        _uiState.value = ImportUiState.Idle
+    }
+}

--- a/android-app/app/src/main/res/drawable/ic_import_exercise.xml
+++ b/android-app/app/src/main/res/drawable/ic_import_exercise.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M20.57,14.86L22,13.43 20.57,12 17,15.57 8.43,7 12,3.43 10.57,2 9.14,3.43 7.71,2 5.57,4.14 4.14,2.71 2.71,4.14l1.43,1.43 -2.14,2.14 1.43,1.43L2,10.57 3.43,12 7,8.43 15.57,17 12,20.57 13.43,22l1.43,-1.43L16.29,22l2.14,-2.14 1.43,1.43 1.43,-1.43 -1.43,-1.43 2.14,-2.14z"/>
+</vector>

--- a/android-app/app/src/main/res/drawable/ic_import_heartrate.xml
+++ b/android-app/app/src/main/res/drawable/ic_import_heartrate.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78-3.4,6.86-8.55,11.54L12,21.35z"/>
+</vector>

--- a/android-app/app/src/main/res/drawable/ic_import_sleep.xml
+++ b/android-app/app/src/main/res/drawable/ic_import_sleep.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M12,3a9,9 0,1 0,9,9A9,9 0,0 0,12,3zm0,16a7,7 0,1 1,7,-7A7,7 0,0 1,12,19zm1,-11h-2v6l5,3 1,-1.73 -4,-2.27z"/>
+</vector>

--- a/android-app/app/src/main/res/drawable/ic_import_steps.xml
+++ b/android-app/app/src/main/res/drawable/ic_import_steps.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/black"
+        android:pathData="M13.49,5.48c1.1,0 2,-0.9 2,-2s-0.9,-2 -2,-2 -2,0.9 -2,2 0.9,2 2,2zM9.89,19.38l1,-4.4 2.1,2v6h2v-7.5l-2.1,-2 0.6,-3c1.3,1.5 3.3,2.5 5.5,2.5v-2c-1.9,0 -3.5,-1 -4.3,-2.4l-1,-1.6c-0.4,-0.6 -1,-1 -1.7,-1 -0.3,0 -0.5,0.1 -0.8,0.1l-5.2,2.2v4.7h2v-3.4l1.8,-0.7 -1.6,8.1 -4.9,-1 -0.4,2 7,1.4z"/>
+</vector>

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">Nightfall</string>
+    <string name="import_type_sleep">Sommeil</string>
+    <string name="import_type_heartrate">Fréquence cardiaque</string>
+    <string name="import_type_steps">Pas</string>
+    <string name="import_type_exercise">Exercice</string>
+    <string name="import_rgpd_notice">Ces données sont envoyées uniquement vers %1$s. Elles ne transitent par aucun serveur tiers. Aucune copie n\'est conservée sur cet appareil après l\'import.</string>
+    <string name="import_step_connection">Connexion</string>
+    <string name="import_step_selection">Sélection</string>
+    <string name="import_step_upload">Import</string>
 </resources>

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt
@@ -1,0 +1,182 @@
+package fr.datasaillance.nightfall.data.http
+
+// spec: Tests d'acceptation TA-06
+// spec: section "CountingRequestBody" + "Architecture" + "D3 / D9"
+// RED by construction: fr.datasaillance.nightfall.data.http.CountingRequestBody does not exist yet
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// This import will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.data.http.CountingRequestBody
+
+class CountingRequestBodyTest {
+
+    // spec: TA-06 — onProgress is called at least twice when writing in chunks
+    @Test
+    fun writeTo_onProgressCalledAtLeastTwice() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — onProgress must be invoked at least twice (at least one intermediate + final)
+        assert(progressValues.size >= 2) {
+            "onProgress must be called at least twice during writeTo — spec: TA-06, called ${progressValues.size} times"
+        }
+    }
+
+    // spec: TA-06 — last onProgress value is 1.0f
+    @Test
+    fun writeTo_lastProgressValueIsOne() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — the last callback value must be exactly 1.0f
+        val lastProgress = progressValues.last()
+        assertEquals(
+            "Last onProgress value must be 1.0f — spec: TA-06",
+            1.0f,
+            lastProgress,
+            0.0001f,
+        )
+    }
+
+    // spec: TA-06 — no onProgress value exceeds 1.0f
+    @Test
+    fun writeTo_noProgressValueExceedsOne() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — progress is coerced via coerceIn(0f, 1f); no value must exceed 1.0f
+        val exceeded = progressValues.filter { it > 1.0f }
+        assertTrue(
+            "No onProgress value must exceed 1.0f — spec: TA-06, violations: $exceeded",
+            exceeded.isEmpty(),
+        )
+    }
+
+    // spec: D9 / TA-06 — contentLength() returns totalBytes
+    @Test
+    fun contentLength_returnsTotalBytes() {
+        val content = ByteArray(500) { 0x00.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val totalBytes = 1234L  // intentionally different from content size to verify delegation
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = totalBytes,
+            onProgress = {},
+        )
+
+        // spec: D9 — contentLength() must return the totalBytes constructor parameter, not delegate.contentLength()
+        assertEquals(
+            "contentLength() must return totalBytes passed to constructor — spec: D9 / TA-06",
+            totalBytes,
+            counting.contentLength(),
+        )
+    }
+
+    // spec: TA-06 — contentType() delegates to the wrapped RequestBody
+    @Test
+    fun contentType_delegatesToWrappedBody() {
+        val content = ByteArray(100) { 0x00.toByte() }
+        val mediaType = "text/csv".toMediaType()
+        val delegate = content.toRequestBody(mediaType)
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 100L,
+            onProgress = {},
+        )
+
+        // spec: TA-06 — contentType() must return the same MediaType as the delegate
+        val returned = counting.contentType()
+        assertEquals(
+            "contentType() must delegate to wrapped RequestBody — spec: TA-06",
+            mediaType.toString(),
+            returned?.toString(),
+        )
+    }
+
+    // spec: TA-06 — all bytes are written to the sink (no truncation)
+    @Test
+    fun writeTo_allBytesWrittenToSink() {
+        val content = ByteArray(1000) { it.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = {},
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: D3 — streaming must not truncate bytes; all content must be written
+        assertEquals(
+            "writeTo must write all bytes to sink — spec: D3 / TA-06",
+            1000L,
+            sink.size,
+        )
+    }
+
+    // spec: TA-06 (edge) — progress values are monotonically non-decreasing
+    @Test
+    fun writeTo_progressIsMonotonicallyNonDecreasing() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — each progress value must be >= the previous one (monotonic progress)
+        for (i in 1 until progressValues.size) {
+            assertTrue(
+                "onProgress values must be non-decreasing — spec: TA-06, index $i: ${progressValues[i - 1]} → ${progressValues[i]}",
+                progressValues[i] >= progressValues[i - 1],
+            )
+        }
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt
@@ -1,0 +1,71 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+// spec: Tests d'acceptation TA-AUTH-07
+// spec: section "ForgotPasswordScreen" layout + "Parité light / dark mode"
+// RED by construction: fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen does not exist yet
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+
+class ForgotPasswordScreenTest {
+
+    // spec: D10 — Paparazzi offline screenshot tests
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        // spec: D1 — AuthViewModel constructed directly without Hilt (issue #52)
+        return fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    // spec: TA-AUTH-07 — ForgotPasswordScreen dark mode, state = ForgotPasswordUiState.Idle
+    // spec: section "ForgotPasswordScreen" — titre, champ email, bouton "Envoyer le lien"
+    @Test
+    fun forgotPasswordScreen_idle_dark() {
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen(
+                    viewModel = viewModel,
+                    onBack = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-07 — Idle state: titre visible, AuthTextField email, bouton "Envoyer le lien"
+    }
+
+    // spec: TA-AUTH-07 — ForgotPasswordScreen dark mode, state = ForgotPasswordUiState.Sent
+    // spec: section "ForgotPasswordScreen" — "Un email a été envoyé si ce compte existe." (anti-enum)
+    @Test
+    fun forgotPasswordScreen_sent_dark() {
+        // spec: TA-AUTH-07 — anti-enum: same confirmation message regardless of whether account exists
+        // The Screen replaces the form with a confirmation message when forgotState == Sent
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen(
+                    viewModel = viewModel,
+                    onBack = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-07 — Sent state: form replaced by "Un email a été envoyé si ce compte existe."
+        // spec: TA-AUTH-07 — TextButton "Retour à la connexion" remains visible
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
@@ -1,0 +1,131 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+// spec: Tests d'acceptation TA-AUTH-04, TA-AUTH-12
+// spec: section "LoginScreen" layout + "Parité light / dark mode"
+// RED by construction: fr.datasaillance.nightfall.ui.screens.auth.LoginScreen does not exist yet
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlinx.coroutines.flow.MutableStateFlow
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.ui.screens.auth.LoginScreen
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.LoginUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+
+class LoginScreenTest {
+
+    // spec: TA-AUTH-12 / D10 — Paparazzi offline screenshot tests
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(
+        loginState: fr.datasaillance.nightfall.viewmodel.auth.LoginUiState = fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle
+    ): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        val viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+        // Inject desired initial state by manipulating the ViewModel's internal flow
+        // The ViewModel exposes loginState: StateFlow<LoginUiState> — we rely on its initial value
+        // For non-Idle states, we call the relevant method after mocking api responses,
+        // but for snapshot tests the ViewModel is used as a state holder via collectAsState().
+        // spec: D1 — AuthViewModel is shared; state is injected via mock configuration
+        return viewModel
+    }
+
+    // spec: TA-AUTH-12 — LoginScreen dark mode, state = LoginUiState.Idle
+    // spec: "Parité light / dark mode" — fond #191E22, CTA #D37C04, lien #07BCD3
+    @Test
+    fun loginScreen_idle_dark() {
+        val viewModel = buildViewModel(fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-12 — snapshot must match golden: fond #191E22, CTA #D37C04, lien #07BCD3
+    }
+
+    // spec: TA-AUTH-12 — LoginScreen light mode, state = LoginUiState.Idle
+    // spec: "Parité light / dark mode" — fond #FAFAFA, même CTA #D37C04
+    @Test
+    fun loginScreen_idle_light() {
+        val viewModel = buildViewModel(fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = false) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-12 — snapshot light: fond #FAFAFA, CTA #D37C04
+    }
+
+    // spec: TA-AUTH-02 / TA-AUTH-03 — LoginScreen shows inline error message (no dialog)
+    // spec: section "LoginScreen" — AuthErrorMessage visible si LoginUiState.Error
+    @Test
+    fun loginScreen_error_dark() {
+        // For the error state snapshot, we need the ViewModel to be in Error state.
+        // Since AuthViewModel doesn't exist yet, this import fails RED as intended.
+        // When implemented, call viewModel._loginState.value = LoginUiState.Error(...)
+        // or use a fake ViewModel. For now the class import is the RED trigger.
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        val viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-AUTH-02 — error is displayed inline under the form fields
+                // The Screen must reflect LoginUiState.Error from the ViewModel's StateFlow
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-02 — AuthErrorMessage visible, no Dialog; password field still editable
+    }
+
+    // spec: TA-AUTH-04 — LoginScreen loading state: button disabled, CircularProgressIndicator visible
+    // spec: section "AuthPrimaryButton" — isLoading replaces text with CircularProgressIndicator
+    @Test
+    fun loginScreen_loading_dark() {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        val viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-AUTH-04 — AuthPrimaryButton enabled=false, CircularProgressIndicator shown
+                // spec: TA-AUTH-04 — AuthTextField enabled=false when Loading
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-04 — loading state: button disabled, fields disabled, progress indicator visible
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt
@@ -1,0 +1,90 @@
+package fr.datasaillance.nightfall.ui.screens.auth
+
+// spec: Tests d'acceptation TA-AUTH-05, TA-AUTH-06
+// spec: section "RegisterScreen" layout + "Parité light / dark mode"
+// RED by construction: fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen does not exist yet
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+
+class RegisterScreenTest {
+
+    // spec: D10 — Paparazzi offline screenshot tests
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        // spec: D1 — AuthViewModel constructed directly without Hilt (issue #52)
+        return fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    // spec: TA-AUTH-05 — RegisterScreen dark mode, state = RegisterUiState.Idle
+    // spec: "Parité light / dark mode" — fond #191E22, CTA #D37C04
+    @Test
+    fun registerScreen_idle_dark() {
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen(
+                    viewModel = viewModel,
+                    onRegisterSuccess = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-05 — screenshot dark: fond #191E22, 3 AuthTextFields, CTA "S'inscrire" #D37C04
+    }
+
+    // spec: TA-AUTH-05 — RegisterScreen light mode, state = RegisterUiState.Idle
+    // spec: "Parité light / dark mode" — fond #FAFAFA, CTA #D37C04
+    @Test
+    fun registerScreen_idle_light() {
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = false) {
+                fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen(
+                    viewModel = viewModel,
+                    onRegisterSuccess = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-05 — screenshot light: fond #FAFAFA, CTA #D37C04
+    }
+
+    // spec: TA-AUTH-06 — RegisterScreen: password != confirmation → "S'inscrire" button disabled
+    // spec: section "RegisterScreen" — validation inline: mots de passe doivent être identiques avant envoi
+    @Test
+    fun registerScreen_passwordMismatch_dark() {
+        // spec: TA-AUTH-06 — password mismatch is a client-side guard, no network call
+        // The Screen receives password and confirmation as local state; when they differ,
+        // AuthPrimaryButton must have enabled=false.
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-AUTH-06 — "S'inscrire" button must be disabled when password != confirmation
+                // Screen handles this via local Compose state — no ViewModel call needed
+                fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen(
+                    viewModel = viewModel,
+                    onRegisterSuccess = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-06 — AuthPrimaryButton enabled=false; no POST /auth/register call made
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt
@@ -1,0 +1,296 @@
+package fr.datasaillance.nightfall.viewmodel.auth
+
+// spec: Tests d'acceptation TA-AUTH-01 through TA-AUTH-10
+// spec: section "AuthViewModel" + "Tests d'acceptation"
+// RED by construction: fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel does not exist yet
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.HttpException
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.LoginUiState
+// fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState
+// fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+// fr.datasaillance.nightfall.data.http.LoginRequest
+// fr.datasaillance.nightfall.data.http.LoginResponse
+// fr.datasaillance.nightfall.data.http.RegisterRequest
+// fr.datasaillance.nightfall.data.http.RegisterResponse
+// fr.datasaillance.nightfall.data.http.PasswordResetRequest
+// fr.datasaillance.nightfall.data.http.StatusResponse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var api: fr.datasaillance.nightfall.data.http.NightfallApi
+    private lateinit var tokenDataStore: fr.datasaillance.nightfall.data.auth.TokenDataStore
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+
+    @Before
+    fun setUp() {
+        // spec: TA-AUTH-04 — viewModelScope.launch must use a test dispatcher
+        Dispatchers.setMain(testDispatcher)
+        api = mock()
+        tokenDataStore = mock()
+        // spec: D1 — AuthViewModel constructed directly without Hilt (issue #52)
+        viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-AUTH-01 — login() success → saveToken() called, state is LoginUiState.Success
+    @Test
+    fun login_success_savesTokenAndEmitsSuccess() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.LoginResponse(
+            access_token = "tok_abc",
+            refresh_token = "ref_abc",
+            token_type = "bearer",
+            expires_in = 3600
+        )
+        whenever(api.login(any())).thenReturn(fakeResponse)
+
+        viewModel.login("user@example.com", "password123")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-01 — tokenDataStore.saveToken() called with the access_token
+        verify(tokenDataStore).saveToken("tok_abc")
+
+        // spec: TA-AUTH-01 — loginState must be LoginUiState.Success
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Success) {
+            "loginState must be LoginUiState.Success after successful login — spec: TA-AUTH-01, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-02 — login() HTTP 401 → LoginUiState.Error("Email ou mot de passe incorrect")
+    @Test
+    fun login_http401_emitsErrorInvalidCredentials() = runTest {
+        val httpException = mock<HttpException>()
+        whenever(httpException.code()).thenReturn(401)
+        whenever(api.login(any())).thenThrow(httpException)
+
+        viewModel.login("bad@example.com", "wrongpassword")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-02 — saveToken() must NOT be called on 401
+        verify(tokenDataStore, never()).saveToken(any())
+
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error) {
+            "loginState must be LoginUiState.Error on HTTP 401 — spec: TA-AUTH-02, got: $state"
+        }
+        val errorMessage = (state as fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error).message
+        assert(errorMessage == "Email ou mot de passe incorrect") {
+            "Error message for HTTP 401 must be 'Email ou mot de passe incorrect' — spec: TA-AUTH-02, got: '$errorMessage'"
+        }
+    }
+
+    // spec: TA-AUTH-03 — login() HTTP 403 → LoginUiState.Error("Email non vérifié — consultez votre boîte mail")
+    @Test
+    fun login_http403_emitsErrorEmailNotVerified() = runTest {
+        val httpException = mock<HttpException>()
+        whenever(httpException.code()).thenReturn(403)
+        whenever(api.login(any())).thenThrow(httpException)
+
+        viewModel.login("unverified@example.com", "password123")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-03 — saveToken() must NOT be called on 403
+        verify(tokenDataStore, never()).saveToken(any())
+
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error) {
+            "loginState must be LoginUiState.Error on HTTP 403 — spec: TA-AUTH-03, got: $state"
+        }
+        val errorMessage = (state as fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error).message
+        assert(errorMessage == "Email non vérifié — consultez votre boîte mail") {
+            "Error message for HTTP 403 must be 'Email non vérifié — consultez votre boîte mail' — spec: TA-AUTH-03, got: '$errorMessage'"
+        }
+    }
+
+    // spec: TA-AUTH-04 — loginState is LoginUiState.Loading while request is in-flight
+    @Test
+    fun login_emitsLoadingWhileInFlight() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.LoginResponse(
+            access_token = "tok",
+            refresh_token = "ref",
+            token_type = "bearer",
+            expires_in = 3600
+        )
+        whenever(api.login(any())).thenReturn(fakeResponse)
+
+        // spec: TA-AUTH-04 — state must be Loading synchronously before coroutine completes
+        viewModel.login("user@example.com", "password123")
+
+        // Before advanceUntilIdle() — coroutine is suspended at the api.login() call
+        val stateWhileInFlight = viewModel.loginState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Loading) {
+            "loginState must be LoginUiState.Loading immediately after login() call — spec: TA-AUTH-04, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+
+    // spec: TA-AUTH-05 — register() HTTP 201 → RegisterUiState.Success
+    @Test
+    fun register_success_emitsSuccess() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.RegisterResponse(
+            id = "user-uuid-123",
+            email = "new@example.com"
+        )
+        whenever(api.register(any(), any())).thenReturn(fakeResponse)
+
+        viewModel.register("new@example.com", "StrongP@ss1", registrationToken = "reg-token")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-05 — registerState must be RegisterUiState.Success
+        val state = viewModel.registerState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState.Success) {
+            "registerState must be RegisterUiState.Success on HTTP 201 — spec: TA-AUTH-05, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-07 — requestPasswordReset() always → ForgotPasswordUiState.Sent (anti-enum)
+    @Test
+    fun requestPasswordReset_alwaysEmitsSent_onSuccess() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.StatusResponse(status = "pending")
+        whenever(api.requestPasswordReset(any())).thenReturn(fakeResponse)
+
+        viewModel.requestPasswordReset("any@example.com")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-07 — ForgotPasswordUiState.Sent regardless of backend response
+        val state = viewModel.forgotState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState.Sent) {
+            "forgotState must be ForgotPasswordUiState.Sent on success — spec: TA-AUTH-07, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-07 — requestPasswordReset() always → ForgotPasswordUiState.Sent even on exception (anti-enum)
+    @Test
+    fun requestPasswordReset_alwaysEmitsSent_onNetworkError() = runTest {
+        whenever(api.requestPasswordReset(any())).thenThrow(RuntimeException("Network timeout"))
+
+        viewModel.requestPasswordReset("any@example.com")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-07 — anti-enum: Sent even when backend throws (prevents account enumeration)
+        val state = viewModel.forgotState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState.Sent) {
+            "forgotState must be ForgotPasswordUiState.Sent even on network error — spec: TA-AUTH-07, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-08 — storeTokenFromCallback("valid_jwt") → saveToken called, state is LoginUiState.Success
+    @Test
+    fun storeTokenFromCallback_validToken_savesTokenAndEmitsSuccess() {
+        viewModel.storeTokenFromCallback("valid_jwt_token_xyz")
+
+        // spec: TA-AUTH-08 — tokenDataStore.saveToken() must be called with the token value
+        verify(tokenDataStore).saveToken("valid_jwt_token_xyz")
+
+        // spec: TA-AUTH-08 — loginState must be LoginUiState.Success
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Success) {
+            "loginState must be LoginUiState.Success after storeTokenFromCallback — spec: TA-AUTH-08, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-09 — The Screen handles null/empty token before calling storeTokenFromCallback.
+    // The ViewModel's storeTokenFromCallback(token) with a valid token must call saveToken.
+    // Verifying the contract: saveToken is NOT called when the Screen withholds the call.
+    // We test initial state: before any storeTokenFromCallback call, saveToken has never been invoked.
+    @Test
+    fun tokenDataStore_saveToken_notCalled_untilStoreTokenFromCallbackInvoked() {
+        // spec: TA-AUTH-09 — saveToken() must NOT be called if the Screen never invokes storeTokenFromCallback
+        // (Screen is responsible for guarding against null/empty token)
+        verify(tokenDataStore, never()).saveToken(any())
+
+        // spec: TA-AUTH-09 — initial state is LoginUiState.Idle (not Success, not Error)
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle) {
+            "loginState must be LoginUiState.Idle before any action — spec: TA-AUTH-09, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-10 — No Timber log contains the JWT value after successful login
+    @Test
+    fun login_success_doesNotLogTokenValue() = runTest {
+        val sensitiveToken = "super-secret-jwt-do-not-log-me-12345"
+        val fakeResponse = fr.datasaillance.nightfall.data.http.LoginResponse(
+            access_token = sensitiveToken,
+            refresh_token = "ref_token",
+            token_type = "bearer",
+            expires_in = 3600
+        )
+        whenever(api.login(any())).thenReturn(fakeResponse)
+
+        // Capture Timber logs via a custom tree
+        val loggedMessages = mutableListOf<String>()
+        val testTree = object : timber.log.Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                loggedMessages.add(message)
+                t?.message?.let { loggedMessages.add(it) }
+            }
+        }
+        timber.log.Timber.plant(testTree)
+
+        viewModel.login("user@example.com", "MyPassword123!")
+        advanceUntilIdle()
+
+        timber.log.Timber.uproot(testTree)
+
+        // spec: TA-AUTH-10 / D12 — no log line must contain the access_token value
+        val leaked = loggedMessages.filter { it.contains(sensitiveToken) }
+        assert(leaked.isEmpty()) {
+            "Timber logs must NOT contain the JWT access_token value — spec: TA-AUTH-10, D12. Found: $leaked"
+        }
+    }
+
+    // spec: TA-AUTH-10 — No Timber log contains the password value after login attempt
+    @Test
+    fun login_doesNotLogPasswordValue() = runTest {
+        val sensitivePassword = "MyUniquePassword!999"
+        val httpException = mock<HttpException>()
+        whenever(httpException.code()).thenReturn(401)
+        whenever(api.login(any())).thenThrow(httpException)
+
+        val loggedMessages = mutableListOf<String>()
+        val testTree = object : timber.log.Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                loggedMessages.add(message)
+            }
+        }
+        timber.log.Timber.plant(testTree)
+
+        viewModel.login("user@example.com", sensitivePassword)
+        advanceUntilIdle()
+
+        timber.log.Timber.uproot(testTree)
+
+        // spec: TA-AUTH-10 / D12 — password must never appear in any log output
+        val leaked = loggedMessages.filter { it.contains(sensitivePassword) }
+        assert(leaked.isEmpty()) {
+            "Timber logs must NOT contain the password value — spec: TA-AUTH-10, D12. Found: $leaked"
+        }
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt
@@ -1,0 +1,363 @@
+package fr.datasaillance.nightfall.viewmodel.import_
+
+// spec: Tests d'acceptation TA-01, TA-02, TA-05, TA-07, TA-08
+// spec: section "ImportViewModel" + "Architecture" + "Tests d'acceptation"
+// RED by construction: fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel does not exist yet
+
+import android.content.ContentResolver
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+// fr.datasaillance.nightfall.domain.import_.ImportUiState
+// fr.datasaillance.nightfall.domain.import_.ImportDataType
+// fr.datasaillance.nightfall.domain.import_.ImportResult
+// fr.datasaillance.nightfall.data.import_.ImportRepository
+// fr.datasaillance.nightfall.data.import_.CsvEntry
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class ImportViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: fr.datasaillance.nightfall.data.import_.ImportRepository
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+
+    // SAF mocks — these types exist in Android SDK (safe to mock with mock-maker-inline)
+    private lateinit var mockContentResolver: ContentResolver
+    private lateinit var mockTreeUri: Uri
+
+    @Before
+    fun setUp() {
+        // spec: D7 — viewModelScope uses Dispatchers.Main; must be replaced with test dispatcher
+        Dispatchers.setMain(testDispatcher)
+        repository = mock()
+        // spec: D7 — No Hilt (issue #52): ImportViewModel constructed directly with repository
+        viewModel = fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel(repository)
+        mockContentResolver = mock()
+        mockTreeUri = mock()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-01 — checkConnection() when pingBackend() returns true → state is Connected
+    @Test
+    fun checkConnection_pingSuccess_emitsConnected() = runTest {
+        whenever(repository.pingBackend()).thenReturn(true)
+
+        viewModel.checkConnection()
+        advanceUntilIdle()
+
+        // spec: TA-01 — ImportUiState must be Connected after a successful ping
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Connected) {
+            "uiState must be ImportUiState.Connected when pingBackend() returns true — spec: TA-01, got: $state"
+        }
+    }
+
+    // spec: TA-02 — checkConnection() when pingBackend() returns false → state is ConnectionFailed with exact message
+    @Test
+    fun checkConnection_pingFailure_emitsConnectionFailed() = runTest {
+        whenever(repository.pingBackend()).thenReturn(false)
+
+        viewModel.checkConnection()
+        advanceUntilIdle()
+
+        // spec: TA-02 — ImportUiState must be ConnectionFailed with the spec-mandated message
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.ConnectionFailed) {
+            "uiState must be ImportUiState.ConnectionFailed when pingBackend() returns false — spec: TA-02, got: $state"
+        }
+        val message = (state as fr.datasaillance.nightfall.domain.import_.ImportUiState.ConnectionFailed).message
+        assert(message == "Backend inaccessible — vérifiez l'URL dans les paramètres") {
+            "ConnectionFailed message must match spec exactly — spec: TA-02, got: '$message'"
+        }
+    }
+
+    // spec: TA-01/TA-02 — checkConnection() sets Connecting synchronously before coroutine suspends
+    // Pattern: _uiState.value = Connecting is set BEFORE viewModelScope.launch suspends at pingBackend()
+    @Test
+    fun checkConnection_setsConnectingBeforeCoroutineSuspends() = runTest {
+        // Make pingBackend() a proper suspend that will park on testDispatcher
+        whenever(repository.pingBackend()).thenReturn(true)
+
+        // spec: TA-01 — Connecting must be set synchronously before the coroutine reaches pingBackend()
+        viewModel.checkConnection()
+
+        // Before advanceUntilIdle() — coroutine is suspended at repository.pingBackend()
+        val stateWhileInFlight = viewModel.uiState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.domain.import_.ImportUiState.Connecting) {
+            "uiState must be ImportUiState.Connecting immediately after checkConnection() — spec: TA-01, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+
+    // spec: TA-05 — startUpload() with SLEEP and HEART_RATE entries in the map
+    //   → state transitions through Uploading(SLEEP) → Uploading(HEART_RATE) → Success
+    //   → STEPS and EXERCISE appear in skippedTypes
+    @Test
+    fun startUpload_sleepAndHeartRate_uploadsSequentiallyAndSkipsStepsExercise() = runTest {
+        val sleepUri = mock<Uri>()
+        val heartRateUri = mock<Uri>()
+
+        val csvEntries = mapOf(
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(sleepUri, 1024L),
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(heartRateUri, 2048L),
+        )
+
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(csvEntries)
+
+        val sleepResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP,
+            inserted = 10,
+            skipped = 0,
+        )
+        val heartRateResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE,
+            inserted = 20,
+            skipped = 0,
+        )
+
+        // spec: TA-05 — mock uploadCsv for SLEEP
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(sleepUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP),
+                totalBytes = eq(1024L),
+                onProgress = any(),
+            )
+        ).thenReturn(sleepResult)
+
+        // spec: TA-05 — mock uploadCsv for HEART_RATE
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(heartRateUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE),
+                totalBytes = eq(2048L),
+                onProgress = any(),
+            )
+        ).thenReturn(heartRateResult)
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-05 — final state must be Success
+        val finalState = viewModel.uiState.value
+        assert(finalState is fr.datasaillance.nightfall.domain.import_.ImportUiState.Success) {
+            "uiState must be ImportUiState.Success after upload completes — spec: TA-05, got: $finalState"
+        }
+
+        val successState = finalState as fr.datasaillance.nightfall.domain.import_.ImportUiState.Success
+
+        // spec: TA-05 — results contain SLEEP and HEART_RATE
+        val resultTypes = successState.results.map { it.type }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP in resultTypes) {
+            "Success.results must include SLEEP — spec: TA-05"
+        }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE in resultTypes) {
+            "Success.results must include HEART_RATE — spec: TA-05"
+        }
+    }
+
+    // spec: TA-05 — STEPS and EXERCISE must appear in skippedTypes when not in the CSV map
+    // This test captures an intermediate Uploading state to verify skippedTypes
+    @Test
+    fun startUpload_stepsAndExerciseNotInMap_appearsInSkipped() = runTest {
+        val sleepUri = mock<Uri>()
+        val csvEntries = mapOf(
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(sleepUri, 512L),
+        )
+
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(csvEntries)
+
+        val sleepResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP,
+            inserted = 5,
+            skipped = 0,
+        )
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(sleepUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP),
+                totalBytes = any(),
+                onProgress = any(),
+            )
+        ).thenReturn(sleepResult)
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-05 — Success state's results must NOT include STEPS or EXERCISE (they are skipped, not uploaded)
+        val finalState = viewModel.uiState.value
+        assert(finalState is fr.datasaillance.nightfall.domain.import_.ImportUiState.Success) {
+            "uiState must be Success — spec: TA-05, got: $finalState"
+        }
+        val successState = finalState as fr.datasaillance.nightfall.domain.import_.ImportUiState.Success
+        val resultTypes = successState.results.map { it.type }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.STEPS !in resultTypes) {
+            "Success.results must NOT include STEPS when it was skipped — spec: TA-05"
+        }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.EXERCISE !in resultTypes) {
+            "Success.results must NOT include EXERCISE when it was skipped — spec: TA-05"
+        }
+    }
+
+    // spec: TA-07 — startUpload() when extractCsvEntries returns empty map → Error with exact message, retryable = true
+    @Test
+    fun startUpload_emptyCsvMap_emitsErrorRetryable() = runTest {
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(emptyMap())
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-07 — state must be Error with the spec-mandated message and retryable = true
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Error) {
+            "uiState must be ImportUiState.Error when no Samsung Health files found — spec: TA-07, got: $state"
+        }
+        val errorState = state as fr.datasaillance.nightfall.domain.import_.ImportUiState.Error
+        assert(errorState.message == "Aucun fichier Samsung Health reconnu dans l'archive.") {
+            "Error message must match spec exactly — spec: TA-07, got: '${errorState.message}'"
+        }
+        assert(errorState.retryable) {
+            "Error must be retryable = true — spec: TA-07"
+        }
+    }
+
+    // spec: TA-08 — SLEEP succeeds; HEART_RATE throws IOException → final state is Success
+    //   results include HEART_RATE with non-null errorMessage; STEPS and EXERCISE are processed (skipped if not in map)
+    @Test
+    fun startUpload_heartRateIoException_doesNotBlockGlobalSuccess() = runTest {
+        val sleepUri = mock<Uri>()
+        val heartRateUri = mock<Uri>()
+
+        val csvEntries = mapOf(
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(sleepUri, 1024L),
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(heartRateUri, 2048L),
+        )
+
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(csvEntries)
+
+        val sleepResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP,
+            inserted = 10,
+            skipped = 0,
+        )
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(sleepUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP),
+                totalBytes = any(),
+                onProgress = any(),
+            )
+        ).thenReturn(sleepResult)
+
+        // spec: TA-08 — HEART_RATE upload throws IOException (connexion coupée)
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(heartRateUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE),
+                totalBytes = any(),
+                onProgress = any(),
+            )
+        ).thenThrow(java.io.IOException("Connection reset by peer"))
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-08 — final state must still be Success (partial success, not global failure)
+        val finalState = viewModel.uiState.value
+        assert(finalState is fr.datasaillance.nightfall.domain.import_.ImportUiState.Success) {
+            "uiState must be ImportUiState.Success even when HEART_RATE upload fails — spec: TA-08, got: $finalState"
+        }
+
+        val successState = finalState as fr.datasaillance.nightfall.domain.import_.ImportUiState.Success
+
+        // spec: TA-08 — results must include HEART_RATE with non-null errorMessage
+        val heartRateResult = successState.results.find {
+            it.type == fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE
+        }
+        assert(heartRateResult != null) {
+            "Success.results must include HEART_RATE entry even after IOException — spec: TA-08"
+        }
+        assert(heartRateResult!!.errorMessage != null) {
+            "HEART_RATE ImportResult.errorMessage must be non-null after IOException — spec: TA-08"
+        }
+        assert(heartRateResult.inserted == 0) {
+            "HEART_RATE ImportResult.inserted must be 0 after IOException — spec: TA-08"
+        }
+
+        // spec: TA-08 — SLEEP must be in results with no error
+        val sleepResultActual = successState.results.find {
+            it.type == fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP
+        }
+        assert(sleepResultActual != null) {
+            "Success.results must include SLEEP — spec: TA-08"
+        }
+        assert(sleepResultActual!!.errorMessage == null) {
+            "SLEEP ImportResult.errorMessage must be null (success) — spec: TA-08"
+        }
+    }
+
+    // spec: Architecture "reset()" — calling reset() returns state to Idle
+    @Test
+    fun reset_returnsToIdleState() = runTest {
+        // Move to a non-Idle state first
+        whenever(repository.pingBackend()).thenReturn(true)
+        viewModel.checkConnection()
+        advanceUntilIdle()
+
+        assert(viewModel.uiState.value is fr.datasaillance.nightfall.domain.import_.ImportUiState.Connected) {
+            "Precondition: state must be Connected before reset"
+        }
+
+        // spec: reset() — calling reset() must return state to Idle
+        viewModel.reset()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Idle) {
+            "uiState must be ImportUiState.Idle after reset() — spec: ImportViewModel.reset(), got: $state"
+        }
+    }
+
+    // spec: D7 — initial state is Idle before any action
+    @Test
+    fun initialState_isIdle() {
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Idle) {
+            "uiState must be ImportUiState.Idle at construction — spec: D7 (StateFlow initial value), got: $state"
+        }
+    }
+}

--- a/docs/vault/code/android-app/app/build.gradle.md
+++ b/docs/vault/code/android-app/app/build.gradle.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/build.gradle.kts
-git_blob: bca9efa2391c7f78325ff890e7353fb6cc230628
-last_synced: '2026-05-07T00:48:24Z'
-loc: 119
+git_blob: 8d1a9c9824e0ba51d312a4319c7ac589d2032d54
+last_synced: '2026-05-07T02:02:39Z'
+loc: 122
 annotations: []
 imports: []
 exports: []
@@ -116,6 +116,9 @@ dependencies {
 
     // Logging
     implementation("com.jakewharton.timber:timber:5.0.1")
+
+    // Browser (Custom Tabs for OAuth)
+    implementation("androidx.browser:browser:1.8.0")
 
     // Core
     implementation("androidx.core:core-ktx:1.15.0")

--- a/docs/vault/code/android-app/app/build.gradle.md
+++ b/docs/vault/code/android-app/app/build.gradle.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/build.gradle.kts
-git_blob: 8d1a9c9824e0ba51d312a4319c7ac589d2032d54
-last_synced: '2026-05-07T02:02:39Z'
-loc: 122
+git_blob: 523fc31d70b5f0c1d8ad2550f524d8f7b628fbb5
+last_synced: '2026-05-07T03:10:49Z'
+loc: 123
 annotations: []
 imports: []
 exports: []
@@ -100,6 +100,7 @@ dependencies {
     implementation("androidx.compose.ui:ui-tooling-preview")
     implementation("androidx.activity:activity-compose:1.9.3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
 
     // Navigation
     implementation("androidx.navigation:navigation-compose:2.8.5")

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.md
@@ -1,0 +1,50 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt
+git_blob: 5830c67f0834c1b963e8ebb7142cfbbe9de12e4d
+last_synced: '2026-05-07T02:02:39Z'
+loc: 12
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/AuthModels.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.http
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class LoginRequest(val email: String, val password: String)
+@Serializable data class LoginResponse(val access_token: String, val refresh_token: String, val token_type: String, val expires_in: Int)
+@Serializable data class RegisterRequest(val email: String, val password: String)
+@Serializable data class RegisterResponse(val id: String, val email: String)
+@Serializable data class PasswordResetRequest(val email: String)
+@Serializable data class StatusResponse(val status: String)
+@Serializable data class GoogleStartRequest(val return_to: String? = null)
+@Serializable data class GoogleStartResponse(val authorize_url: String)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LoginRequest` (class) — lines 5-5
+- `LoginResponse` (class) — lines 6-6
+- `RegisterRequest` (class) — lines 7-7
+- `RegisterResponse` (class) — lines 8-8
+- `PasswordResetRequest` (class) — lines 9-9
+- `StatusResponse` (class) — lines 10-10
+- `GoogleStartRequest` (class) — lines 11-11
+- `GoogleStartResponse` (class) — lines 12-12

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.md
@@ -1,0 +1,74 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt
+git_blob: 7091f8de03e5834851813753c187f5f263531c1c
+last_synced: '2026-05-07T03:10:49Z'
+loc: 38
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.http
+
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.Buffer
+import okio.BufferedSink
+import okio.ForwardingSink
+import okio.Sink
+import okio.buffer
+
+class CountingRequestBody(
+    private val delegate: RequestBody,
+    private val totalBytes: Long,
+    private val onProgress: (Float) -> Unit,
+) : RequestBody() {
+
+    override fun contentType(): MediaType? = delegate.contentType()
+
+    override fun contentLength(): Long = totalBytes
+
+    override fun writeTo(sink: BufferedSink) {
+        onProgress(0f)
+        val counted = CountingSink(sink)
+        val buffered = counted.buffer()
+        delegate.writeTo(buffered)
+        buffered.flush()
+    }
+
+    inner class CountingSink(delegate: Sink) : ForwardingSink(delegate) {
+        private var bytesWritten = 0L
+
+        override fun write(source: Buffer, byteCount: Long) {
+            super.write(source, byteCount)
+            bytesWritten += byteCount
+            onProgress((bytesWritten.toFloat() / totalBytes).coerceIn(0f, 1f))
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `CountingRequestBody` (class) — lines 11-38
+- `contentType` (function) — lines 17-17
+- `contentLength` (function) — lines 19-19
+- `writeTo` (function) — lines 21-27
+- `CountingSink` (class) — lines 29-37
+- `write` (function) — lines 32-36

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
-git_blob: 3ff676ff6624b9cd7074cf4be2c6058e47fbecc1
-last_synced: '2026-05-07T00:48:24Z'
-loc: 9
+git_blob: e00c2ce51b9232acaada50a5ff6f07cf8aa0031d
+last_synced: '2026-05-07T02:02:39Z'
+loc: 24
 annotations: []
 imports: []
 exports: []
@@ -24,11 +24,26 @@ tags:
 package fr.datasaillance.nightfall.data.http
 
 import retrofit2.Response
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.POST
 
 interface NightfallApi {
     @GET("health")
     suspend fun health(): Response<Unit>
+
+    @POST("auth/login")
+    suspend fun login(@Body body: LoginRequest): LoginResponse
+
+    @POST("auth/register")
+    suspend fun register(@Body body: RegisterRequest, @Header("X-Registration-Token") registrationToken: String?): RegisterResponse
+
+    @POST("auth/password/reset/request")
+    suspend fun requestPasswordReset(@Body body: PasswordResetRequest): StatusResponse
+
+    @POST("auth/google/start")
+    suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
 }
 ```
 
@@ -37,5 +52,9 @@ interface NightfallApi {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NightfallApi` (class) — lines 6-9
-- `health` (function) — lines 7-8
+- `NightfallApi` (class) — lines 9-24
+- `health` (function) — lines 10-11
+- `login` (function) — lines 13-14
+- `register` (function) — lines 16-17
+- `requestPasswordReset` (function) — lines 19-20
+- `googleStart` (function) — lines 22-23

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
-git_blob: e00c2ce51b9232acaada50a5ff6f07cf8aa0031d
-last_synced: '2026-05-07T02:02:39Z'
-loc: 24
+git_blob: 3f989123930d5deec5041d161889cc1dc163e6c3
+last_synced: '2026-05-07T03:10:49Z'
+loc: 46
 annotations: []
 imports: []
 exports: []
@@ -23,11 +23,17 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.data.http
 
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
+
+@kotlinx.serialization.Serializable
+data class ImportApiResponse(val inserted: Int, val skipped: Int)
 
 interface NightfallApi {
     @GET("health")
@@ -44,6 +50,22 @@ interface NightfallApi {
 
     @POST("auth/google/start")
     suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
+
+    @Multipart
+    @POST("api/sleep/import")
+    suspend fun importSleep(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/heartrate/import")
+    suspend fun importHeartRate(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/steps/import")
+    suspend fun importSteps(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/exercise/import")
+    suspend fun importExercise(@Part file: MultipartBody.Part): ImportApiResponse
 }
 ```
 
@@ -52,9 +74,14 @@ interface NightfallApi {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NightfallApi` (class) — lines 9-24
-- `health` (function) — lines 10-11
-- `login` (function) — lines 13-14
-- `register` (function) — lines 16-17
-- `requestPasswordReset` (function) — lines 19-20
-- `googleStart` (function) — lines 22-23
+- `ImportApiResponse` (class) — lines 12-13
+- `NightfallApi` (class) — lines 15-46
+- `health` (function) — lines 16-17
+- `login` (function) — lines 19-20
+- `register` (function) — lines 22-23
+- `requestPasswordReset` (function) — lines 25-26
+- `googleStart` (function) — lines 28-29
+- `importSleep` (function) — lines 31-33
+- `importHeartRate` (function) — lines 35-37
+- `importSteps` (function) — lines 39-41
+- `importExercise` (function) — lines 43-45

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.md
@@ -1,0 +1,62 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt
+git_blob: e7cb7ff2c43c6ef7386e75ebcbbc913b86c4e4df
+last_synced: '2026-05-07T03:10:49Z'
+loc: 27
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.import_
+
+import android.content.ContentResolver
+import android.net.Uri
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
+import java.io.IOException
+
+data class CsvEntry(val uri: Uri, val size: Long)
+
+interface ImportRepository {
+    suspend fun pingBackend(): Boolean
+
+    suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry>
+
+    @Throws(IOException::class)
+    suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `CsvEntry` (class) — lines 9-9
+- `ImportRepository` (class) — lines 11-27
+- `pingBackend` (function) — lines 12-12
+- `extractCsvEntries` (function) — lines 14-17
+- `uploadCsv` (function) — lines 19-26

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.md
@@ -1,0 +1,159 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
+git_blob: 58de67aea204eea8b2f605bb8e206e90048a0718
+last_synced: '2026-05-07T03:10:49Z'
+loc: 124
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.import_
+
+import android.content.ContentResolver
+import android.net.Uri
+import fr.datasaillance.nightfall.data.http.CountingRequestBody
+import fr.datasaillance.nightfall.data.http.ImportApiResponse
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.util.zip.ZipInputStream
+
+private const val MAX_UNCOMPRESSED_BYTES = 200_000_000L
+private const val MAX_ZIP_ENTRIES = 100
+
+class ImportRepositoryImpl(
+    private val api: NightfallApi,
+) : ImportRepository {
+
+    override suspend fun pingBackend(): Boolean {
+        return try {
+            val response = api.health()
+            response.isSuccessful
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    private val zipEntryCache = mutableMapOf<ImportDataType, ByteArray>()
+
+    override suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry> {
+        zipEntryCache.clear()
+        return try {
+            extractFromZip(contentResolver, treeUri)
+        } catch (e: IOException) {
+            emptyMap()
+        }
+    }
+
+    private fun extractFromZip(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry> {
+        val result = mutableMapOf<ImportDataType, CsvEntry>()
+        val inputStream = contentResolver.openInputStream(treeUri)
+            ?: throw IOException("Cannot open URI")
+
+        var totalUncompressed = 0L
+        var entryCount = 0
+
+        ZipInputStream(inputStream).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                if (entryCount >= MAX_ZIP_ENTRIES) {
+                    throw IOException("Archive trop grande: dépasse $MAX_ZIP_ENTRIES entrées")
+                }
+                entryCount++
+
+                val name = entry.name.substringAfterLast('/')
+                val matchingType = ImportDataType.entries.firstOrNull { type ->
+                    name.startsWith(type.samsungFilenamePrefix) && name.endsWith(".csv")
+                }
+
+                if (matchingType != null && matchingType !in result) {
+                    val baos = ByteArrayOutputStream()
+                    val buffer = ByteArray(8192)
+                    var read: Int
+                    while (zis.read(buffer).also { read = it } != -1) {
+                        totalUncompressed += read
+                        if (totalUncompressed > MAX_UNCOMPRESSED_BYTES) {
+                            throw IOException("Archive trop grande: dépasse ${MAX_UNCOMPRESSED_BYTES / 1_000_000} Mo décompressés")
+                        }
+                        baos.write(buffer, 0, read)
+                    }
+                    val bytes = baos.toByteArray()
+                    zipEntryCache[matchingType] = bytes
+                    result[matchingType] = CsvEntry(uri = treeUri, size = bytes.size.toLong())
+                }
+
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+        return result
+    }
+
+    override suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult {
+        val bytes = zipEntryCache[type]
+            ?: run {
+                contentResolver.openInputStream(uri)?.readBytes()
+                    ?: throw IOException("Cannot read file for $type")
+            }
+
+        val mediaType = "text/csv".toMediaType()
+        val requestBody = bytes.toRequestBody(mediaType)
+        val countingBody = CountingRequestBody(
+            delegate = requestBody,
+            totalBytes = totalBytes,
+            onProgress = onProgress,
+        )
+        val part = MultipartBody.Part.createFormData("file", "${type.samsungFilenamePrefix}.csv", countingBody)
+
+        val response: ImportApiResponse = when (type) {
+            ImportDataType.SLEEP -> api.importSleep(part)
+            ImportDataType.HEART_RATE -> api.importHeartRate(part)
+            ImportDataType.STEPS -> api.importSteps(part)
+            ImportDataType.EXERCISE -> api.importExercise(part)
+        }
+        return ImportResult(type = type, inserted = response.inserted, skipped = response.skipped)
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportRepositoryImpl` (class) — lines 20-124
+- `pingBackend` (function) — lines 24-31
+- `extractCsvEntries` (function) — lines 35-45
+- `extractFromZip` (function) — lines 47-92
+- `uploadCsv` (function) — lines 94-123

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/di/NetworkModule.kt
-git_blob: 41c5a12a6a68b9fff89ad4344068125d0942bc8d
-last_synced: '2026-05-07T00:48:24Z'
-loc: 35
+git_blob: 00e2736b028ae943b310362287575b3d6d72aaab
+last_synced: '2026-05-07T02:02:39Z'
+loc: 46
 annotations: []
 imports: []
 exports: []
@@ -29,6 +29,9 @@ import fr.datasaillance.nightfall.data.http.AuthInterceptor
 import fr.datasaillance.nightfall.data.http.NightfallApi
 import fr.datasaillance.nightfall.data.network.BackendUrlStore
 import kotlinx.serialization.json.Json
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -42,6 +45,14 @@ object NetworkModule {
     fun provideOkHttpClient(authInterceptor: AuthInterceptor): OkHttpClient =
         OkHttpClient.Builder()
             .addInterceptor(authInterceptor)
+            .cookieJar(object : CookieJar {
+                private val cookieStore = mutableMapOf<String, List<Cookie>>()
+                override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+                    cookieStore[url.host] = cookies
+                }
+                override fun loadForRequest(url: HttpUrl): List<Cookie> =
+                    cookieStore[url.host] ?: emptyList()
+            })
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(30, TimeUnit.SECONDS)
             .build()
@@ -63,7 +74,9 @@ object NetworkModule {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `provideAuthInterceptor` (function) — lines 16-17
-- `provideOkHttpClient` (function) — lines 19-24
-- `provideRetrofit` (function) — lines 26-31
-- `provideNightfallApi` (function) — lines 33-34
+- `provideAuthInterceptor` (function) — lines 19-20
+- `provideOkHttpClient` (function) — lines 22-35
+- `saveFromResponse` (function) — lines 27-29
+- `loadForRequest` (function) — lines 30-31
+- `provideRetrofit` (function) — lines 37-42
+- `provideNightfallApi` (function) — lines 44-45

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.md
@@ -1,0 +1,66 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
+git_blob: 54597c9c952e5cb764bf75abafee457c0d844873
+last_synced: '2026-05-07T03:10:49Z'
+loc: 35
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.domain.import_
+
+import fr.datasaillance.nightfall.R
+
+enum class ImportDataType(
+    val samsungFilenamePrefix: String,
+    val apiPath: String,
+    val labelRes: Int,
+    val iconRes: Int,
+) {
+    SLEEP(
+        samsungFilenamePrefix = "com.samsung.health.sleep",
+        apiPath = "api/sleep/import",
+        labelRes = R.string.import_type_sleep,
+        iconRes = R.drawable.ic_import_sleep,
+    ),
+    HEART_RATE(
+        samsungFilenamePrefix = "com.samsung.health.heart_rate",
+        apiPath = "api/heartrate/import",
+        labelRes = R.string.import_type_heartrate,
+        iconRes = R.drawable.ic_import_heartrate,
+    ),
+    STEPS(
+        samsungFilenamePrefix = "com.samsung.health.step_daily_trend",
+        apiPath = "api/steps/import",
+        labelRes = R.string.import_type_steps,
+        iconRes = R.drawable.ic_import_steps,
+    ),
+    EXERCISE(
+        samsungFilenamePrefix = "com.samsung.health.exercise",
+        apiPath = "api/exercise/import",
+        labelRes = R.string.import_type_exercise,
+        iconRes = R.drawable.ic_import_exercise,
+    ),
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportDataType` (class) — lines 5-35

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.md
@@ -1,0 +1,39 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt
+git_blob: 30bf359f638515070bf27f59abd34e67a1906c13
+last_synced: '2026-05-07T03:10:49Z'
+loc: 8
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportResult.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.domain.import_
+
+data class ImportResult(
+    val type: ImportDataType,
+    val inserted: Int,
+    val skipped: Int,
+    val errorMessage: String? = null,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportResult` (class) — lines 3-8

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.md
@@ -1,0 +1,52 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
+git_blob: 5302471b968ad69b32309fc6d75c0d22884bf421
+last_synced: '2026-05-07T03:10:49Z'
+loc: 17
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.domain.import_
+
+sealed class ImportUiState {
+    object Idle : ImportUiState()
+    object Connecting : ImportUiState()
+    data class ConnectionFailed(val message: String) : ImportUiState()
+    object Connected : ImportUiState()
+    object Selecting : ImportUiState()
+    data class Uploading(
+        val currentType: ImportDataType,
+        val progress: Float,
+        val completedTypes: List<ImportDataType>,
+        val skippedTypes: List<ImportDataType>,
+    ) : ImportUiState()
+    data class Success(val results: List<ImportResult>) : ImportUiState()
+    data class Error(val message: String, val retryable: Boolean) : ImportUiState()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportUiState` (class) — lines 3-17
+- `ConnectionFailed` (class) — lines 6-6
+- `Uploading` (class) — lines 9-14
+- `Success` (class) — lines 15-15
+- `Error` (class) — lines 16-16

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 98d03f64aa735f1dc02df9a36e392f05b46108f8
-last_synced: '2026-05-07T00:48:24Z'
-loc: 108
+git_blob: 18548846e0244c8ab9de18641934a122078f921c
+last_synced: '2026-05-07T03:10:49Z'
+loc: 149
 annotations: []
 imports: []
 exports: []
@@ -23,17 +23,26 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.ui.navigation
 
+import android.content.ContentResolver
+import android.net.Uri
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.compose.DialogNavigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.ComposeNavigator
-import androidx.navigation.compose.DialogNavigator
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.import_.CsvEntry
+import fr.datasaillance.nightfall.data.import_.ImportRepository
+import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
 import fr.datasaillance.nightfall.ui.screens.import_.ImportScreen
 import fr.datasaillance.nightfall.ui.screens.login.LoginScreen
@@ -41,13 +50,15 @@ import fr.datasaillance.nightfall.ui.screens.profile.ProfileScreen
 import fr.datasaillance.nightfall.ui.screens.settings.SettingsScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
 import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
+import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
 
 @Composable
 fun NavGraph(
     navController: NavHostController,
     hasToken: Boolean,
     backendUrl: String = "",
-    onSaveUrl: (String) -> Unit = {}
+    onSaveUrl: (String) -> Unit = {},
+    api: NightfallApi? = null,
 ) {
     val startDestination = if (hasToken) NavDestination.Sleep.route else NavDestination.Login.route
 
@@ -103,7 +114,20 @@ fun NavGraph(
                     }
                 )
             }
-            composable(NavDestination.Import.route) { ImportScreen() }
+            composable(NavDestination.Import.route) {
+                val repository: ImportRepository = remember {
+                    if (api != null) {
+                        ImportRepositoryImpl(api)
+                    } else {
+                        NoOpImportRepository()
+                    }
+                }
+                val viewModel = remember { ImportViewModel(repository) }
+                ImportScreen(
+                    viewModel = viewModel,
+                    onNavigateBack = { navController.popBackStack() },
+                )
+            }
             composable(NavDestination.Settings.route) {
                 SettingsScreen(
                     currentUrl = backendUrl,
@@ -112,6 +136,23 @@ fun NavGraph(
             }
         }
     }
+}
+
+private class NoOpImportRepository : ImportRepository {
+    override suspend fun pingBackend(): Boolean = false
+
+    override suspend fun extractCsvEntries(
+        contentResolver: ContentResolver,
+        treeUri: Uri,
+    ): Map<ImportDataType, CsvEntry> = emptyMap()
+
+    override suspend fun uploadCsv(
+        contentResolver: ContentResolver,
+        uri: Uri,
+        type: ImportDataType,
+        totalBytes: Long,
+        onProgress: (Float) -> Unit,
+    ): ImportResult = throw UnsupportedOperationException("No-op repository")
 }
 
 /**
@@ -136,5 +177,9 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 22-92
-- `ensureComposeNavigators` (function) — lines 100-108
+- `NavGraph` (function) — lines 32-116
+- `NoOpImportRepository` (class) — lines 118-133
+- `pingBackend` (function) — lines 119-119
+- `extractCsvEntries` (function) — lines 121-124
+- `uploadCsv` (function) — lines 126-132
+- `ensureComposeNavigators` (function) — lines 141-149

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.md
@@ -1,0 +1,66 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt
+git_blob: 661a16c9ff6463a154bc65b0d96fedc1c0cc61cc
+last_synced: '2026-05-07T02:02:39Z'
+loc: 35
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/AuthCallbackScreen.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+
+@Composable
+fun AuthCallbackScreen(
+    token: String?,
+    viewModel: AuthViewModel,
+    onSuccess: () -> Unit,
+    onFailure: () -> Unit
+) {
+    LaunchedEffect(Unit) {
+        if (!token.isNullOrBlank()) {
+            viewModel.storeTokenFromCallback(token)
+            onSuccess()
+        } else {
+            viewModel.setLoginError("Authentification Google échouée")
+            onFailure()
+        }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `AuthCallbackScreen` (function) — lines 12-35

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.md
@@ -1,0 +1,137 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt
+git_blob: d6ad23662f7d735f469adbcd54e2c22413766d98
+last_synced: '2026-05-07T02:02:39Z'
+loc: 106
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreen.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.collectAsState
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthPrimaryButton
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthTextField
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+import fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState
+
+@Composable
+fun ForgotPasswordScreen(
+    viewModel: AuthViewModel,
+    onBack: () -> Unit
+) {
+    val forgotState by viewModel.forgotState.collectAsState()
+
+    var email by remember { mutableStateOf("") }
+
+    val isLoading = forgotState is ForgotPasswordUiState.Loading
+    val isSent = forgotState is ForgotPasswordUiState.Sent
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            if (isSent) {
+                Text(
+                    text = "Un email a été envoyé si ce compte existe.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                TextButton(onClick = onBack) {
+                    Text(
+                        text = "Retour à la connexion",
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+            } else {
+                Text(
+                    text = "Réinitialiser le mot de passe",
+                    style = MaterialTheme.typography.headlineLarge,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                AuthTextField(
+                    value = email,
+                    onValueChange = { email = it },
+                    label = "Email",
+                    enabled = !isLoading,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                AuthPrimaryButton(
+                    text = "Envoyer le lien",
+                    onClick = { viewModel.requestPasswordReset(email) },
+                    isLoading = isLoading,
+                    modifier = Modifier.fillMaxWidth()
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                TextButton(onClick = onBack) {
+                    Text(
+                        text = "Retour à la connexion",
+                        color = MaterialTheme.colorScheme.tertiary
+                    )
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ForgotPasswordScreen` (function) — lines 30-106

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.md
@@ -1,0 +1,201 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
+git_blob: b6fcda171011ef3aac4b27a64f6b4525beaf5b40
+last_synced: '2026-05-07T02:02:39Z'
+loc: 170
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthErrorMessage
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthPrimaryButton
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthTextField
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+import fr.datasaillance.nightfall.viewmodel.auth.LoginUiState
+import kotlinx.coroutines.launch
+
+@Composable
+fun LoginScreen(
+    viewModel: AuthViewModel,
+    onLoginSuccess: () -> Unit,
+    onNavigateRegister: () -> Unit,
+    onNavigateForgotPassword: () -> Unit
+) {
+    val loginState by viewModel.loginState.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    LaunchedEffect(loginState) {
+        if (loginState is LoginUiState.Success) {
+            onLoginSuccess()
+        }
+    }
+
+    val isLoading = loginState is LoginUiState.Loading
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Connexion",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            AuthTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = "Email",
+                enabled = !isLoading,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                modifier = Modifier.fillMaxWidth().semantics {
+                    testTag = "field_email"
+                    contentDescription = "Adresse email"
+                }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = "Mot de passe",
+                isPassword = true,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth().semantics {
+                    testTag = "field_password"
+                    contentDescription = "Mot de passe"
+                }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (loginState is LoginUiState.Error) {
+                AuthErrorMessage(
+                    message = (loginState as LoginUiState.Error).message,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthPrimaryButton(
+                text = "Se connecter",
+                onClick = { viewModel.login(email, password) },
+                isLoading = isLoading,
+                modifier = Modifier.fillMaxWidth().semantics { testTag = "btn_login" }
+            )
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val url = viewModel.getGoogleStartUrl()
+                        if (url != null) {
+                            CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(url))
+                        }
+                    }
+                },
+                enabled = !isLoading,
+                border = BorderStroke(1.dp, MaterialTheme.colorScheme.tertiary),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = MaterialTheme.colorScheme.tertiary
+                ),
+                modifier = Modifier.fillMaxWidth().semantics { testTag = "btn_google_oauth" }
+            ) {
+                Text("Continuer avec Google")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            TextButton(
+                onClick = onNavigateForgotPassword,
+                modifier = Modifier.semantics { testTag = "link_forgot_password" }
+            ) {
+                Text(
+                    text = "Mot de passe oublié ?",
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            }
+
+            TextButton(onClick = onNavigateRegister) {
+                Text(
+                    text = "Créer un compte",
+                    color = MaterialTheme.colorScheme.tertiary
+                )
+            }
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LoginScreen` (function) — lines 43-170

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.md
@@ -1,0 +1,161 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt
+git_blob: 1335d4fe0118b19b3c4d0b30f234167b11893ec2
+last_synced: '2026-05-07T02:02:39Z'
+loc: 130
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreen.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.collectAsState
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthErrorMessage
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthPrimaryButton
+import fr.datasaillance.nightfall.ui.screens.auth.components.AuthTextField
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+import fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState
+
+@Composable
+fun RegisterScreen(
+    viewModel: AuthViewModel,
+    onRegisterSuccess: () -> Unit,
+    registrationToken: String? = null
+) {
+    val registerState by viewModel.registerState.collectAsState()
+
+    var email by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var confirmPassword by remember { mutableStateOf("") }
+
+    LaunchedEffect(registerState) {
+        if (registerState is RegisterUiState.Success) {
+            onRegisterSuccess()
+        }
+    }
+
+    val isLoading = registerState is RegisterUiState.Loading
+    val passwordsMatch = password == confirmPassword && password.isNotEmpty()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "Créer un compte",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            AuthTextField(
+                value = email,
+                onValueChange = { email = it },
+                label = "Email",
+                enabled = !isLoading,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthTextField(
+                value = password,
+                onValueChange = { password = it },
+                label = "Mot de passe",
+                isPassword = true,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            AuthTextField(
+                value = confirmPassword,
+                onValueChange = { confirmPassword = it },
+                label = "Confirmer le mot de passe",
+                isPassword = true,
+                isError = confirmPassword.isNotEmpty() && !passwordsMatch,
+                enabled = !isLoading,
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            if (confirmPassword.isNotEmpty() && !passwordsMatch) {
+                Spacer(modifier = Modifier.height(8.dp))
+                AuthErrorMessage(
+                    message = "Les mots de passe ne correspondent pas",
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            if (registerState is RegisterUiState.Error) {
+                Spacer(modifier = Modifier.height(8.dp))
+                AuthErrorMessage(
+                    message = (registerState as RegisterUiState.Error).message,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            AuthPrimaryButton(
+                text = "S'inscrire",
+                onClick = { viewModel.register(email, password, registrationToken = registrationToken) },
+                isLoading = isLoading,
+                enabled = passwordsMatch,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `RegisterScreen` (function) — lines 31-130

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.md
@@ -1,0 +1,54 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt
+git_blob: eb347a1579322297e5763a2317496892b1efce4f
+last_synced: '2026-05-07T02:02:39Z'
+loc: 23
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthErrorMessage.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+
+@Composable
+fun AuthErrorMessage(
+    message: String,
+    modifier: Modifier = Modifier
+) {
+    Text(
+        text = message,
+        color = MaterialTheme.colorScheme.error,
+        modifier = modifier.semantics {
+            liveRegion = LiveRegionMode.Polite
+        }
+    )
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `AuthErrorMessage` (function) — lines 11-23

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.md
@@ -1,0 +1,69 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt
+git_blob: d7a94c4b3f96c4b9db123811c4bfbcea909e55bb
+last_synced: '2026-05-07T02:02:39Z'
+loc: 38
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthPrimaryButton.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth.components
+
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+
+@Composable
+fun AuthPrimaryButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled && !isLoading,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.secondary
+        )
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.onSecondary,
+                modifier = Modifier.semantics { contentDescription = "Chargement en cours" }
+            )
+        } else {
+            Text(text)
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `AuthPrimaryButton` (function) — lines 13-38

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.md
@@ -1,0 +1,85 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt
+git_blob: 54bb7b1eb9f0d6a6747c3426c3211bcf55df905f
+last_synced: '2026-05-07T02:02:39Z'
+loc: 54
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/components/AuthTextField.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth.components
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+
+@Composable
+fun AuthTextField(
+    value: String,
+    onValueChange: (String) -> Unit,
+    label: String,
+    modifier: Modifier = Modifier,
+    isPassword: Boolean = false,
+    isError: Boolean = false,
+    enabled: Boolean = true,
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default
+) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChange,
+        label = { Text(label) },
+        modifier = modifier,
+        isError = isError,
+        enabled = enabled,
+        visualTransformation = if (isPassword && !passwordVisible) PasswordVisualTransformation() else VisualTransformation.None,
+        keyboardOptions = keyboardOptions,
+        singleLine = true,
+        trailingIcon = if (isPassword) {
+            {
+                val icon = if (passwordVisible) Icons.Filled.Visibility else Icons.Filled.VisibilityOff
+                val desc = if (passwordVisible) "Masquer le mot de passe" else "Afficher le mot de passe"
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(imageVector = icon, contentDescription = desc)
+                }
+            }
+        } else null
+    )
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `AuthTextField` (function) — lines 21-54

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt
-git_blob: 929fbd9b1761671d3937bcbf97b76df8e6e99a66
-last_synced: '2026-05-07T00:48:24Z'
-loc: 9
+git_blob: 3103a4b1522e3e6ef7195f24301304182da21f28
+last_synced: '2026-05-07T03:10:49Z'
+loc: 365
 annotations: []
 imports: []
 exports: []
@@ -23,12 +23,368 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.ui.screens.import_
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import fr.datasaillance.nightfall.R
+import fr.datasaillance.nightfall.domain.import_.ImportUiState
+import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ImportScreen(
+    viewModel: ImportViewModel,
+    onNavigateBack: () -> Unit,
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocumentTree()
+    ) { uri ->
+        uri?.let { viewModel.startUpload(context.contentResolver, it) }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.import_step_upload)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Retour")
+                    }
+                },
+            )
+        },
+    ) { padding ->
+        when (val state = uiState) {
+            is ImportUiState.Idle -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                IdleContent(onCheckConnection = { viewModel.checkConnection() })
+            }
+            is ImportUiState.Connecting -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ConnectingContent()
+            }
+            is ImportUiState.ConnectionFailed -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ConnectionFailedContent(
+                    message = state.message,
+                    onRetry = { viewModel.checkConnection() },
+                )
+            }
+            is ImportUiState.Connected -> ConnectedContent(
+                onSelectFolder = { launcher.launch(null) },
+                padding = padding,
+            )
+            is ImportUiState.Selecting -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                SelectingContent()
+            }
+            is ImportUiState.Uploading -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                UploadingContent(
+                    currentType = stringResource(state.currentType.labelRes),
+                    progress = state.progress,
+                    completedCount = state.completedTypes.size,
+                    totalCount = state.completedTypes.size + state.skippedTypes.size + 1,
+                )
+            }
+            is ImportUiState.Success -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                SuccessContent(
+                    results = state.results,
+                    onDone = {
+                        viewModel.reset()
+                        onNavigateBack()
+                    },
+                )
+            }
+            is ImportUiState.Error -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ErrorContent(
+                    message = state.message,
+                    retryable = state.retryable,
+                    onRetry = { viewModel.reset() },
+                    onBack = onNavigateBack,
+                )
+            }
+        }
+    }
+}
 
 @Composable
-fun ImportScreen() {
-    Text("Import — p4-android-import")
+private fun IdleContent(onCheckConnection: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Importer des données Samsung Health",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onCheckConnection) {
+            Text("Vérifier la connexion")
+        }
+    }
+}
+
+@Composable
+private fun ConnectingContent() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Connexion au serveur…")
+    }
+}
+
+@Composable
+private fun ConnectionFailedContent(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(onClick = onRetry) {
+            Text("Réessayer")
+        }
+    }
+}
+
+@Composable
+private fun ConnectedContent(
+    onSelectFolder: () -> Unit,
+    padding: PaddingValues,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            "Connexion établie",
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        RgpdNoticeCard()
+        Button(
+            onClick = onSelectFolder,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Sélectionner le dossier Samsung Health")
+        }
+    }
+}
+
+@Composable
+private fun RgpdNoticeCard() {
+    val primary = MaterialTheme.colorScheme.primary
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.small,
+            )
+            .drawBehind {
+                drawRect(color = primary, size = size.copy(width = 4.dp.toPx()))
+            }
+            .padding(start = 12.dp, top = 12.dp, end = 12.dp, bottom = 12.dp),
+    ) {
+        Text(
+            text = buildAnnotatedString {
+                append("Ces données sont envoyées uniquement vers ")
+                withStyle(SpanStyle(fontWeight = FontWeight.SemiBold, color = primary)) {
+                    append("votre serveur")
+                }
+                append(". Elles ne transitent par aucun serveur tiers. Aucune copie n'est conservée sur cet appareil après l'import.")
+            },
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun SelectingContent() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("Sélectionnez le dossier Samsung Health…")
+    }
+}
+
+@Composable
+private fun UploadingContent(
+    currentType: String,
+    progress: Float,
+    completedCount: Int,
+    totalCount: Int,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Import en cours : $currentType",
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        LinearProgressIndicator(
+            progress = { progress },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "$completedCount / $totalCount types traités",
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun SuccessContent(
+    results: List<fr.datasaillance.nightfall.domain.import_.ImportResult>,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Import terminé",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        results.forEach { result ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(result.type.name)
+                if (result.errorMessage != null) {
+                    Text("Erreur", color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("${result.inserted} insérés, ${result.skipped} ignorés")
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onDone) {
+            Text("Terminer")
+        }
+    }
+}
+
+@Composable
+private fun ErrorContent(
+    message: String,
+    retryable: Boolean,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.error,
+            style = MaterialTheme.typography.bodyLarge,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        if (retryable) {
+            Button(onClick = onRetry) {
+                Text("Réessayer")
+            }
+        } else {
+            Button(onClick = onBack) {
+                Text("Retour")
+            }
+        }
+    }
 }
 ```
 
@@ -37,4 +393,13 @@ fun ImportScreen() {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportScreen` (function) — lines 6-9
+- `ImportScreen` (function) — lines 45-154
+- `IdleContent` (function) — lines 156-172
+- `ConnectingContent` (function) — lines 174-185
+- `ConnectionFailedContent` (function) — lines 187-204
+- `ConnectedContent` (function) — lines 206-231
+- `RgpdNoticeCard` (function) — lines 233-259
+- `SelectingContent` (function) — lines 261-270
+- `UploadingContent` (function) — lines 272-299
+- `SuccessContent` (function) — lines 301-335
+- `ErrorContent` (function) — lines 337-365

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.md
@@ -1,0 +1,38 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt
+git_blob: 163687e8daf1eac2d5a2aec739ca682e39821544
+last_synced: '2026-05-07T03:10:49Z'
+loc: 7
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportStep.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.import_
+
+sealed class ImportStep(val index: Int, val label: String) {
+    object Connection : ImportStep(1, "Connexion")
+    object Selection  : ImportStep(2, "Sélection")
+    object Upload     : ImportStep(3, "Import")
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportStep` (class) — lines 3-7

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.md
@@ -1,0 +1,58 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt
+git_blob: f15b74f2c8680c36ad2fbad88b14a3c0cdd5e87e
+last_synced: '2026-05-07T02:02:39Z'
+loc: 22
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthUiState.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.auth
+
+sealed class LoginUiState {
+    object Idle : LoginUiState()
+    object Loading : LoginUiState()
+    object Success : LoginUiState()
+    data class Error(val message: String) : LoginUiState()
+}
+
+sealed class RegisterUiState {
+    object Idle : RegisterUiState()
+    object Loading : RegisterUiState()
+    object Success : RegisterUiState()
+    data class Error(val message: String) : RegisterUiState()
+}
+
+sealed class ForgotPasswordUiState {
+    object Idle : ForgotPasswordUiState()
+    object Loading : ForgotPasswordUiState()
+    object Sent : ForgotPasswordUiState()
+    data class Error(val message: String) : ForgotPasswordUiState()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LoginUiState` (class) — lines 3-8
+- `Error` (class) — lines 7-7
+- `RegisterUiState` (class) — lines 10-15
+- `Error` (class) — lines 14-14
+- `ForgotPasswordUiState` (class) — lines 17-22
+- `Error` (class) — lines 21-21

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.md
@@ -1,0 +1,132 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt
+git_blob: 95aeee7ef4a9a4dbe702cf9a6ca50fd24895cd4e
+last_synced: '2026-05-07T02:02:39Z'
+loc: 94
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.GoogleStartRequest
+import fr.datasaillance.nightfall.data.http.LoginRequest
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.http.PasswordResetRequest
+import fr.datasaillance.nightfall.data.http.RegisterRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.IOException
+
+class AuthViewModel(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore
+) : ViewModel() {
+
+    private val _loginState = MutableStateFlow<LoginUiState>(LoginUiState.Idle)
+    val loginState: StateFlow<LoginUiState> = _loginState.asStateFlow()
+
+    private val _registerState = MutableStateFlow<RegisterUiState>(RegisterUiState.Idle)
+    val registerState: StateFlow<RegisterUiState> = _registerState.asStateFlow()
+
+    private val _forgotState = MutableStateFlow<ForgotPasswordUiState>(ForgotPasswordUiState.Idle)
+    val forgotState: StateFlow<ForgotPasswordUiState> = _forgotState.asStateFlow()
+
+    fun login(email: String, password: String) {
+        _loginState.value = LoginUiState.Loading
+        viewModelScope.launch {
+            try {
+                val response = api.login(LoginRequest(email, password))
+                tokenDataStore.saveToken(response.access_token)
+                _loginState.value = LoginUiState.Success
+            } catch (e: retrofit2.HttpException) {
+                _loginState.value = LoginUiState.Error(mapHttpError(e.code()))
+            } catch (e: IOException) {
+                _loginState.value = LoginUiState.Error("Vérifiez votre connexion réseau")
+            }
+        }
+    }
+
+    fun register(email: String, password: String, registrationToken: String?) {
+        _registerState.value = RegisterUiState.Loading
+        viewModelScope.launch {
+            try {
+                api.register(RegisterRequest(email, password), registrationToken)
+                _registerState.value = RegisterUiState.Success
+            } catch (e: retrofit2.HttpException) {
+                _registerState.value = RegisterUiState.Error(mapHttpError(e.code()))
+            } catch (e: IOException) {
+                _registerState.value = RegisterUiState.Error("Vérifiez votre connexion réseau")
+            }
+        }
+    }
+
+    fun requestPasswordReset(email: String) {
+        _forgotState.value = ForgotPasswordUiState.Loading
+        viewModelScope.launch {
+            try {
+                api.requestPasswordReset(PasswordResetRequest(email))
+            } catch (e: Exception) {
+                // intentional fall-through — anti-enum: always emit Sent
+            }
+            _forgotState.value = ForgotPasswordUiState.Sent
+        }
+    }
+
+    suspend fun getGoogleStartUrl(): String? = try {
+        api.googleStart(GoogleStartRequest()).authorize_url
+    } catch (e: Exception) {
+        null
+    }
+
+    fun storeTokenFromCallback(token: String) {
+        tokenDataStore.saveToken(token)
+        _loginState.value = LoginUiState.Success
+    }
+
+    fun setLoginError(message: String) {
+        _loginState.value = LoginUiState.Error(message)
+    }
+
+    private fun mapHttpError(code: Int): String = when (code) {
+        401 -> "Email ou mot de passe incorrect"
+        403 -> "Email non vérifié — consultez votre boîte mail"
+        409 -> "Cette adresse email est déjà utilisée"
+        400 -> "Mot de passe trop faible (12 caractères minimum, majuscule, chiffre, symbole)"
+        else -> "Erreur serveur ($code)"
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `AuthViewModel` (class) — lines 17-94
+- `login` (function) — lines 31-44
+- `register` (function) — lines 46-58
+- `requestPasswordReset` (function) — lines 60-70
+- `getGoogleStartUrl` (function) — lines 72-76
+- `storeTokenFromCallback` (function) — lines 78-81
+- `setLoginError` (function) — lines 83-85
+- `mapHttpError` (function) — lines 87-93

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.md
@@ -1,0 +1,133 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
+git_blob: 85fcb95df8c1dee7501bee28dcb5fce4643c0d3b
+last_synced: '2026-05-07T03:10:49Z'
+loc: 99
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.import_
+
+import android.content.ContentResolver
+import android.net.Uri
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.import_.ImportRepository
+import fr.datasaillance.nightfall.domain.import_.ImportDataType
+import fr.datasaillance.nightfall.domain.import_.ImportResult
+import fr.datasaillance.nightfall.domain.import_.ImportUiState
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ImportViewModel(
+    private val repository: ImportRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<ImportUiState>(ImportUiState.Idle)
+    val uiState: StateFlow<ImportUiState> = _uiState.asStateFlow()
+
+    fun checkConnection() {
+        _uiState.value = ImportUiState.Connecting
+        viewModelScope.launch {
+            val ok = repository.pingBackend()
+            _uiState.value = if (ok) {
+                ImportUiState.Connected
+            } else {
+                ImportUiState.ConnectionFailed("Backend inaccessible — vérifiez l'URL dans les paramètres")
+            }
+        }
+    }
+
+    fun startUpload(contentResolver: ContentResolver, treeUri: Uri) {
+        viewModelScope.launch {
+            val csvEntries = repository.extractCsvEntries(contentResolver, treeUri)
+            if (csvEntries.isEmpty()) {
+                _uiState.value = ImportUiState.Error(
+                    message = "Aucun fichier Samsung Health reconnu dans l'archive.",
+                    retryable = true,
+                )
+                return@launch
+            }
+            val results = mutableListOf<ImportResult>()
+            val completed = mutableListOf<ImportDataType>()
+            val skipped = mutableListOf<ImportDataType>()
+
+            for (type in ImportDataType.entries) {
+                val entry = csvEntries[type]
+                if (entry == null) {
+                    skipped.add(type)
+                    continue
+                }
+                try {
+                    _uiState.value = ImportUiState.Uploading(
+                        currentType = type,
+                        progress = 0f,
+                        completedTypes = completed.toList(),
+                        skippedTypes = skipped.toList(),
+                    )
+                    val result = repository.uploadCsv(
+                        contentResolver = contentResolver,
+                        uri = entry.uri,
+                        type = type,
+                        totalBytes = entry.size,
+                        onProgress = { progress ->
+                            _uiState.value = ImportUiState.Uploading(
+                                currentType = type,
+                                progress = progress,
+                                completedTypes = completed.toList(),
+                                skippedTypes = skipped.toList(),
+                            )
+                        },
+                    )
+                    results.add(result)
+                    completed.add(type)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    results.add(
+                        ImportResult(
+                            type = type,
+                            inserted = 0,
+                            skipped = 0,
+                            errorMessage = e.message,
+                        )
+                    )
+                }
+            }
+            _uiState.value = ImportUiState.Success(results)
+        }
+    }
+
+    fun reset() {
+        _uiState.value = ImportUiState.Idle
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportViewModel` (class) — lines 17-99
+- `checkConnection` (function) — lines 24-34
+- `startUpload` (function) — lines 36-94
+- `reset` (function) — lines 96-98

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.md
@@ -1,0 +1,220 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt
+git_blob: 3e49ee77ae759d28d20c686e8bcde7a466a4d00d
+last_synced: '2026-05-07T03:10:49Z'
+loc: 182
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.http
+
+// spec: Tests d'acceptation TA-06
+// spec: section "CountingRequestBody" + "Architecture" + "D3 / D9"
+// RED by construction: fr.datasaillance.nightfall.data.http.CountingRequestBody does not exist yet
+
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.Buffer
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+// This import will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.data.http.CountingRequestBody
+
+class CountingRequestBodyTest {
+
+    // spec: TA-06 — onProgress is called at least twice when writing in chunks
+    @Test
+    fun writeTo_onProgressCalledAtLeastTwice() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — onProgress must be invoked at least twice (at least one intermediate + final)
+        assert(progressValues.size >= 2) {
+            "onProgress must be called at least twice during writeTo — spec: TA-06, called ${progressValues.size} times"
+        }
+    }
+
+    // spec: TA-06 — last onProgress value is 1.0f
+    @Test
+    fun writeTo_lastProgressValueIsOne() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — the last callback value must be exactly 1.0f
+        val lastProgress = progressValues.last()
+        assertEquals(
+            "Last onProgress value must be 1.0f — spec: TA-06",
+            1.0f,
+            lastProgress,
+            0.0001f,
+        )
+    }
+
+    // spec: TA-06 — no onProgress value exceeds 1.0f
+    @Test
+    fun writeTo_noProgressValueExceedsOne() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — progress is coerced via coerceIn(0f, 1f); no value must exceed 1.0f
+        val exceeded = progressValues.filter { it > 1.0f }
+        assertTrue(
+            "No onProgress value must exceed 1.0f — spec: TA-06, violations: $exceeded",
+            exceeded.isEmpty(),
+        )
+    }
+
+    // spec: D9 / TA-06 — contentLength() returns totalBytes
+    @Test
+    fun contentLength_returnsTotalBytes() {
+        val content = ByteArray(500) { 0x00.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val totalBytes = 1234L  // intentionally different from content size to verify delegation
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = totalBytes,
+            onProgress = {},
+        )
+
+        // spec: D9 — contentLength() must return the totalBytes constructor parameter, not delegate.contentLength()
+        assertEquals(
+            "contentLength() must return totalBytes passed to constructor — spec: D9 / TA-06",
+            totalBytes,
+            counting.contentLength(),
+        )
+    }
+
+    // spec: TA-06 — contentType() delegates to the wrapped RequestBody
+    @Test
+    fun contentType_delegatesToWrappedBody() {
+        val content = ByteArray(100) { 0x00.toByte() }
+        val mediaType = "text/csv".toMediaType()
+        val delegate = content.toRequestBody(mediaType)
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 100L,
+            onProgress = {},
+        )
+
+        // spec: TA-06 — contentType() must return the same MediaType as the delegate
+        val returned = counting.contentType()
+        assertEquals(
+            "contentType() must delegate to wrapped RequestBody — spec: TA-06",
+            mediaType.toString(),
+            returned?.toString(),
+        )
+    }
+
+    // spec: TA-06 — all bytes are written to the sink (no truncation)
+    @Test
+    fun writeTo_allBytesWrittenToSink() {
+        val content = ByteArray(1000) { it.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = {},
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: D3 — streaming must not truncate bytes; all content must be written
+        assertEquals(
+            "writeTo must write all bytes to sink — spec: D3 / TA-06",
+            1000L,
+            sink.size,
+        )
+    }
+
+    // spec: TA-06 (edge) — progress values are monotonically non-decreasing
+    @Test
+    fun writeTo_progressIsMonotonicallyNonDecreasing() {
+        val content = ByteArray(1000) { 0x42.toByte() }
+        val delegate = content.toRequestBody("text/csv".toMediaType())
+        val progressValues = mutableListOf<Float>()
+
+        val counting = CountingRequestBody(
+            delegate = delegate,
+            totalBytes = 1000L,
+            onProgress = { progressValues.add(it) },
+        )
+
+        val sink = Buffer()
+        counting.writeTo(sink)
+
+        // spec: TA-06 — each progress value must be >= the previous one (monotonic progress)
+        for (i in 1 until progressValues.size) {
+            assertTrue(
+                "onProgress values must be non-decreasing — spec: TA-06, index $i: ${progressValues[i - 1]} → ${progressValues[i]}",
+                progressValues[i] >= progressValues[i - 1],
+            )
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `CountingRequestBodyTest` (class) — lines 18-182
+- `writeTo_onProgressCalledAtLeastTwice` (function) — lines 21-40
+- `writeTo_lastProgressValueIsOne` (function) — lines 43-66
+- `writeTo_noProgressValueExceedsOne` (function) — lines 69-90
+- `contentLength_returnsTotalBytes` (function) — lines 93-111
+- `contentType_delegatesToWrappedBody` (function) — lines 114-133
+- `writeTo_allBytesWrittenToSink` (function) — lines 136-156
+- `writeTo_progressIsMonotonicallyNonDecreasing` (function) — lines 159-181

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.md
@@ -1,0 +1,105 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt
+git_blob: 85c533b7377d73106c8301d4c847d4c86d527af3
+last_synced: '2026-05-07T02:02:39Z'
+loc: 71
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+// spec: Tests d'acceptation TA-AUTH-07
+// spec: section "ForgotPasswordScreen" layout + "Parité light / dark mode"
+// RED by construction: fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen does not exist yet
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+
+class ForgotPasswordScreenTest {
+
+    // spec: D10 — Paparazzi offline screenshot tests
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        // spec: D1 — AuthViewModel constructed directly without Hilt (issue #52)
+        return fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    // spec: TA-AUTH-07 — ForgotPasswordScreen dark mode, state = ForgotPasswordUiState.Idle
+    // spec: section "ForgotPasswordScreen" — titre, champ email, bouton "Envoyer le lien"
+    @Test
+    fun forgotPasswordScreen_idle_dark() {
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen(
+                    viewModel = viewModel,
+                    onBack = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-07 — Idle state: titre visible, AuthTextField email, bouton "Envoyer le lien"
+    }
+
+    // spec: TA-AUTH-07 — ForgotPasswordScreen dark mode, state = ForgotPasswordUiState.Sent
+    // spec: section "ForgotPasswordScreen" — "Un email a été envoyé si ce compte existe." (anti-enum)
+    @Test
+    fun forgotPasswordScreen_sent_dark() {
+        // spec: TA-AUTH-07 — anti-enum: same confirmation message regardless of whether account exists
+        // The Screen replaces the form with a confirmation message when forgotState == Sent
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen(
+                    viewModel = viewModel,
+                    onBack = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-07 — Sent state: form replaced by "Un email a été envoyé si ce compte existe."
+        // spec: TA-AUTH-07 — TextButton "Retour à la connexion" remains visible
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ForgotPasswordScreenTest` (class) — lines 19-71
+- `buildViewModel` (function) — lines 28-33
+- `forgotPasswordScreen_idle_dark` (function) — lines 37-50
+- `forgotPasswordScreen_sent_dark` (function) — lines 54-70

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.md
@@ -1,0 +1,167 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
+git_blob: e74f61d57f8c4c0eaa5efaa3b0f43b0b9b14ae48
+last_synced: '2026-05-07T02:02:39Z'
+loc: 131
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+// spec: Tests d'acceptation TA-AUTH-04, TA-AUTH-12
+// spec: section "LoginScreen" layout + "Parité light / dark mode"
+// RED by construction: fr.datasaillance.nightfall.ui.screens.auth.LoginScreen does not exist yet
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import kotlinx.coroutines.flow.MutableStateFlow
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.ui.screens.auth.LoginScreen
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.LoginUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+
+class LoginScreenTest {
+
+    // spec: TA-AUTH-12 / D10 — Paparazzi offline screenshot tests
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(
+        loginState: fr.datasaillance.nightfall.viewmodel.auth.LoginUiState = fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle
+    ): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        val viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+        // Inject desired initial state by manipulating the ViewModel's internal flow
+        // The ViewModel exposes loginState: StateFlow<LoginUiState> — we rely on its initial value
+        // For non-Idle states, we call the relevant method after mocking api responses,
+        // but for snapshot tests the ViewModel is used as a state holder via collectAsState().
+        // spec: D1 — AuthViewModel is shared; state is injected via mock configuration
+        return viewModel
+    }
+
+    // spec: TA-AUTH-12 — LoginScreen dark mode, state = LoginUiState.Idle
+    // spec: "Parité light / dark mode" — fond #191E22, CTA #D37C04, lien #07BCD3
+    @Test
+    fun loginScreen_idle_dark() {
+        val viewModel = buildViewModel(fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-12 — snapshot must match golden: fond #191E22, CTA #D37C04, lien #07BCD3
+    }
+
+    // spec: TA-AUTH-12 — LoginScreen light mode, state = LoginUiState.Idle
+    // spec: "Parité light / dark mode" — fond #FAFAFA, même CTA #D37C04
+    @Test
+    fun loginScreen_idle_light() {
+        val viewModel = buildViewModel(fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = false) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-12 — snapshot light: fond #FAFAFA, CTA #D37C04
+    }
+
+    // spec: TA-AUTH-02 / TA-AUTH-03 — LoginScreen shows inline error message (no dialog)
+    // spec: section "LoginScreen" — AuthErrorMessage visible si LoginUiState.Error
+    @Test
+    fun loginScreen_error_dark() {
+        // For the error state snapshot, we need the ViewModel to be in Error state.
+        // Since AuthViewModel doesn't exist yet, this import fails RED as intended.
+        // When implemented, call viewModel._loginState.value = LoginUiState.Error(...)
+        // or use a fake ViewModel. For now the class import is the RED trigger.
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        val viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-AUTH-02 — error is displayed inline under the form fields
+                // The Screen must reflect LoginUiState.Error from the ViewModel's StateFlow
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-02 — AuthErrorMessage visible, no Dialog; password field still editable
+    }
+
+    // spec: TA-AUTH-04 — LoginScreen loading state: button disabled, CircularProgressIndicator visible
+    // spec: section "AuthPrimaryButton" — isLoading replaces text with CircularProgressIndicator
+    @Test
+    fun loginScreen_loading_dark() {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        val viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-AUTH-04 — AuthPrimaryButton enabled=false, CircularProgressIndicator shown
+                // spec: TA-AUTH-04 — AuthTextField enabled=false when Loading
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-04 — loading state: button disabled, fields disabled, progress indicator visible
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LoginScreenTest` (class) — lines 21-131
+- `buildViewModel` (function) — lines 30-42
+- `loginScreen_idle_dark` (function) — lines 46-61
+- `loginScreen_idle_light` (function) — lines 65-80
+- `loginScreen_error_dark` (function) — lines 84-107
+- `loginScreen_loading_dark` (function) — lines 111-130

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.md
@@ -1,0 +1,125 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt
+git_blob: 75f74eb966726aecef7bff3438b888fc115832b5
+last_synced: '2026-05-07T02:02:39Z'
+loc: 90
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.auth
+
+// spec: Tests d'acceptation TA-AUTH-05, TA-AUTH-06
+// spec: section "RegisterScreen" layout + "Parité light / dark mode"
+// RED by construction: fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen does not exist yet
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+
+class RegisterScreenTest {
+
+    // spec: D10 — Paparazzi offline screenshot tests
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        // spec: D1 — AuthViewModel constructed directly without Hilt (issue #52)
+        return fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    // spec: TA-AUTH-05 — RegisterScreen dark mode, state = RegisterUiState.Idle
+    // spec: "Parité light / dark mode" — fond #191E22, CTA #D37C04
+    @Test
+    fun registerScreen_idle_dark() {
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen(
+                    viewModel = viewModel,
+                    onRegisterSuccess = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-05 — screenshot dark: fond #191E22, 3 AuthTextFields, CTA "S'inscrire" #D37C04
+    }
+
+    // spec: TA-AUTH-05 — RegisterScreen light mode, state = RegisterUiState.Idle
+    // spec: "Parité light / dark mode" — fond #FAFAFA, CTA #D37C04
+    @Test
+    fun registerScreen_idle_light() {
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = false) {
+                fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen(
+                    viewModel = viewModel,
+                    onRegisterSuccess = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-05 — screenshot light: fond #FAFAFA, CTA #D37C04
+    }
+
+    // spec: TA-AUTH-06 — RegisterScreen: password != confirmation → "S'inscrire" button disabled
+    // spec: section "RegisterScreen" — validation inline: mots de passe doivent être identiques avant envoi
+    @Test
+    fun registerScreen_passwordMismatch_dark() {
+        // spec: TA-AUTH-06 — password mismatch is a client-side guard, no network call
+        // The Screen receives password and confirmation as local state; when they differ,
+        // AuthPrimaryButton must have enabled=false.
+        val viewModel = buildViewModel()
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-AUTH-06 — "S'inscrire" button must be disabled when password != confirmation
+                // Screen handles this via local Compose state — no ViewModel call needed
+                fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen(
+                    viewModel = viewModel,
+                    onRegisterSuccess = {}
+                )
+            }
+        }
+        // spec: TA-AUTH-06 — AuthPrimaryButton enabled=false; no POST /auth/register call made
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `RegisterScreenTest` (class) — lines 19-90
+- `buildViewModel` (function) — lines 28-33
+- `registerScreen_idle_dark` (function) — lines 37-50
+- `registerScreen_idle_light` (function) — lines 54-67
+- `registerScreen_passwordMismatch_dark` (function) — lines 71-89

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.md
@@ -1,0 +1,342 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt
+git_blob: 7fefd68003ff409094d6e3bdf0fd1acf07e22476
+last_synced: '2026-05-07T02:02:39Z'
+loc: 296
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.auth
+
+// spec: Tests d'acceptation TA-AUTH-01 through TA-AUTH-10
+// spec: section "AuthViewModel" + "Tests d'acceptation"
+// RED by construction: fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel does not exist yet
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.HttpException
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+// fr.datasaillance.nightfall.viewmodel.auth.LoginUiState
+// fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState
+// fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState
+// fr.datasaillance.nightfall.data.http.NightfallApi (auth methods don't exist yet)
+// fr.datasaillance.nightfall.data.http.LoginRequest
+// fr.datasaillance.nightfall.data.http.LoginResponse
+// fr.datasaillance.nightfall.data.http.RegisterRequest
+// fr.datasaillance.nightfall.data.http.RegisterResponse
+// fr.datasaillance.nightfall.data.http.PasswordResetRequest
+// fr.datasaillance.nightfall.data.http.StatusResponse
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var api: fr.datasaillance.nightfall.data.http.NightfallApi
+    private lateinit var tokenDataStore: fr.datasaillance.nightfall.data.auth.TokenDataStore
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
+
+    @Before
+    fun setUp() {
+        // spec: TA-AUTH-04 — viewModelScope.launch must use a test dispatcher
+        Dispatchers.setMain(testDispatcher)
+        api = mock()
+        tokenDataStore = mock()
+        // spec: D1 — AuthViewModel constructed directly without Hilt (issue #52)
+        viewModel = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-AUTH-01 — login() success → saveToken() called, state is LoginUiState.Success
+    @Test
+    fun login_success_savesTokenAndEmitsSuccess() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.LoginResponse(
+            access_token = "tok_abc",
+            refresh_token = "ref_abc",
+            token_type = "bearer",
+            expires_in = 3600
+        )
+        whenever(api.login(any())).thenReturn(fakeResponse)
+
+        viewModel.login("user@example.com", "password123")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-01 — tokenDataStore.saveToken() called with the access_token
+        verify(tokenDataStore).saveToken("tok_abc")
+
+        // spec: TA-AUTH-01 — loginState must be LoginUiState.Success
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Success) {
+            "loginState must be LoginUiState.Success after successful login — spec: TA-AUTH-01, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-02 — login() HTTP 401 → LoginUiState.Error("Email ou mot de passe incorrect")
+    @Test
+    fun login_http401_emitsErrorInvalidCredentials() = runTest {
+        val httpException = mock<HttpException>()
+        whenever(httpException.code()).thenReturn(401)
+        whenever(api.login(any())).thenThrow(httpException)
+
+        viewModel.login("bad@example.com", "wrongpassword")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-02 — saveToken() must NOT be called on 401
+        verify(tokenDataStore, never()).saveToken(any())
+
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error) {
+            "loginState must be LoginUiState.Error on HTTP 401 — spec: TA-AUTH-02, got: $state"
+        }
+        val errorMessage = (state as fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error).message
+        assert(errorMessage == "Email ou mot de passe incorrect") {
+            "Error message for HTTP 401 must be 'Email ou mot de passe incorrect' — spec: TA-AUTH-02, got: '$errorMessage'"
+        }
+    }
+
+    // spec: TA-AUTH-03 — login() HTTP 403 → LoginUiState.Error("Email non vérifié — consultez votre boîte mail")
+    @Test
+    fun login_http403_emitsErrorEmailNotVerified() = runTest {
+        val httpException = mock<HttpException>()
+        whenever(httpException.code()).thenReturn(403)
+        whenever(api.login(any())).thenThrow(httpException)
+
+        viewModel.login("unverified@example.com", "password123")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-03 — saveToken() must NOT be called on 403
+        verify(tokenDataStore, never()).saveToken(any())
+
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error) {
+            "loginState must be LoginUiState.Error on HTTP 403 — spec: TA-AUTH-03, got: $state"
+        }
+        val errorMessage = (state as fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Error).message
+        assert(errorMessage == "Email non vérifié — consultez votre boîte mail") {
+            "Error message for HTTP 403 must be 'Email non vérifié — consultez votre boîte mail' — spec: TA-AUTH-03, got: '$errorMessage'"
+        }
+    }
+
+    // spec: TA-AUTH-04 — loginState is LoginUiState.Loading while request is in-flight
+    @Test
+    fun login_emitsLoadingWhileInFlight() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.LoginResponse(
+            access_token = "tok",
+            refresh_token = "ref",
+            token_type = "bearer",
+            expires_in = 3600
+        )
+        whenever(api.login(any())).thenReturn(fakeResponse)
+
+        // spec: TA-AUTH-04 — state must be Loading synchronously before coroutine completes
+        viewModel.login("user@example.com", "password123")
+
+        // Before advanceUntilIdle() — coroutine is suspended at the api.login() call
+        val stateWhileInFlight = viewModel.loginState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Loading) {
+            "loginState must be LoginUiState.Loading immediately after login() call — spec: TA-AUTH-04, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+
+    // spec: TA-AUTH-05 — register() HTTP 201 → RegisterUiState.Success
+    @Test
+    fun register_success_emitsSuccess() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.RegisterResponse(
+            id = "user-uuid-123",
+            email = "new@example.com"
+        )
+        whenever(api.register(any(), any())).thenReturn(fakeResponse)
+
+        viewModel.register("new@example.com", "StrongP@ss1", registrationToken = "reg-token")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-05 — registerState must be RegisterUiState.Success
+        val state = viewModel.registerState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.RegisterUiState.Success) {
+            "registerState must be RegisterUiState.Success on HTTP 201 — spec: TA-AUTH-05, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-07 — requestPasswordReset() always → ForgotPasswordUiState.Sent (anti-enum)
+    @Test
+    fun requestPasswordReset_alwaysEmitsSent_onSuccess() = runTest {
+        val fakeResponse = fr.datasaillance.nightfall.data.http.StatusResponse(status = "pending")
+        whenever(api.requestPasswordReset(any())).thenReturn(fakeResponse)
+
+        viewModel.requestPasswordReset("any@example.com")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-07 — ForgotPasswordUiState.Sent regardless of backend response
+        val state = viewModel.forgotState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState.Sent) {
+            "forgotState must be ForgotPasswordUiState.Sent on success — spec: TA-AUTH-07, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-07 — requestPasswordReset() always → ForgotPasswordUiState.Sent even on exception (anti-enum)
+    @Test
+    fun requestPasswordReset_alwaysEmitsSent_onNetworkError() = runTest {
+        whenever(api.requestPasswordReset(any())).thenThrow(RuntimeException("Network timeout"))
+
+        viewModel.requestPasswordReset("any@example.com")
+        advanceUntilIdle()
+
+        // spec: TA-AUTH-07 — anti-enum: Sent even when backend throws (prevents account enumeration)
+        val state = viewModel.forgotState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.ForgotPasswordUiState.Sent) {
+            "forgotState must be ForgotPasswordUiState.Sent even on network error — spec: TA-AUTH-07, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-08 — storeTokenFromCallback("valid_jwt") → saveToken called, state is LoginUiState.Success
+    @Test
+    fun storeTokenFromCallback_validToken_savesTokenAndEmitsSuccess() {
+        viewModel.storeTokenFromCallback("valid_jwt_token_xyz")
+
+        // spec: TA-AUTH-08 — tokenDataStore.saveToken() must be called with the token value
+        verify(tokenDataStore).saveToken("valid_jwt_token_xyz")
+
+        // spec: TA-AUTH-08 — loginState must be LoginUiState.Success
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Success) {
+            "loginState must be LoginUiState.Success after storeTokenFromCallback — spec: TA-AUTH-08, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-09 — The Screen handles null/empty token before calling storeTokenFromCallback.
+    // The ViewModel's storeTokenFromCallback(token) with a valid token must call saveToken.
+    // Verifying the contract: saveToken is NOT called when the Screen withholds the call.
+    // We test initial state: before any storeTokenFromCallback call, saveToken has never been invoked.
+    @Test
+    fun tokenDataStore_saveToken_notCalled_untilStoreTokenFromCallbackInvoked() {
+        // spec: TA-AUTH-09 — saveToken() must NOT be called if the Screen never invokes storeTokenFromCallback
+        // (Screen is responsible for guarding against null/empty token)
+        verify(tokenDataStore, never()).saveToken(any())
+
+        // spec: TA-AUTH-09 — initial state is LoginUiState.Idle (not Success, not Error)
+        val state = viewModel.loginState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Idle) {
+            "loginState must be LoginUiState.Idle before any action — spec: TA-AUTH-09, got: $state"
+        }
+    }
+
+    // spec: TA-AUTH-10 — No Timber log contains the JWT value after successful login
+    @Test
+    fun login_success_doesNotLogTokenValue() = runTest {
+        val sensitiveToken = "super-secret-jwt-do-not-log-me-12345"
+        val fakeResponse = fr.datasaillance.nightfall.data.http.LoginResponse(
+            access_token = sensitiveToken,
+            refresh_token = "ref_token",
+            token_type = "bearer",
+            expires_in = 3600
+        )
+        whenever(api.login(any())).thenReturn(fakeResponse)
+
+        // Capture Timber logs via a custom tree
+        val loggedMessages = mutableListOf<String>()
+        val testTree = object : timber.log.Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                loggedMessages.add(message)
+                t?.message?.let { loggedMessages.add(it) }
+            }
+        }
+        timber.log.Timber.plant(testTree)
+
+        viewModel.login("user@example.com", "MyPassword123!")
+        advanceUntilIdle()
+
+        timber.log.Timber.uproot(testTree)
+
+        // spec: TA-AUTH-10 / D12 — no log line must contain the access_token value
+        val leaked = loggedMessages.filter { it.contains(sensitiveToken) }
+        assert(leaked.isEmpty()) {
+            "Timber logs must NOT contain the JWT access_token value — spec: TA-AUTH-10, D12. Found: $leaked"
+        }
+    }
+
+    // spec: TA-AUTH-10 — No Timber log contains the password value after login attempt
+    @Test
+    fun login_doesNotLogPasswordValue() = runTest {
+        val sensitivePassword = "MyUniquePassword!999"
+        val httpException = mock<HttpException>()
+        whenever(httpException.code()).thenReturn(401)
+        whenever(api.login(any())).thenThrow(httpException)
+
+        val loggedMessages = mutableListOf<String>()
+        val testTree = object : timber.log.Timber.Tree() {
+            override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+                loggedMessages.add(message)
+            }
+        }
+        timber.log.Timber.plant(testTree)
+
+        viewModel.login("user@example.com", sensitivePassword)
+        advanceUntilIdle()
+
+        timber.log.Timber.uproot(testTree)
+
+        // spec: TA-AUTH-10 / D12 — password must never appear in any log output
+        val leaked = loggedMessages.filter { it.contains(sensitivePassword) }
+        assert(leaked.isEmpty()) {
+            "Timber logs must NOT contain the password value — spec: TA-AUTH-10, D12. Found: $leaked"
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `AuthViewModelTest` (class) — lines 37-296
+- `setUp` (function) — lines 45-53
+- `tearDown` (function) — lines 55-58
+- `login_success_savesTokenAndEmitsSuccess` (function) — lines 61-82
+- `login_http401_emitsErrorInvalidCredentials` (function) — lines 85-105
+- `login_http403_emitsErrorEmailNotVerified` (function) — lines 108-128
+- `login_emitsLoadingWhileInFlight` (function) — lines 131-151
+- `register_success_emitsSuccess` (function) — lines 154-170
+- `requestPasswordReset_alwaysEmitsSent_onSuccess` (function) — lines 173-186
+- `requestPasswordReset_alwaysEmitsSent_onNetworkError` (function) — lines 189-201
+- `storeTokenFromCallback_validToken_savesTokenAndEmitsSuccess` (function) — lines 204-216
+- `tokenDataStore_saveToken_notCalled_untilStoreTokenFromCallbackInvoked` (function) — lines 222-233
+- `login_success_doesNotLogTokenValue` (function) — lines 236-267
+- `log` (function) — lines 250-253
+- `login_doesNotLogPasswordValue` (function) — lines 270-295
+- `log` (function) — lines 279-281

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.md
@@ -1,0 +1,405 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt
+git_blob: 3b311c3bde70b5163a50b6f8c2000d31e98ba7bb
+last_synced: '2026-05-07T03:10:49Z'
+loc: 363
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.import_
+
+// spec: Tests d'acceptation TA-01, TA-02, TA-05, TA-07, TA-08
+// spec: section "ImportViewModel" + "Architecture" + "Tests d'acceptation"
+// RED by construction: fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel does not exist yet
+
+import android.content.ContentResolver
+import android.net.Uri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+// These imports will fail to resolve until production code is written:
+// fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+// fr.datasaillance.nightfall.domain.import_.ImportUiState
+// fr.datasaillance.nightfall.domain.import_.ImportDataType
+// fr.datasaillance.nightfall.domain.import_.ImportResult
+// fr.datasaillance.nightfall.data.import_.ImportRepository
+// fr.datasaillance.nightfall.data.import_.CsvEntry
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28])
+class ImportViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: fr.datasaillance.nightfall.data.import_.ImportRepository
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+
+    // SAF mocks — these types exist in Android SDK (safe to mock with mock-maker-inline)
+    private lateinit var mockContentResolver: ContentResolver
+    private lateinit var mockTreeUri: Uri
+
+    @Before
+    fun setUp() {
+        // spec: D7 — viewModelScope uses Dispatchers.Main; must be replaced with test dispatcher
+        Dispatchers.setMain(testDispatcher)
+        repository = mock()
+        // spec: D7 — No Hilt (issue #52): ImportViewModel constructed directly with repository
+        viewModel = fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel(repository)
+        mockContentResolver = mock()
+        mockTreeUri = mock()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-01 — checkConnection() when pingBackend() returns true → state is Connected
+    @Test
+    fun checkConnection_pingSuccess_emitsConnected() = runTest {
+        whenever(repository.pingBackend()).thenReturn(true)
+
+        viewModel.checkConnection()
+        advanceUntilIdle()
+
+        // spec: TA-01 — ImportUiState must be Connected after a successful ping
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Connected) {
+            "uiState must be ImportUiState.Connected when pingBackend() returns true — spec: TA-01, got: $state"
+        }
+    }
+
+    // spec: TA-02 — checkConnection() when pingBackend() returns false → state is ConnectionFailed with exact message
+    @Test
+    fun checkConnection_pingFailure_emitsConnectionFailed() = runTest {
+        whenever(repository.pingBackend()).thenReturn(false)
+
+        viewModel.checkConnection()
+        advanceUntilIdle()
+
+        // spec: TA-02 — ImportUiState must be ConnectionFailed with the spec-mandated message
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.ConnectionFailed) {
+            "uiState must be ImportUiState.ConnectionFailed when pingBackend() returns false — spec: TA-02, got: $state"
+        }
+        val message = (state as fr.datasaillance.nightfall.domain.import_.ImportUiState.ConnectionFailed).message
+        assert(message == "Backend inaccessible — vérifiez l'URL dans les paramètres") {
+            "ConnectionFailed message must match spec exactly — spec: TA-02, got: '$message'"
+        }
+    }
+
+    // spec: TA-01/TA-02 — checkConnection() sets Connecting synchronously before coroutine suspends
+    // Pattern: _uiState.value = Connecting is set BEFORE viewModelScope.launch suspends at pingBackend()
+    @Test
+    fun checkConnection_setsConnectingBeforeCoroutineSuspends() = runTest {
+        // Make pingBackend() a proper suspend that will park on testDispatcher
+        whenever(repository.pingBackend()).thenReturn(true)
+
+        // spec: TA-01 — Connecting must be set synchronously before the coroutine reaches pingBackend()
+        viewModel.checkConnection()
+
+        // Before advanceUntilIdle() — coroutine is suspended at repository.pingBackend()
+        val stateWhileInFlight = viewModel.uiState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.domain.import_.ImportUiState.Connecting) {
+            "uiState must be ImportUiState.Connecting immediately after checkConnection() — spec: TA-01, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+
+    // spec: TA-05 — startUpload() with SLEEP and HEART_RATE entries in the map
+    //   → state transitions through Uploading(SLEEP) → Uploading(HEART_RATE) → Success
+    //   → STEPS and EXERCISE appear in skippedTypes
+    @Test
+    fun startUpload_sleepAndHeartRate_uploadsSequentiallyAndSkipsStepsExercise() = runTest {
+        val sleepUri = mock<Uri>()
+        val heartRateUri = mock<Uri>()
+
+        val csvEntries = mapOf(
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(sleepUri, 1024L),
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(heartRateUri, 2048L),
+        )
+
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(csvEntries)
+
+        val sleepResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP,
+            inserted = 10,
+            skipped = 0,
+        )
+        val heartRateResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE,
+            inserted = 20,
+            skipped = 0,
+        )
+
+        // spec: TA-05 — mock uploadCsv for SLEEP
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(sleepUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP),
+                totalBytes = eq(1024L),
+                onProgress = any(),
+            )
+        ).thenReturn(sleepResult)
+
+        // spec: TA-05 — mock uploadCsv for HEART_RATE
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(heartRateUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE),
+                totalBytes = eq(2048L),
+                onProgress = any(),
+            )
+        ).thenReturn(heartRateResult)
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-05 — final state must be Success
+        val finalState = viewModel.uiState.value
+        assert(finalState is fr.datasaillance.nightfall.domain.import_.ImportUiState.Success) {
+            "uiState must be ImportUiState.Success after upload completes — spec: TA-05, got: $finalState"
+        }
+
+        val successState = finalState as fr.datasaillance.nightfall.domain.import_.ImportUiState.Success
+
+        // spec: TA-05 — results contain SLEEP and HEART_RATE
+        val resultTypes = successState.results.map { it.type }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP in resultTypes) {
+            "Success.results must include SLEEP — spec: TA-05"
+        }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE in resultTypes) {
+            "Success.results must include HEART_RATE — spec: TA-05"
+        }
+    }
+
+    // spec: TA-05 — STEPS and EXERCISE must appear in skippedTypes when not in the CSV map
+    // This test captures an intermediate Uploading state to verify skippedTypes
+    @Test
+    fun startUpload_stepsAndExerciseNotInMap_appearsInSkipped() = runTest {
+        val sleepUri = mock<Uri>()
+        val csvEntries = mapOf(
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(sleepUri, 512L),
+        )
+
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(csvEntries)
+
+        val sleepResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP,
+            inserted = 5,
+            skipped = 0,
+        )
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(sleepUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP),
+                totalBytes = any(),
+                onProgress = any(),
+            )
+        ).thenReturn(sleepResult)
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-05 — Success state's results must NOT include STEPS or EXERCISE (they are skipped, not uploaded)
+        val finalState = viewModel.uiState.value
+        assert(finalState is fr.datasaillance.nightfall.domain.import_.ImportUiState.Success) {
+            "uiState must be Success — spec: TA-05, got: $finalState"
+        }
+        val successState = finalState as fr.datasaillance.nightfall.domain.import_.ImportUiState.Success
+        val resultTypes = successState.results.map { it.type }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.STEPS !in resultTypes) {
+            "Success.results must NOT include STEPS when it was skipped — spec: TA-05"
+        }
+        assert(fr.datasaillance.nightfall.domain.import_.ImportDataType.EXERCISE !in resultTypes) {
+            "Success.results must NOT include EXERCISE when it was skipped — spec: TA-05"
+        }
+    }
+
+    // spec: TA-07 — startUpload() when extractCsvEntries returns empty map → Error with exact message, retryable = true
+    @Test
+    fun startUpload_emptyCsvMap_emitsErrorRetryable() = runTest {
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(emptyMap())
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-07 — state must be Error with the spec-mandated message and retryable = true
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Error) {
+            "uiState must be ImportUiState.Error when no Samsung Health files found — spec: TA-07, got: $state"
+        }
+        val errorState = state as fr.datasaillance.nightfall.domain.import_.ImportUiState.Error
+        assert(errorState.message == "Aucun fichier Samsung Health reconnu dans l'archive.") {
+            "Error message must match spec exactly — spec: TA-07, got: '${errorState.message}'"
+        }
+        assert(errorState.retryable) {
+            "Error must be retryable = true — spec: TA-07"
+        }
+    }
+
+    // spec: TA-08 — SLEEP succeeds; HEART_RATE throws IOException → final state is Success
+    //   results include HEART_RATE with non-null errorMessage; STEPS and EXERCISE are processed (skipped if not in map)
+    @Test
+    fun startUpload_heartRateIoException_doesNotBlockGlobalSuccess() = runTest {
+        val sleepUri = mock<Uri>()
+        val heartRateUri = mock<Uri>()
+
+        val csvEntries = mapOf(
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(sleepUri, 1024L),
+            fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE to
+                fr.datasaillance.nightfall.data.import_.CsvEntry(heartRateUri, 2048L),
+        )
+
+        whenever(repository.extractCsvEntries(any(), any())).thenReturn(csvEntries)
+
+        val sleepResult = fr.datasaillance.nightfall.domain.import_.ImportResult(
+            type = fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP,
+            inserted = 10,
+            skipped = 0,
+        )
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(sleepUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP),
+                totalBytes = any(),
+                onProgress = any(),
+            )
+        ).thenReturn(sleepResult)
+
+        // spec: TA-08 — HEART_RATE upload throws IOException (connexion coupée)
+        whenever(
+            repository.uploadCsv(
+                contentResolver = any(),
+                uri = eq(heartRateUri),
+                type = eq(fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE),
+                totalBytes = any(),
+                onProgress = any(),
+            )
+        ).thenThrow(java.io.IOException("Connection reset by peer"))
+
+        viewModel.startUpload(mockContentResolver, mockTreeUri)
+        advanceUntilIdle()
+
+        // spec: TA-08 — final state must still be Success (partial success, not global failure)
+        val finalState = viewModel.uiState.value
+        assert(finalState is fr.datasaillance.nightfall.domain.import_.ImportUiState.Success) {
+            "uiState must be ImportUiState.Success even when HEART_RATE upload fails — spec: TA-08, got: $finalState"
+        }
+
+        val successState = finalState as fr.datasaillance.nightfall.domain.import_.ImportUiState.Success
+
+        // spec: TA-08 — results must include HEART_RATE with non-null errorMessage
+        val heartRateResult = successState.results.find {
+            it.type == fr.datasaillance.nightfall.domain.import_.ImportDataType.HEART_RATE
+        }
+        assert(heartRateResult != null) {
+            "Success.results must include HEART_RATE entry even after IOException — spec: TA-08"
+        }
+        assert(heartRateResult!!.errorMessage != null) {
+            "HEART_RATE ImportResult.errorMessage must be non-null after IOException — spec: TA-08"
+        }
+        assert(heartRateResult.inserted == 0) {
+            "HEART_RATE ImportResult.inserted must be 0 after IOException — spec: TA-08"
+        }
+
+        // spec: TA-08 — SLEEP must be in results with no error
+        val sleepResultActual = successState.results.find {
+            it.type == fr.datasaillance.nightfall.domain.import_.ImportDataType.SLEEP
+        }
+        assert(sleepResultActual != null) {
+            "Success.results must include SLEEP — spec: TA-08"
+        }
+        assert(sleepResultActual!!.errorMessage == null) {
+            "SLEEP ImportResult.errorMessage must be null (success) — spec: TA-08"
+        }
+    }
+
+    // spec: Architecture "reset()" — calling reset() returns state to Idle
+    @Test
+    fun reset_returnsToIdleState() = runTest {
+        // Move to a non-Idle state first
+        whenever(repository.pingBackend()).thenReturn(true)
+        viewModel.checkConnection()
+        advanceUntilIdle()
+
+        assert(viewModel.uiState.value is fr.datasaillance.nightfall.domain.import_.ImportUiState.Connected) {
+            "Precondition: state must be Connected before reset"
+        }
+
+        // spec: reset() — calling reset() must return state to Idle
+        viewModel.reset()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Idle) {
+            "uiState must be ImportUiState.Idle after reset() — spec: ImportViewModel.reset(), got: $state"
+        }
+    }
+
+    // spec: D7 — initial state is Idle before any action
+    @Test
+    fun initialState_isIdle() {
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.domain.import_.ImportUiState.Idle) {
+            "uiState must be ImportUiState.Idle at construction — spec: D7 (StateFlow initial value), got: $state"
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ImportViewModelTest` (class) — lines 35-363
+- `setUp` (function) — lines 48-57
+- `tearDown` (function) — lines 59-62
+- `checkConnection_pingSuccess_emitsConnected` (function) — lines 65-77
+- `checkConnection_pingFailure_emitsConnectionFailed` (function) — lines 80-96
+- `checkConnection_setsConnectingBeforeCoroutineSuspends` (function) — lines 100-115
+- `startUpload_sleepAndHeartRate_uploadsSequentiallyAndSkipsStepsExercise` (function) — lines 120-186
+- `startUpload_stepsAndExerciseNotInMap_appearsInSkipped` (function) — lines 190-231
+- `startUpload_emptyCsvMap_emitsErrorRetryable` (function) — lines 234-253
+- `startUpload_heartRateIoException_doesNotBlockGlobalSuccess` (function) — lines 257-332
+- `reset_returnsToIdleState` (function) — lines 335-353
+- `initialState_isIdle` (function) — lines 356-362

--- a/docs/vault/specs/2026-05-06-p4-android-auth.md
+++ b/docs/vault/specs/2026-05-06-p4-android-auth.md
@@ -1,14 +1,18 @@
 ---
 title: "Phase 4 Android Auth Screens"
 slug: 2026-05-06-p4-android-auth
-status: draft
+status: ready
 created: 2026-05-06
 phase: P4
 spec_type: ui
 related_specs:
   - 2026-05-06-p4-android-shell
 implements: []
-tested_by: []
+tested_by:
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModelTest.kt
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/RegisterScreenTest.kt
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/ForgotPasswordScreenTest.kt
 branch: feat/p4-android-auth
 tags: [phase4, android, compose, auth, jwt, oauth, google, login]
 ---
@@ -59,7 +63,7 @@ Note : le refresh token est géré en cookie httpOnly par le backend (`/auth/ref
 | D4 | `AuthCallbackScreen` comme destination dédiée (pas un intercepteur Activity) | Le deep link `nightfall://auth/callback` est capturé par Navigation Compose via `deepLinks` — plus propre que `onNewIntent` dans `MainActivity` |
 | D5 | Custom Tabs pour le flow OAuth Google | Custom Tabs partage la session navigateur (cookies Google) sans ouvrir une WebView interne non sécurisée ; requis pour le PKCE implicit flow |
 | D6 | Appel `POST /auth/google/start` avant ouverture Custom Tabs | Le backend génère le state CSRF et l'URL Google avec nonce — le client ne forge pas l'URL lui-même |
-| D7 | `OkHttp CookieJar` (in-memory) pour le refresh cookie httpOnly | Le backend pose le cookie `refresh_token` sur `/auth/refresh` avec `httpOnly + SameSite=Strict` ; OkHttp doit pouvoir le renvoyer sur `/auth/refresh` sans que le code Kotlin y touche |
+| D7 | `OkHttp CookieJar` inline (in-memory) pour le refresh cookie httpOnly | Le backend pose le cookie `refresh_token` sur `/auth/refresh` avec `httpOnly + SameSite=Strict` ; OkHttp doit pouvoir le renvoyer sur `/auth/refresh` sans que le code Kotlin y touche. Note impl : `JavaNetCookieJar` (prescrit initialement) requiert `okhttp-urlconnection` non disponible dans le projet — un `CookieJar` anonyme `mutableMapOf<String, List<Cookie>>` est utilisé à la place ; sémantiquement équivalent pour un hôte unique |
 | D8 | Pas de `refresh_token` dans `TokenDataStore` | Le refresh token est httpOnly et géré par le cookie jar OkHttp — le stocker en clair en SharedPreferences violerait C2 |
 | D9 | Validation côté client minimale (email non-vide, password ≥ 1 char) avant envoi | Évite les 400 inutiles ; la vraie validation (force du mot de passe) reste serveur (`validate_password_strength`) |
 | D10 | Timeout réseau hérité du shell : 30s connect + 30s read | Défini dans `NetworkModule.kt` — pas de surcharge dans `AuthViewModel` |
@@ -92,6 +96,7 @@ android-app/app/src/main/java/fr/datasaillance/nightfall/
 data/
   http/
     NightfallApi.kt                 ← peupler avec AuthService (voir ci-dessous)
+    AuthModels.kt                   ← data classes auth (impl : dans data.http, non data.http.auth — flat package retenu)
   auth/
     TokenDataStore.kt               ← existant shell — pas modifié
 ```
@@ -166,6 +171,8 @@ sealed class ForgotPasswordUiState {
     object Loading : ForgotPasswordUiState()
     object Sent : ForgotPasswordUiState()           // affiche confirmation, pas de distinction
     data class Error(val message: String) : ForgotPasswordUiState()
+    // Note : Error n'est jamais émis par requestPasswordReset() (anti-enum — toujours Sent).
+    // Le variant est conservé dans la sealed class pour cohérence de pattern ; il est intentionnellement mort.
 }
 ```
 
@@ -269,15 +276,15 @@ Note : `mapHttpError` ne logue jamais les valeurs email/password — uniquement 
 | Lien / accent | `MaterialTheme.colorScheme.tertiary` (Cyan500) | `#07BCD3` |
 | Texte principal | `MaterialTheme.colorScheme.onBackground` | `#E8E4DC` (dark) / `#1A1916` (light) |
 | Erreur | `MaterialTheme.colorScheme.error` | Material 3 default |
-| Police | Cairo (tous styles) | — |
+| Police | Inter (corps/UI) + Playfair Display (titres) | — |
 
-Couleurs interdites dans ces écrans : `#6366f1`, tout `linear-gradient` décoratif, tout `box-shadow` type glow, toute police autre que Cairo.
+Couleurs interdites dans ces écrans : `#6366f1`, tout `linear-gradient` décoratif, tout `box-shadow` type glow, toute police autre que Inter/Playfair Display.
 
 ### LoginScreen
 
 Structure verticale centrée (`Column` + `Arrangement.Center`) :
 
-1. Logo/titre "Nightfall" en `MaterialTheme.typography.headlineMedium` (Cairo SemiBold)
+1. Logo/titre "Nightfall" en `MaterialTheme.typography.headlineMedium` (Playfair Display Bold)
 2. `AuthTextField` email (type `KeyboardType.Email`, `ImeAction.Next`)
 3. `AuthTextField` password (type `KeyboardType.Password`, toggle visibilité, `ImeAction.Done`)
 4. `AuthErrorMessage` — visible uniquement si `LoginUiState.Error` ; texte en `MaterialTheme.colorScheme.error`

--- a/docs/vault/specs/2026-05-06-p4-android-import.md
+++ b/docs/vault/specs/2026-05-06-p4-android-import.md
@@ -1,7 +1,7 @@
 ---
 title: "Phase 4 Android Import SAF"
 slug: 2026-05-06-p4-android-import
-status: draft
+status: ready
 created: 2026-05-06
 phase: P4
 spec_type: feature
@@ -9,7 +9,9 @@ related_specs:
   - 2026-05-06-p4-android-shell
   - 2026-04-24-v2-csv-import-sqlalchemy
 implements: []
-tested_by: []
+tested_by:
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModelTest.kt
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/data/http/CountingRequestBodyTest.kt
 branch: feat/p4-android-import
 tags: [phase4, android, saf, import, samsung-health, csv, multipart, rgpd]
 ---
@@ -442,7 +444,7 @@ La carte `RgpdNoticeCard` est affichée entre l'étape Connexion confirmée et l
 | Icône type import "ignoré" | `colorScheme.onSurface` opacité 38% |
 | `LinearProgressIndicator` | `color = colorScheme.primary`, `trackColor = colorScheme.surfaceVariant` |
 | Indicateur étape active | `colorScheme.secondary` (Amber600 `#D37C04`) |
-| Police | Cairo (héritée de `NightfallTheme`) |
+| Police | Inter (corps/UI) + Playfair Display (titres) — héritées de `NightfallTheme` |
 | Interdits | `#6366f1`, `linear-gradient` décoratif, `box-shadow` glow |
 
 Light et dark mode sont tous les deux couverts via `NightfallTheme` — aucun `if (darkTheme)` inline dans `ImportScreen.kt`.
@@ -560,7 +562,7 @@ Light et dark mode sont tous les deux couverts via `NightfallTheme` — aucun `i
 | **C1** Local-first | `ImportRepository` ne cible que `backendUrl` de l'utilisateur. Aucun appel vers Firebase, S3, Supabase ou tout autre tiers. La vérification est testée via `TA-10` |
 | **C2** Chiffrement / pas de cache en clair | Aucune copie des CSV sur le stockage de l'app (`TA-10`). Transit TLS obligatoire sauf émulateur (`D11`). Les données Art.9 sont chiffrées à l'écriture côté backend (responsabilité des routers FastAPI existants) |
 | **C3** Sécurité | Pentester agent passe avant merge. Points d'attention : injection de chemin via URI SAF, dépassement mémoire via ZIP bomb (voir note ci-dessous), absence de validation de type MIME côté Android |
-| **C4** Design DataSaillance | Tokens teal/amber/cyan via `NightfallTheme`. Aucun `#6366f1`, aucun gradient décoratif. Police Cairo |
+| **C4** Design DataSaillance | Tokens teal/amber/cyan via `NightfallTheme`. Aucun `#6366f1`, aucun gradient décoratif. Police Inter + Playfair Display |
 | **C5** No LLM | Aucun appel LLM dans tout ce module |
 
 **Note sécurité ZIP bomb** : si le fichier sélectionné est un ZIP, `ImportRepository.extractCsvEntries` doit implémenter une limite de décompression (ex : 200 Mo décompressés max, ou 10 entrées max) pour éviter un `OutOfMemoryError` volontaire. Cette limite est à définir avec le coder-android et à documenter dans le PR.


### PR DESCRIPTION
## Summary

- **ImportViewModel** — plain ViewModel (no Hilt, issue #52) ; `checkConnection()` set `Connecting` synchronously before `viewModelScope.launch` (StandardTestDispatcher pattern) ; `startUpload()` upload séquentiel SLEEP→HEART_RATE→STEPS→EXERCISE avec catch par type (`CancellationException` re-throwé) pour succès partiel
- **CountingRequestBody** — OkHttp `RequestBody` avec `CountingSink` ; `onProgress(0f)` appelé en début de `writeTo` (garantit ≥ 2 callbacks même pour payloads < segment OkIO 8192 bytes)
- **ImportRepositoryImpl** — `extractCsvEntries` via `ZipInputStream` avec ZIP bomb protection (200 Mo / 100 entrées max, `IOException("Archive trop grande")`) ; `uploadCsv` streamé via `CountingRequestBody` + dispatch Retrofit par type
- **ImportScreen** — stepper 3 étapes ; SAF launcher `OpenDocumentTree` → `viewModel.startUpload` ; `RgpdNoticeCard` (surfaceVariant + bordure primary 4dp + URL en SemiBold) ; `collectAsStateWithLifecycle` ; non-dismissable
- **16 nouveaux tests GREEN** (ImportViewModelTest 9 + CountingRequestBodyTest 7) — 63/63 total GREEN

## Notes de scope

- Cette PR inclut les commits shell (`7a71b2b`) et auth (`e89d409`) — branches stackées ; quand les PR #53 et #54 sont mergées vers dev, cette PR sera rebasée automatiquement
- Backend endpoints (`POST /api/sleep/import` etc.) sont hors scope Android — à implémenter dans une PR backend séparée

## Test plan

- [ ] `./gradlew :app:testNativeDebugUnitTest` → 63/63 GREEN
- [ ] `ImportViewModelTest` : TA-01 ping success → Connected, TA-02 ping fail → ConnectionFailed + message exact, Connecting synchrone avant advanceUntilIdle, TA-05 upload séquentiel SLEEP+HEART_RATE, skippedTypes STEPS/EXERCISE, TA-07 empty map → Error retryable, TA-08 IOException → Success partiel, reset() → Idle, état initial Idle
- [ ] `CountingRequestBodyTest` : onProgress ≥ 2 appels, dernière valeur = 1.0f, aucune valeur > 1.0f, contentLength = totalBytes, contentType délégué, tous les bytes écrits, progression monotone
- [ ] ZIP bomb : tester avec archive > 100 entrées ou > 200 Mo → `IOException("Archive trop grande")`
- [ ] SAF picker : état `Connected` → bouton "Sélectionner" → `OpenDocumentTree` → `startUpload`
- [ ] `RgpdNoticeCard` visible après connexion confirmée, pas de bouton Ignorer