### PR TITLE
chore(ci): allowlist android test dirs in gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,6 +7,8 @@ useDefault = true
 description = "Test fixtures and vault doc mirror — fake secrets, never used in production"
 paths = [
   '''^tests/.*''',
+  '''^android-app/.*/src/test/.*''',
+  '''^android-app/.*/src/androidTest/.*''',
   '''^docs/vault/code/.*''',
 ]
 regexes = [


### PR DESCRIPTION
## Summary

- Adds `android-app/.*/src/test/.*` and `android-app/.*/src/androidTest/.*` to the gitleaks allowlist
- The `NightfallWebViewClientTest.kt` uses a synthetic JWT string (`eyJ...test`) as a test fixture — not a real secret
- Unblocks PR #58 (dev → main release) whose Security gates CI step was failing on this false positive

## Test plan

- [ ] CI security gates pass on this PR
- [ ] PR #58 re-runs and security gates pass after merge