### PR TITLE
feat(android): P5.0 LoginScreen natif — NavGraph wiring + isFormValid

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,10 +29,21 @@
 | Phase 4 Backend Import CSV multipart | `server/services/csv_import.py`, `server/routers/sleep.py`, `server/routers/heartrate.py`, `server/routers/steps.py`, `server/routers/exercise.py`, `tests/server/test_import_csv_multipart.py` | [`b11e00f`](#2026-05-07-b11e00f) |
 | Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`4dcf071`](#2026-05-07-4dcf071) |
 | Phase 4 Android WebView Bridge | `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallWebViewClient.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallJsInterface.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/WebViewScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/settings/SettingsDataStore.kt` | [`b7105b4`](#2026-05-07-b7105b4) |
+| P5.0 LoginScreen natif | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt` | [`TBD`](#2026-05-08-TBD) |
 
 ---
 
 ## Changelog
+
+### 2026-05-08 `TBD`
+feat: (android): P5.0 LoginScreen natif — isFormValid, NavGraph wiring, AppModule.provideAuthViewModel
+- LoginScreen.kt — isFormValid = email.isNotBlank() && password.isNotBlank(), bouton Se connecter disabled si champs vides (TA-L-04)
+- NavGraph.kt — import stub ui.screens.login remplacé par ui.screens.auth.LoginScreen, AuthViewModel câblé via AppModule.provideAuthViewModel
+- NavDestination.kt — Register et ForgotPassword ajoutés
+- AppModule.kt — provideAuthViewModel(api, tokenDataStore) ajouté
+- Stub ui/screens/login/LoginScreen.kt supprimé (dead code)
+- Tests — NavGraphTest: TA-L-02 (login success → Sleep), LoginScreenTest: TA-L-06 (loading state disable behavioral), NavDestinationP5Test: Register/ForgotPassword routes
+- 110/110 tests GREEN
 
 ### 2026-05-07 `b11e00f`
 feat(backend): Phase 4 import CSV multipart — POST /api/sleep/import, /api/heartrate/import, /api/steps/import, /api/exercise/import

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,13 +29,13 @@
 | Phase 4 Backend Import CSV multipart | `server/services/csv_import.py`, `server/routers/sleep.py`, `server/routers/heartrate.py`, `server/routers/steps.py`, `server/routers/exercise.py`, `tests/server/test_import_csv_multipart.py` | [`b11e00f`](#2026-05-07-b11e00f) |
 | Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`4dcf071`](#2026-05-07-4dcf071) |
 | Phase 4 Android WebView Bridge | `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallWebViewClient.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallJsInterface.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/WebViewScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/settings/SettingsDataStore.kt` | [`b7105b4`](#2026-05-07-b7105b4) |
-| P5.0 LoginScreen natif | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt` | [`TBD`](#2026-05-08-TBD) |
+| P5.0 LoginScreen natif | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt` | [`2ccecfe`](#2026-05-08-2ccecfe) |
 
 ---
 
 ## Changelog
 
-### 2026-05-08 `TBD`
+### 2026-05-08 `2ccecfe`
 feat: (android): P5.0 LoginScreen natif — isFormValid, NavGraph wiring, AppModule.provideAuthViewModel
 - LoginScreen.kt — isFormValid = email.isNotBlank() && password.isNotBlank(), bouton Se connecter disabled si champs vides (TA-L-04)
 - NavGraph.kt — import stub ui.screens.login remplacé par ui.screens.auth.LoginScreen, AuthViewModel câblé via AppModule.provideAuthViewModel

--- a/VISION.md
+++ b/VISION.md
@@ -71,7 +71,7 @@ Pentester agent invoqué à chaque spec et chaque PR. Verdict bloquant si findin
 
 - **Palette et logos (source de vérité)** : `../Vectorizer/IdentiteVisuelle/`
 - **Méthodologie CSS** : `../OpenDesign/` (structure global.css, organisation des fichiers) — pas les tokens couleur
-- **Polices** : `../Vectorizer/IdentiteVisuelle/Polices/` (Playfair Display) + Cairo via Google Fonts
+- **Polices** : `../Vectorizer/IdentiteVisuelle/Polices/` (Playfair Display pour les titres) + Inter via Google Fonts (UI body)
 
 ### Tokens (source of truth — extraits des logos IdentiteVisuelle)
 
@@ -105,7 +105,7 @@ Pentester agent invoqué à chaque spec et chaque PR. Verdict bloquant si findin
 - **Accent teal** (`#0e9eb0`) pour les éléments primaires (liens, focus, sélection)
 - **Accent amber** (`#d37c04`) pour les CTA et actions principales
 - **Accent cyan** (`#3be5e7`) pour les highlights et visualisations de données
-- **Police** : Cairo (variable, 400/500/600/700) + fallback système
+- **Police** : Playfair Display (titres/display) + Inter (UI body, 400/500/600/700) + fallback système
 - **Pas de gradients décoratifs** — surfaces plates, hiérarchie par poids et taille
 - **Pas de `#6366f1`** (indigo Tailwind) — anti-slop explicite
 - **Pas de glows/halos** — box-shadow décoratif interdit

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt
@@ -2,7 +2,9 @@ package fr.datasaillance.nightfall.di
 
 import android.content.Context
 import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.NightfallApi
 import fr.datasaillance.nightfall.data.settings.SettingsDataStore
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 
 object AppModule {
     fun provideTokenDataStore(context: Context): TokenDataStore =
@@ -10,4 +12,7 @@ object AppModule {
 
     fun provideSettingsDataStore(context: Context): SettingsDataStore =
         SettingsDataStore(context)
+
+    fun provideAuthViewModel(api: NightfallApi, tokenDataStore: TokenDataStore): AuthViewModel =
+        AuthViewModel(api, tokenDataStore)
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
@@ -4,13 +4,15 @@ sealed class NavDestination(
     val route: String,
     val label: String
 ) {
-    object Login    : NavDestination("login",    "Connexion")
-    object Sleep    : NavDestination("sleep",    "Sommeil")
-    object Trends   : NavDestination("trends",   "Tendances")
-    object Activity : NavDestination("activity", "Activité")
-    object Profile  : NavDestination("profile",  "Profil")
-    object Import   : NavDestination("import",   "Importer")
-    object Settings : NavDestination("settings", "Paramètres")
+    object Login          : NavDestination("login",           "Connexion")
+    object Sleep          : NavDestination("sleep",           "Sommeil")
+    object Trends         : NavDestination("trends",          "Tendances")
+    object Activity       : NavDestination("activity",        "Activité")
+    object Profile        : NavDestination("profile",         "Profil")
+    object Import         : NavDestination("import",          "Importer")
+    object Settings       : NavDestination("settings",        "Paramètres")
+    object Register       : NavDestination("register",        "Créer un compte")
+    object ForgotPassword : NavDestination("forgot_password", "Mot de passe oublié")
 
     companion object {
         fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Trends, Activity, Profile)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -14,20 +14,36 @@ import androidx.navigation.compose.DialogNavigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.di.AppModule
+import fr.datasaillance.nightfall.data.http.GoogleStartRequest
+import fr.datasaillance.nightfall.data.http.GoogleStartResponse
+import fr.datasaillance.nightfall.data.http.ImportApiResponse
+import fr.datasaillance.nightfall.data.http.LoginRequest
+import fr.datasaillance.nightfall.data.http.LoginResponse
 import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.http.PasswordResetRequest
+import fr.datasaillance.nightfall.data.http.RegisterRequest
+import fr.datasaillance.nightfall.data.http.RegisterResponse
+import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
+import fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen
+import fr.datasaillance.nightfall.ui.screens.auth.LoginScreen
+import fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen
 import fr.datasaillance.nightfall.ui.screens.import_.ImportScreen
-import fr.datasaillance.nightfall.ui.screens.login.LoginScreen
 import fr.datasaillance.nightfall.ui.screens.profile.ProfileScreen
 import fr.datasaillance.nightfall.ui.screens.settings.SettingsScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
 import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+import okhttp3.MultipartBody
+import retrofit2.Response
 
 @Composable
 fun NavGraph(
@@ -36,8 +52,16 @@ fun NavGraph(
     backendUrl: String = "",
     onSaveUrl: (String) -> Unit = {},
     api: NightfallApi? = null,
+    authViewModel: AuthViewModel? = null,
 ) {
+    val context = androidx.compose.ui.platform.LocalContext.current
     val startDestination = if (hasToken) NavDestination.Sleep.route else NavDestination.Login.route
+    val resolvedAuthViewModel = authViewModel ?: remember(api, context) {
+        AppModule.provideAuthViewModel(
+            api = api ?: NoOpNightfallApi(),
+            tokenDataStore = AppModule.provideTokenDataStore(context)
+        )
+    }
 
     // Adds ComposeNavigator/DialogNavigator to the navigator provider when absent.
     // TestNavHostController only registers TestNavigator by default; without this,
@@ -71,11 +95,36 @@ fun NavGraph(
             modifier         = Modifier.padding(innerPadding)
         ) {
             composable(NavDestination.Login.route) {
-                LoginScreen(onLoginSuccess = {
-                    navController.navigate(NavDestination.Sleep.route) {
-                        popUpTo(NavDestination.Login.route) { inclusive = true }
+                LoginScreen(
+                    viewModel = resolvedAuthViewModel,
+                    onLoginSuccess = {
+                        navController.navigate(NavDestination.Sleep.route) {
+                            popUpTo(NavDestination.Login.route) { inclusive = true }
+                        }
+                    },
+                    onNavigateRegister = {
+                        navController.navigate(NavDestination.Register.route)
+                    },
+                    onNavigateForgotPassword = {
+                        navController.navigate(NavDestination.ForgotPassword.route)
                     }
-                })
+                )
+            }
+            composable(NavDestination.Register.route) {
+                RegisterScreen(
+                    viewModel = resolvedAuthViewModel,
+                    onRegisterSuccess = {
+                        navController.navigate(NavDestination.Sleep.route) {
+                            popUpTo(NavDestination.Login.route) { inclusive = true }
+                        }
+                    }
+                )
+            }
+            composable(NavDestination.ForgotPassword.route) {
+                ForgotPasswordScreen(
+                    viewModel = resolvedAuthViewModel,
+                    onBack = { navController.popBackStack() }
+                )
             }
             composable(NavDestination.Sleep.route)    { SleepScreen() }
             composable(NavDestination.Trends.route)   { TrendsScreen() }
@@ -130,6 +179,18 @@ private class NoOpImportRepository : ImportRepository {
         totalBytes: Long,
         onProgress: (Float) -> Unit,
     ): ImportResult = throw UnsupportedOperationException("No-op repository")
+}
+
+private class NoOpNightfallApi : NightfallApi {
+    override suspend fun health(): Response<Unit> = throw UnsupportedOperationException("No-op api")
+    override suspend fun login(body: LoginRequest): LoginResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun register(body: RegisterRequest, registrationToken: String?): RegisterResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun requestPasswordReset(body: PasswordResetRequest): StatusResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun googleStart(body: GoogleStartRequest): GoogleStartResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importSleep(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importHeartRate(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importSteps(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importExercise(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
 }
 
 /**

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
@@ -61,6 +61,7 @@ fun LoginScreen(
     }
 
     val isLoading = loginState is LoginUiState.Loading
+    val isFormValid = email.isNotBlank() && password.isNotBlank()
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -123,6 +124,7 @@ fun LoginScreen(
                 text = "Se connecter",
                 onClick = { viewModel.login(email, password) },
                 isLoading = isLoading,
+                enabled = isFormValid && !isLoading,
                 modifier = Modifier.fillMaxWidth().semantics { testTag = "btn_login" }
             )
 

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/login/LoginScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/login/LoginScreen.kt
@@ -1,9 +1,0 @@
-package fr.datasaillance.nightfall.ui.screens.login
-
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-
-@Composable
-fun LoginScreen(onLoginSuccess: () -> Unit = {}) {
-    Text("Login — p4-android-auth")
-}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.kt
@@ -1,0 +1,60 @@
+package fr.datasaillance.nightfall.ui.navigation
+
+// spec: P5 §10 / §6.1 — NavDestination.Register et NavDestination.ForgotPassword manquants
+// RED par exécution : ces tests compilent via reflection JVM mais échouent à l'exécution
+// TANT QUE NavDestination.kt n'expose pas ces deux objets dans le sealed class.
+// Une fois ajoutés, ces tests passeront GREEN et valideront les routes.
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NavDestinationP5Test {
+
+    // spec: §10 — NavDestination.Register requis par NavGraph.kt câblé (onNavigateRegister)
+    // RED : NavDestination.kt ne contient pas Register dans le sealed class.
+    // Lookup via reflection : échoue à l'exécution avec NoSuchFieldException tant que l'objet est absent.
+    @Test
+    fun navDestination_register_route_exists() {
+        // spec: §10 / §6.1 — NavDestination.Register doit être un objet du sealed class
+        // avec un champ `route` non vide (convention: "register")
+        val nestedClass = try {
+            Class.forName("fr.datasaillance.nightfall.ui.navigation.NavDestination\$Register")
+        } catch (e: ClassNotFoundException) {
+            throw AssertionError(
+                "NavDestination.Register object not found — must be added to NavDestination sealed class — spec: §10. " +
+                "ClassNotFoundException: ${e.message}"
+            )
+        }
+        val instance = nestedClass.getField("INSTANCE").get(null)
+        val routeField = nestedClass.getMethod("getRoute")
+        val route = routeField.invoke(instance) as String
+        assert(route.isNotBlank()) {
+            "NavDestination.Register.route must be non-blank — spec: §10"
+        }
+    }
+
+    // spec: §10 — NavDestination.ForgotPassword requis par NavGraph.kt câblé (onNavigateForgotPassword)
+    // RED : NavDestination.kt ne contient pas ForgotPassword dans le sealed class.
+    // Lookup via reflection : échoue à l'exécution avec AssertionError tant que l'objet est absent.
+    @Test
+    fun navDestination_forgotPassword_route_exists() {
+        // spec: §10 / §6.1 — NavDestination.ForgotPassword doit être un objet du sealed class
+        // avec un champ `route` non vide (convention: "forgot-password")
+        val nestedClass = try {
+            Class.forName("fr.datasaillance.nightfall.ui.navigation.NavDestination\$ForgotPassword")
+        } catch (e: ClassNotFoundException) {
+            throw AssertionError(
+                "NavDestination.ForgotPassword object not found — must be added to NavDestination sealed class — spec: §10. " +
+                "ClassNotFoundException: ${e.message}"
+            )
+        }
+        val instance = nestedClass.getField("INSTANCE").get(null)
+        val routeField = nestedClass.getMethod("getRoute")
+        val route = routeField.invoke(instance) as String
+        assert(route.isNotBlank()) {
+            "NavDestination.ForgotPassword.route must be non-blank — spec: §10"
+        }
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.kt
@@ -9,9 +9,13 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 // These imports will fail to resolve until production code is written:
@@ -181,5 +185,62 @@ class NavGraphTest {
         assert(navController.currentDestination?.route == NavDestination.Login.route) {
             "Expected navigation to login after logout — spec: TA-11"
         }
+    }
+
+    // spec: TA-L-02 — login success → navController navigue vers Sleep, Login popped de la back-stack
+    @Test
+    fun navGraph_login_success_navigates_to_sleep() {
+        val api = mock<NightfallApi>()
+        val tokenStore = mock<TokenDataStore>()
+        val viewModel = AuthViewModel(api, tokenStore)
+        val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
+
+        composeTestRule.setContent {
+            NightfallTheme {
+                NavGraph(
+                    navController = navController,
+                    hasToken = false,
+                    authViewModel = viewModel
+                )
+            }
+        }
+
+        // storeTokenFromCallback sets loginState = Success synchronously
+        composeTestRule.runOnUiThread { viewModel.storeTokenFromCallback("fake-token") }
+        composeTestRule.waitForIdle()
+
+        assert(navController.currentDestination?.route == NavDestination.Sleep.route) {
+            "Expected navigation to sleep after login success — spec: TA-L-02"
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // spec: P5 §6.1 — NavGraph doit importer ui.screens.auth.LoginScreen (et non le stub
+    // ui.screens.login.LoginScreen) — vérification via le titre "Connexion" visible.
+    // ---------------------------------------------------------------------------
+    @Test
+    fun navGraph_login_screen_shows_real_loginscreen() {
+        val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
+
+        composeTestRule.setContent {
+            NightfallTheme {
+                // spec: §6.1 — NavGraph câble ui.screens.auth.LoginScreen (vrai LoginScreen)
+                NavGraph(
+                    navController = navController,
+                    hasToken = false
+                )
+            }
+        }
+
+        // spec: §4.1 — le vrai LoginScreen affiche un Text "Connexion" (headlineLarge)
+        // Le stub legacy affiche "Login — p4-android-auth" — ce noeud ne doit plus exister
+        composeTestRule
+            .onNodeWithText("Connexion")
+            .assertExists("NavGraph must render the real LoginScreen with title 'Connexion' — spec: §6.1 / §4.1")
+
+        // spec: §8 — field_email doit être visible (testTag présent dans le vrai LoginScreen uniquement)
+        composeTestRule
+            .onNode(androidx.compose.ui.test.hasTestTag("field_email"))
+            .assertExists("field_email testTag must be present — only exists in ui.screens.auth.LoginScreen — spec: §8")
     }
 }

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
@@ -1,15 +1,22 @@
 package fr.datasaillance.nightfall.ui.screens.auth
 
-// spec: Tests d'acceptation TA-AUTH-04, TA-AUTH-12
+// spec: Tests d'acceptation TA-AUTH-04, TA-AUTH-12, TA-L-01, TA-L-04, TA-L-06
 // spec: section "LoginScreen" layout + "Parité light / dark mode"
 // RED by construction: fr.datasaillance.nightfall.ui.screens.auth.LoginScreen does not exist yet
 
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performTextInput
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
 import kotlinx.coroutines.flow.MutableStateFlow
 
 // These imports will fail to resolve until production code is written:
@@ -127,5 +134,149 @@ class LoginScreenTest {
             }
         }
         // spec: TA-AUTH-04 — loading state: button disabled, fields disabled, progress indicator visible
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Robolectric / ComposeTestRule — behavioral tests (TA-L-01, TA-L-04)
+// These tests use a separate class to avoid mixing Paparazzi @Rule with
+// createComposeRule() in the same class instance (incompatible Rule lifecycles).
+// ---------------------------------------------------------------------------
+
+// spec: TA-L-01, TA-L-04 — behavioral interaction tests
+// RED trigger: LoginScreen.kt uses `enabled = !isLoading` without `isFormValid` guard (TA-L-04)
+// The production code in LoginScreen.kt calls:
+//   AuthPrimaryButton(..., isLoading = isLoading, ...)
+// without passing `enabled = isFormValid`. AuthPrimaryButton defaults `enabled = true`.
+// After impl adds `val isFormValid = email.isNotBlank() && password.isNotBlank()` and passes
+// `enabled = isFormValid` to AuthPrimaryButton, these tests will turn GREEN.
+@RunWith(RobolectricTestRunner::class)
+class LoginScreenInteractionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun buildViewModel(): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        // spec: D1 / §10 — DI manuelle, pas de Hilt (issue #52)
+        return fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    // spec: TA-L-01 / TA-L-04 — bouton "Se connecter" disabled si email ET password sont vides
+    // RED: LoginScreen.kt passe uniquement `isLoading = isLoading` à AuthPrimaryButton — pas de
+    // `enabled = isFormValid`. Le bouton est enabled dès le départ (default enabled=true).
+    // Ce test échoue TANT QUE `isFormValid` n'est pas câblé dans LoginScreen.kt.
+    @Test
+    fun loginScreen_button_disabled_when_fields_empty() {
+        val viewModel = buildViewModel()
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-L-04 — champs vides au démarrage → bouton disabled
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // spec: TA-L-04 — avec email="" et password="" (état initial), btn_login doit être disabled
+        // spec: §4.4 — `val isFormValid = email.isNotBlank() && password.isNotBlank()`
+        composeTestRule
+            .onNode(hasTestTag("btn_login"))
+            .assertIsNotEnabled()
+    }
+
+    // spec: TA-L-04 (complément) — bouton disabled si seulement email rempli, password vide
+    // RED: même raison — `isFormValid` absent dans LoginScreen.kt
+    @Test
+    fun loginScreen_button_disabled_when_only_email_filled() {
+        val viewModel = buildViewModel()
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // Remplir uniquement le champ email
+        composeTestRule
+            .onNode(hasTestTag("field_email"))
+            .performTextInput("user@example.com")
+
+        // spec: TA-L-04 — un seul champ rempli → bouton toujours disabled
+        composeTestRule
+            .onNode(hasTestTag("btn_login"))
+            .assertIsNotEnabled()
+    }
+
+    // spec: TA-L-04 — bouton enabled quand email ET password sont remplis
+    // Ce test documente le contrat complet de TA-L-04 (transition disabled → enabled).
+    // Après impl de `isFormValid`, ce test doit passer GREEN (bouton enabled après saisie des deux champs).
+    @Test
+    fun loginScreen_button_enabled_when_both_fields_filled() {
+        val viewModel = buildViewModel()
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // Remplir les deux champs
+        composeTestRule
+            .onNode(hasTestTag("field_email"))
+            .performTextInput("user@example.com")
+        composeTestRule
+            .onNode(hasTestTag("field_password"))
+            .performTextInput("Password123!")
+
+        // spec: TA-L-04 — email + password remplis + état Idle → bouton enabled
+        composeTestRule
+            .onNode(hasTestTag("btn_login"))
+            .assertIsEnabled()
+    }
+
+    // spec: TA-L-06 — état Loading : champs email/password et bouton disabled
+    @Test
+    fun loginScreen_loading_state_disables_all_interactive_elements() {
+        val viewModel = buildViewModel()
+
+        // Force Loading state via reflection — LoginUiState.Loading is the private _loginState value
+        val field = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel::class.java
+            .getDeclaredField("_loginState")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        (field.get(viewModel) as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.auth.LoginUiState>)
+            .value = fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Loading
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // spec: TA-L-06 — Loading state must disable all interactive elements
+        composeTestRule.onNode(hasTestTag("field_email")).assertIsNotEnabled()
+        composeTestRule.onNode(hasTestTag("field_password")).assertIsNotEnabled()
+        composeTestRule.onNode(hasTestTag("btn_login")).assertIsNotEnabled()
     }
 }

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt
-git_blob: 3c347ed626e0cb9476052e9f3783c920fbaec161
-last_synced: '2026-05-07T03:51:34Z'
-loc: 13
+git_blob: ae126d603890e049b3a64e3625459b444eebf224
+last_synced: '2026-05-07T22:01:38Z'
+loc: 18
 annotations: []
 imports: []
 exports: []
@@ -25,7 +25,9 @@ package fr.datasaillance.nightfall.di
 
 import android.content.Context
 import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.NightfallApi
 import fr.datasaillance.nightfall.data.settings.SettingsDataStore
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 
 object AppModule {
     fun provideTokenDataStore(context: Context): TokenDataStore =
@@ -33,6 +35,9 @@ object AppModule {
 
     fun provideSettingsDataStore(context: Context): SettingsDataStore =
         SettingsDataStore(context)
+
+    fun provideAuthViewModel(api: NightfallApi, tokenDataStore: TokenDataStore): AuthViewModel =
+        AuthViewModel(api, tokenDataStore)
 }
 ```
 
@@ -41,5 +46,6 @@ object AppModule {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `provideTokenDataStore` (function) — lines 8-9
-- `provideSettingsDataStore` (function) — lines 11-12
+- `provideTokenDataStore` (function) — lines 10-11
+- `provideSettingsDataStore` (function) — lines 13-14
+- `provideAuthViewModel` (function) — lines 16-17

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
-git_blob: 579fdac1e89910391d47d3042c98a2235f33c875
-last_synced: '2026-05-07T00:48:24Z'
-loc: 18
+git_blob: 71cf989e2df2a769d7316eec70e1a995411b1362
+last_synced: '2026-05-07T22:01:38Z'
+loc: 20
 annotations: []
 imports: []
 exports: []
@@ -27,13 +27,15 @@ sealed class NavDestination(
     val route: String,
     val label: String
 ) {
-    object Login    : NavDestination("login",    "Connexion")
-    object Sleep    : NavDestination("sleep",    "Sommeil")
-    object Trends   : NavDestination("trends",   "Tendances")
-    object Activity : NavDestination("activity", "Activité")
-    object Profile  : NavDestination("profile",  "Profil")
-    object Import   : NavDestination("import",   "Importer")
-    object Settings : NavDestination("settings", "Paramètres")
+    object Login          : NavDestination("login",           "Connexion")
+    object Sleep          : NavDestination("sleep",           "Sommeil")
+    object Trends         : NavDestination("trends",          "Tendances")
+    object Activity       : NavDestination("activity",        "Activité")
+    object Profile        : NavDestination("profile",         "Profil")
+    object Import         : NavDestination("import",          "Importer")
+    object Settings       : NavDestination("settings",        "Paramètres")
+    object Register       : NavDestination("register",        "Créer un compte")
+    object ForgotPassword : NavDestination("forgot_password", "Mot de passe oublié")
 
     companion object {
         fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Trends, Activity, Profile)
@@ -46,5 +48,5 @@ sealed class NavDestination(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavDestination` (class) — lines 3-18
-- `bottomNavItems` (function) — lines 16-16
+- `NavDestination` (class) — lines 3-20
+- `bottomNavItems` (function) — lines 18-18

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 18548846e0244c8ab9de18641934a122078f921c
-last_synced: '2026-05-07T03:10:49Z'
-loc: 149
+git_blob: 46d256bd1d831cb160659cbd1f639a084851ca56
+last_synced: '2026-05-07T22:01:38Z'
+loc: 210
 annotations: []
 imports: []
 exports: []
@@ -37,20 +37,36 @@ import androidx.navigation.compose.DialogNavigator
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.di.AppModule
+import fr.datasaillance.nightfall.data.http.GoogleStartRequest
+import fr.datasaillance.nightfall.data.http.GoogleStartResponse
+import fr.datasaillance.nightfall.data.http.ImportApiResponse
+import fr.datasaillance.nightfall.data.http.LoginRequest
+import fr.datasaillance.nightfall.data.http.LoginResponse
 import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.http.PasswordResetRequest
+import fr.datasaillance.nightfall.data.http.RegisterRequest
+import fr.datasaillance.nightfall.data.http.RegisterResponse
+import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
+import fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen
+import fr.datasaillance.nightfall.ui.screens.auth.LoginScreen
+import fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen
 import fr.datasaillance.nightfall.ui.screens.import_.ImportScreen
-import fr.datasaillance.nightfall.ui.screens.login.LoginScreen
 import fr.datasaillance.nightfall.ui.screens.profile.ProfileScreen
 import fr.datasaillance.nightfall.ui.screens.settings.SettingsScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
 import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+import okhttp3.MultipartBody
+import retrofit2.Response
 
 @Composable
 fun NavGraph(
@@ -59,8 +75,16 @@ fun NavGraph(
     backendUrl: String = "",
     onSaveUrl: (String) -> Unit = {},
     api: NightfallApi? = null,
+    authViewModel: AuthViewModel? = null,
 ) {
+    val context = androidx.compose.ui.platform.LocalContext.current
     val startDestination = if (hasToken) NavDestination.Sleep.route else NavDestination.Login.route
+    val resolvedAuthViewModel = authViewModel ?: remember(api, context) {
+        AppModule.provideAuthViewModel(
+            api = api ?: NoOpNightfallApi(),
+            tokenDataStore = AppModule.provideTokenDataStore(context)
+        )
+    }
 
     // Adds ComposeNavigator/DialogNavigator to the navigator provider when absent.
     // TestNavHostController only registers TestNavigator by default; without this,
@@ -94,11 +118,36 @@ fun NavGraph(
             modifier         = Modifier.padding(innerPadding)
         ) {
             composable(NavDestination.Login.route) {
-                LoginScreen(onLoginSuccess = {
-                    navController.navigate(NavDestination.Sleep.route) {
-                        popUpTo(NavDestination.Login.route) { inclusive = true }
+                LoginScreen(
+                    viewModel = resolvedAuthViewModel,
+                    onLoginSuccess = {
+                        navController.navigate(NavDestination.Sleep.route) {
+                            popUpTo(NavDestination.Login.route) { inclusive = true }
+                        }
+                    },
+                    onNavigateRegister = {
+                        navController.navigate(NavDestination.Register.route)
+                    },
+                    onNavigateForgotPassword = {
+                        navController.navigate(NavDestination.ForgotPassword.route)
                     }
-                })
+                )
+            }
+            composable(NavDestination.Register.route) {
+                RegisterScreen(
+                    viewModel = resolvedAuthViewModel,
+                    onRegisterSuccess = {
+                        navController.navigate(NavDestination.Sleep.route) {
+                            popUpTo(NavDestination.Login.route) { inclusive = true }
+                        }
+                    }
+                )
+            }
+            composable(NavDestination.ForgotPassword.route) {
+                ForgotPasswordScreen(
+                    viewModel = resolvedAuthViewModel,
+                    onBack = { navController.popBackStack() }
+                )
             }
             composable(NavDestination.Sleep.route)    { SleepScreen() }
             composable(NavDestination.Trends.route)   { TrendsScreen() }
@@ -155,6 +204,18 @@ private class NoOpImportRepository : ImportRepository {
     ): ImportResult = throw UnsupportedOperationException("No-op repository")
 }
 
+private class NoOpNightfallApi : NightfallApi {
+    override suspend fun health(): Response<Unit> = throw UnsupportedOperationException("No-op api")
+    override suspend fun login(body: LoginRequest): LoginResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun register(body: RegisterRequest, registrationToken: String?): RegisterResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun requestPasswordReset(body: PasswordResetRequest): StatusResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun googleStart(body: GoogleStartRequest): GoogleStartResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importSleep(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importHeartRate(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importSteps(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importExercise(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+}
+
 /**
  * Adds [ComposeNavigator] and [DialogNavigator] to the [NavHostController]'s navigator provider
  * if they are not already registered. [androidx.navigation.testing.TestNavHostController] only
@@ -177,9 +238,19 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 32-116
-- `NoOpImportRepository` (class) — lines 118-133
-- `pingBackend` (function) — lines 119-119
-- `extractCsvEntries` (function) — lines 121-124
-- `uploadCsv` (function) — lines 126-132
-- `ensureComposeNavigators` (function) — lines 141-149
+- `NavGraph` (function) — lines 48-165
+- `NoOpImportRepository` (class) — lines 167-182
+- `pingBackend` (function) — lines 168-168
+- `extractCsvEntries` (function) — lines 170-173
+- `uploadCsv` (function) — lines 175-181
+- `NoOpNightfallApi` (class) — lines 184-194
+- `health` (function) — lines 185-185
+- `login` (function) — lines 186-186
+- `register` (function) — lines 187-187
+- `requestPasswordReset` (function) — lines 188-188
+- `googleStart` (function) — lines 189-189
+- `importSleep` (function) — lines 190-190
+- `importHeartRate` (function) — lines 191-191
+- `importSteps` (function) — lines 192-192
+- `importExercise` (function) — lines 193-193
+- `ensureComposeNavigators` (function) — lines 202-210

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
-git_blob: b6fcda171011ef3aac4b27a64f6b4525beaf5b40
-last_synced: '2026-05-07T02:02:39Z'
-loc: 170
+git_blob: 256a00d8552d823e5cb989aa2fa4f6411185318c
+last_synced: '2026-05-07T22:01:38Z'
+loc: 172
 annotations: []
 imports: []
 exports: []
@@ -84,6 +84,7 @@ fun LoginScreen(
     }
 
     val isLoading = loginState is LoginUiState.Loading
+    val isFormValid = email.isNotBlank() && password.isNotBlank()
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -146,6 +147,7 @@ fun LoginScreen(
                 text = "Se connecter",
                 onClick = { viewModel.login(email, password) },
                 isLoading = isLoading,
+                enabled = isFormValid && !isLoading,
                 modifier = Modifier.fillMaxWidth().semantics { testTag = "btn_login" }
             )
 
@@ -198,4 +200,4 @@ fun LoginScreen(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `LoginScreen` (function) — lines 43-170
+- `LoginScreen` (function) — lines 43-172

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.md
@@ -1,0 +1,93 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.kt
+git_blob: 37b8c7a5d1554771c9c8315557a0d7fda6473299
+last_synced: '2026-05-07T22:01:38Z'
+loc: 60
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavDestinationP5Test.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.navigation
+
+// spec: P5 §10 / §6.1 — NavDestination.Register et NavDestination.ForgotPassword manquants
+// RED par exécution : ces tests compilent via reflection JVM mais échouent à l'exécution
+// TANT QUE NavDestination.kt n'expose pas ces deux objets dans le sealed class.
+// Une fois ajoutés, ces tests passeront GREEN et valideront les routes.
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NavDestinationP5Test {
+
+    // spec: §10 — NavDestination.Register requis par NavGraph.kt câblé (onNavigateRegister)
+    // RED : NavDestination.kt ne contient pas Register dans le sealed class.
+    // Lookup via reflection : échoue à l'exécution avec NoSuchFieldException tant que l'objet est absent.
+    @Test
+    fun navDestination_register_route_exists() {
+        // spec: §10 / §6.1 — NavDestination.Register doit être un objet du sealed class
+        // avec un champ `route` non vide (convention: "register")
+        val nestedClass = try {
+            Class.forName("fr.datasaillance.nightfall.ui.navigation.NavDestination\$Register")
+        } catch (e: ClassNotFoundException) {
+            throw AssertionError(
+                "NavDestination.Register object not found — must be added to NavDestination sealed class — spec: §10. " +
+                "ClassNotFoundException: ${e.message}"
+            )
+        }
+        val instance = nestedClass.getField("INSTANCE").get(null)
+        val routeField = nestedClass.getMethod("getRoute")
+        val route = routeField.invoke(instance) as String
+        assert(route.isNotBlank()) {
+            "NavDestination.Register.route must be non-blank — spec: §10"
+        }
+    }
+
+    // spec: §10 — NavDestination.ForgotPassword requis par NavGraph.kt câblé (onNavigateForgotPassword)
+    // RED : NavDestination.kt ne contient pas ForgotPassword dans le sealed class.
+    // Lookup via reflection : échoue à l'exécution avec AssertionError tant que l'objet est absent.
+    @Test
+    fun navDestination_forgotPassword_route_exists() {
+        // spec: §10 / §6.1 — NavDestination.ForgotPassword doit être un objet du sealed class
+        // avec un champ `route` non vide (convention: "forgot-password")
+        val nestedClass = try {
+            Class.forName("fr.datasaillance.nightfall.ui.navigation.NavDestination\$ForgotPassword")
+        } catch (e: ClassNotFoundException) {
+            throw AssertionError(
+                "NavDestination.ForgotPassword object not found — must be added to NavDestination sealed class — spec: §10. " +
+                "ClassNotFoundException: ${e.message}"
+            )
+        }
+        val instance = nestedClass.getField("INSTANCE").get(null)
+        val routeField = nestedClass.getMethod("getRoute")
+        val route = routeField.invoke(instance) as String
+        assert(route.isNotBlank()) {
+            "NavDestination.ForgotPassword.route must be non-blank — spec: §10"
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `NavDestinationP5Test` (class) — lines 12-60
+- `navDestination_register_route_exists` (function) — lines 18-36
+- `navDestination_forgotPassword_route_exists` (function) — lines 41-59

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.kt
-git_blob: 464108babcb702c0afc81470b00b31b176b21e99
-last_synced: '2026-05-07T00:48:24Z'
-loc: 185
+git_blob: e95f969b6b8b20939ef4c8f6d19002d83fc032dd
+last_synced: '2026-05-07T22:01:38Z'
+loc: 246
 annotations: []
 imports: []
 exports: []
@@ -32,9 +32,13 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 // These imports will fail to resolve until production code is written:
@@ -205,6 +209,63 @@ class NavGraphTest {
             "Expected navigation to login after logout — spec: TA-11"
         }
     }
+
+    // spec: TA-L-02 — login success → navController navigue vers Sleep, Login popped de la back-stack
+    @Test
+    fun navGraph_login_success_navigates_to_sleep() {
+        val api = mock<NightfallApi>()
+        val tokenStore = mock<TokenDataStore>()
+        val viewModel = AuthViewModel(api, tokenStore)
+        val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
+
+        composeTestRule.setContent {
+            NightfallTheme {
+                NavGraph(
+                    navController = navController,
+                    hasToken = false,
+                    authViewModel = viewModel
+                )
+            }
+        }
+
+        // storeTokenFromCallback sets loginState = Success synchronously
+        composeTestRule.runOnUiThread { viewModel.storeTokenFromCallback("fake-token") }
+        composeTestRule.waitForIdle()
+
+        assert(navController.currentDestination?.route == NavDestination.Sleep.route) {
+            "Expected navigation to sleep after login success — spec: TA-L-02"
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // spec: P5 §6.1 — NavGraph doit importer ui.screens.auth.LoginScreen (et non le stub
+    // ui.screens.login.LoginScreen) — vérification via le titre "Connexion" visible.
+    // ---------------------------------------------------------------------------
+    @Test
+    fun navGraph_login_screen_shows_real_loginscreen() {
+        val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
+
+        composeTestRule.setContent {
+            NightfallTheme {
+                // spec: §6.1 — NavGraph câble ui.screens.auth.LoginScreen (vrai LoginScreen)
+                NavGraph(
+                    navController = navController,
+                    hasToken = false
+                )
+            }
+        }
+
+        // spec: §4.1 — le vrai LoginScreen affiche un Text "Connexion" (headlineLarge)
+        // Le stub legacy affiche "Login — p4-android-auth" — ce noeud ne doit plus exister
+        composeTestRule
+            .onNodeWithText("Connexion")
+            .assertExists("NavGraph must render the real LoginScreen with title 'Connexion' — spec: §6.1 / §4.1")
+
+        // spec: §8 — field_email doit être visible (testTag présent dans le vrai LoginScreen uniquement)
+        composeTestRule
+            .onNode(androidx.compose.ui.test.hasTestTag("field_email"))
+            .assertExists("field_email testTag must be present — only exists in ui.screens.auth.LoginScreen — spec: §8")
+    }
 }
 ```
 
@@ -213,11 +274,13 @@ class NavGraphTest {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraphTest` (class) — lines 24-185
-- `navGraph_noToken_navigatesToLogin` (function) — lines 31-49
-- `navGraph_withToken_navigatesToSleep` (function) — lines 52-69
-- `navGraph_bottomNav_switchesToTrends` (function) — lines 72-91
-- `navGraph_bottomNav_switchesToActivity` (function) — lines 94-113
-- `navGraph_bottomNav_switchesToProfile` (function) — lines 116-134
-- `navGraph_profileScreen_importButtonNavigatesToImport` (function) — lines 137-159
-- `navGraph_profileScreen_logoutClearsTokenAndNavigatesToLogin` (function) — lines 162-184
+- `NavGraphTest` (class) — lines 28-246
+- `navGraph_noToken_navigatesToLogin` (function) — lines 35-53
+- `navGraph_withToken_navigatesToSleep` (function) — lines 56-73
+- `navGraph_bottomNav_switchesToTrends` (function) — lines 76-95
+- `navGraph_bottomNav_switchesToActivity` (function) — lines 98-117
+- `navGraph_bottomNav_switchesToProfile` (function) — lines 120-138
+- `navGraph_profileScreen_importButtonNavigatesToImport` (function) — lines 141-163
+- `navGraph_profileScreen_logoutClearsTokenAndNavigatesToLogin` (function) — lines 166-188
+- `navGraph_login_success_navigates_to_sleep` (function) — lines 191-215
+- `navGraph_login_screen_shows_real_loginscreen` (function) — lines 221-245

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
-git_blob: e74f61d57f8c4c0eaa5efaa3b0f43b0b9b14ae48
-last_synced: '2026-05-07T02:02:39Z'
-loc: 131
+git_blob: 8697a298f3462bd92eb1f78ff1e895e7f7d514d4
+last_synced: '2026-05-07T22:01:38Z'
+loc: 282
 annotations: []
 imports: []
 exports: []
@@ -23,16 +23,23 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.ui.screens.auth
 
-// spec: Tests d'acceptation TA-AUTH-04, TA-AUTH-12
+// spec: Tests d'acceptation TA-AUTH-04, TA-AUTH-12, TA-L-01, TA-L-04, TA-L-06
 // spec: section "LoginScreen" layout + "Parité light / dark mode"
 // RED by construction: fr.datasaillance.nightfall.ui.screens.auth.LoginScreen does not exist yet
 
 import app.cash.paparazzi.DeviceConfig
 import app.cash.paparazzi.Paparazzi
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performTextInput
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
 import kotlinx.coroutines.flow.MutableStateFlow
 
 // These imports will fail to resolve until production code is written:
@@ -152,6 +159,150 @@ class LoginScreenTest {
         // spec: TA-AUTH-04 — loading state: button disabled, fields disabled, progress indicator visible
     }
 }
+
+// ---------------------------------------------------------------------------
+// Robolectric / ComposeTestRule — behavioral tests (TA-L-01, TA-L-04)
+// These tests use a separate class to avoid mixing Paparazzi @Rule with
+// createComposeRule() in the same class instance (incompatible Rule lifecycles).
+// ---------------------------------------------------------------------------
+
+// spec: TA-L-01, TA-L-04 — behavioral interaction tests
+// RED trigger: LoginScreen.kt uses `enabled = !isLoading` without `isFormValid` guard (TA-L-04)
+// The production code in LoginScreen.kt calls:
+//   AuthPrimaryButton(..., isLoading = isLoading, ...)
+// without passing `enabled = isFormValid`. AuthPrimaryButton defaults `enabled = true`.
+// After impl adds `val isFormValid = email.isNotBlank() && password.isNotBlank()` and passes
+// `enabled = isFormValid` to AuthPrimaryButton, these tests will turn GREEN.
+@RunWith(RobolectricTestRunner::class)
+class LoginScreenInteractionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun buildViewModel(): fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel {
+        val api = mock<fr.datasaillance.nightfall.data.http.NightfallApi>()
+        val tokenDataStore = mock<fr.datasaillance.nightfall.data.auth.TokenDataStore>()
+        // spec: D1 / §10 — DI manuelle, pas de Hilt (issue #52)
+        return fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel(api, tokenDataStore)
+    }
+
+    // spec: TA-L-01 / TA-L-04 — bouton "Se connecter" disabled si email ET password sont vides
+    // RED: LoginScreen.kt passe uniquement `isLoading = isLoading` à AuthPrimaryButton — pas de
+    // `enabled = isFormValid`. Le bouton est enabled dès le départ (default enabled=true).
+    // Ce test échoue TANT QUE `isFormValid` n'est pas câblé dans LoginScreen.kt.
+    @Test
+    fun loginScreen_button_disabled_when_fields_empty() {
+        val viewModel = buildViewModel()
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-L-04 — champs vides au démarrage → bouton disabled
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // spec: TA-L-04 — avec email="" et password="" (état initial), btn_login doit être disabled
+        // spec: §4.4 — `val isFormValid = email.isNotBlank() && password.isNotBlank()`
+        composeTestRule
+            .onNode(hasTestTag("btn_login"))
+            .assertIsNotEnabled()
+    }
+
+    // spec: TA-L-04 (complément) — bouton disabled si seulement email rempli, password vide
+    // RED: même raison — `isFormValid` absent dans LoginScreen.kt
+    @Test
+    fun loginScreen_button_disabled_when_only_email_filled() {
+        val viewModel = buildViewModel()
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // Remplir uniquement le champ email
+        composeTestRule
+            .onNode(hasTestTag("field_email"))
+            .performTextInput("user@example.com")
+
+        // spec: TA-L-04 — un seul champ rempli → bouton toujours disabled
+        composeTestRule
+            .onNode(hasTestTag("btn_login"))
+            .assertIsNotEnabled()
+    }
+
+    // spec: TA-L-04 — bouton enabled quand email ET password sont remplis
+    // Ce test documente le contrat complet de TA-L-04 (transition disabled → enabled).
+    // Après impl de `isFormValid`, ce test doit passer GREEN (bouton enabled après saisie des deux champs).
+    @Test
+    fun loginScreen_button_enabled_when_both_fields_filled() {
+        val viewModel = buildViewModel()
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // Remplir les deux champs
+        composeTestRule
+            .onNode(hasTestTag("field_email"))
+            .performTextInput("user@example.com")
+        composeTestRule
+            .onNode(hasTestTag("field_password"))
+            .performTextInput("Password123!")
+
+        // spec: TA-L-04 — email + password remplis + état Idle → bouton enabled
+        composeTestRule
+            .onNode(hasTestTag("btn_login"))
+            .assertIsEnabled()
+    }
+
+    // spec: TA-L-06 — état Loading : champs email/password et bouton disabled
+    @Test
+    fun loginScreen_loading_state_disables_all_interactive_elements() {
+        val viewModel = buildViewModel()
+
+        // Force Loading state via reflection — LoginUiState.Loading is the private _loginState value
+        val field = fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel::class.java
+            .getDeclaredField("_loginState")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        (field.get(viewModel) as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.auth.LoginUiState>)
+            .value = fr.datasaillance.nightfall.viewmodel.auth.LoginUiState.Loading
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.auth.LoginScreen(
+                    viewModel = viewModel,
+                    onLoginSuccess = {},
+                    onNavigateRegister = {},
+                    onNavigateForgotPassword = {}
+                )
+            }
+        }
+
+        // spec: TA-L-06 — Loading state must disable all interactive elements
+        composeTestRule.onNode(hasTestTag("field_email")).assertIsNotEnabled()
+        composeTestRule.onNode(hasTestTag("field_password")).assertIsNotEnabled()
+        composeTestRule.onNode(hasTestTag("btn_login")).assertIsNotEnabled()
+    }
+}
 ```
 
 ---
@@ -159,9 +310,15 @@ class LoginScreenTest {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `LoginScreenTest` (class) — lines 21-131
-- `buildViewModel` (function) — lines 30-42
-- `loginScreen_idle_dark` (function) — lines 46-61
-- `loginScreen_idle_light` (function) — lines 65-80
-- `loginScreen_error_dark` (function) — lines 84-107
-- `loginScreen_loading_dark` (function) — lines 111-130
+- `LoginScreenTest` (class) — lines 28-138
+- `buildViewModel` (function) — lines 37-49
+- `loginScreen_idle_dark` (function) — lines 53-68
+- `loginScreen_idle_light` (function) — lines 72-87
+- `loginScreen_error_dark` (function) — lines 91-114
+- `loginScreen_loading_dark` (function) — lines 118-137
+- `LoginScreenInteractionTest` (class) — lines 154-282
+- `buildViewModel` (function) — lines 159-164
+- `loginScreen_button_disabled_when_fields_empty` (function) — lines 170-191
+- `loginScreen_button_disabled_when_only_email_filled` (function) — lines 195-219
+- `loginScreen_button_enabled_when_both_fields_filled` (function) — lines 224-251
+- `loginScreen_loading_state_disables_all_interactive_elements` (function) — lines 254-281

--- a/docs/vault/specs/2026-05-07-p5-login-native.md
+++ b/docs/vault/specs/2026-05-07-p5-login-native.md
@@ -1,0 +1,395 @@
+---
+title: "P5 Login Native"
+slug: 2026-05-07-p5-login-native
+status: ready
+created: 2026-05-07
+branch: feat/p5-login-native
+implements:
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+tested_by:
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreenTest.kt
+related_specs:
+  - 2026-05-06-p4-android-shell.md
+  - 2026-04-23-plan-v2-refactor-master.md
+tags: [android, compose, auth, p5, login, ui]
+---
+
+# Spec — P5 Login Native
+
+## 1. Vision
+
+Le `LoginScreen` est le premier écran visible au lancement de l'app quand aucun JWT n'est présent dans `TokenDataStore`. Phase 4 a livré un stub vide (`Text("Login — p4-android-auth")`) à `ui/screens/login/LoginScreen.kt` — un squelette de navigation fonctionnel mais sans UI réelle. Phase 5 commence par remplacer ce stub par un écran natif Compose complet (email + password + bouton CTA amber + feedback erreur inline) qui appelle `AuthViewModel.login()` et navigue vers `NavDestination.Sleep` après succès. Sans ce déblocage, aucun des six écrans de visualisation P5 ne peut être testé sur device.
+
+Un `LoginScreen` fonctionnel existe déjà à `ui/screens/auth/LoginScreen.kt` — il est complet mais non câblé dans `NavGraph.kt`. Le livrable principal de cette spec est de connecter cet écran au graph de navigation et de supprimer le stub legacy.
+
+---
+
+## 2. État de l'existant (audit P4)
+
+| Fichier | État | Action requise |
+|---------|------|----------------|
+| `ui/screens/login/LoginScreen.kt` | Stub — `Text("Login — p4-android-auth")` | Supprimer après câblage |
+| `ui/screens/auth/LoginScreen.kt` | Implémentation complète (voir §4) | Câbler dans NavGraph |
+| `ui/navigation/NavGraph.kt` | Importe le stub legacy | Remplacer l'import et l'instanciation |
+| `viewmodel/auth/AuthViewModel.kt` | Complet — `login()`, `loginState: StateFlow<LoginUiState>` | Instancier dans NavGraph |
+| `viewmodel/auth/AuthUiState.kt` | `LoginUiState` sealed class définie | Aucune |
+| `data/http/AuthModels.kt` | `LoginRequest`, `LoginResponse` définis | Aucune |
+| `data/auth/TokenDataStore.kt` | `saveToken()`, `getToken()`, `hasToken()` — EncryptedSharedPreferences | Aucune |
+| `di/AppModule.kt` | Fournit `TokenDataStore` et `SettingsDataStore` — pas encore `AuthViewModel` | Ajouter factory `provideAuthViewModel` |
+| `data/http/NightfallApi.kt` | `POST auth/login` défini | Aucune |
+| `ui/screens/auth/components/` | `AuthTextField`, `AuthPrimaryButton`, `AuthErrorMessage` présents | Aucune |
+
+---
+
+## 3. Contrat de données
+
+### 3.1 HTTP — POST /auth/login
+
+```
+Endpoint  : POST https://sh-dev.datasaillance.fr/auth/login
+Auth      : aucune (endpoint public)
+Body      : { "email": String, "password": String }
+Success   : HTTP 200 — { "access_token": String, "refresh_token": String, "token_type": "bearer", "expires_in": Int }
+Errors    : 401 (credentials invalides), 403 (email non vérifié), 422 (validation Pydantic)
+```
+
+Mapping erreurs HTTP → message utilisateur (défini dans `AuthViewModel.mapHttpError`) :
+
+| Code | Message affiché |
+|------|----------------|
+| 401 | "Email ou mot de passe incorrect" |
+| 403 | "Email non vérifié — consultez votre boîte mail" |
+| 400 | "Mot de passe trop faible (12 caractères minimum, majuscule, chiffre, symbole)" |
+| autre | "Erreur serveur (\$code)" |
+| IOException | "Vérifiez votre connexion réseau" |
+
+### 3.2 ViewModel — AuthViewModel
+
+```kotlin
+// Constructeur (DI manuelle — pas de Hilt, issue #52)
+class AuthViewModel(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore
+) : ViewModel()
+
+// State exposé
+val loginState: StateFlow<LoginUiState>  // émis depuis _loginState (MutableStateFlow)
+
+// Méthode principale
+fun login(email: String, password: String)
+// 1. émet Loading
+// 2. appelle api.login(LoginRequest(email, password))
+// 3. en succès : tokenDataStore.saveToken(access_token) + émet Success
+// 4. HttpException → émet Error(mapHttpError(code))
+// 5. IOException → émet Error("Vérifiez votre connexion réseau")
+```
+
+### 3.3 Sealed class LoginUiState
+
+```kotlin
+sealed class LoginUiState {
+    object Idle    : LoginUiState()   // état initial, bouton actif si champs non vides
+    object Loading : LoginUiState()   // requête en cours — bouton + champs disabled
+    object Success : LoginUiState()   // déclenche LaunchedEffect → onLoginSuccess()
+    data class Error(val message: String) : LoginUiState()  // message inline sous les champs
+}
+```
+
+### 3.4 TokenDataStore
+
+Stockage du JWT via `EncryptedSharedPreferences` (AES-256-GCM, clé dans AndroidKeyStore). En environnement Robolectric uniquement : fallback `SharedPreferences` non chiffrées (Build.FINGERPRINT == "robolectric") — ce chemin ne doit jamais être actif sur un appareil réel (contrainte C2).
+
+```kotlin
+fun saveToken(token: String)   // appelé après HTTP 200
+fun getToken(): String?
+fun hasToken(): Boolean        // utilisé par NavGraph pour choisir startDestination
+fun clearToken()               // utilisé par logout (ProfileScreen)
+```
+
+---
+
+## 4. Layout et interactions du LoginScreen
+
+### 4.1 Structure visuelle
+
+```
+Surface (fillMaxSize, couleur = colorScheme.background)
+  Column (padding horizontal 24dp, centré verticalement)
+    ├── Text "Connexion" (headlineLarge — Playfair Display Bold 32sp)
+    ├── Spacer 32dp
+    ├── AuthTextField — Email (keyboardType = Email, testTag = "field_email")
+    ├── Spacer 16dp
+    ├── AuthTextField — Mot de passe (isPassword = true, toggle œil, testTag = "field_password")
+    ├── Spacer 8dp
+    ├── [conditionnel] AuthErrorMessage (visible si LoginUiState.Error, liveRegion = Polite)
+    ├── Spacer 8dp
+    ├── Spacer 16dp
+    ├── AuthPrimaryButton "Se connecter" (containerColor = secondary = Amber600, testTag = "btn_login")
+    ├── Spacer 8dp
+    ├── OutlinedButton "Continuer avec Google" (border + contenu = tertiary = Cyan500, testTag = "btn_google_oauth")
+    ├── Spacer 16dp
+    ├── TextButton "Mot de passe oublié ?" (color = tertiary, testTag = "link_forgot_password")
+    └── TextButton "Créer un compte" (color = tertiary)
+```
+
+### 4.2 Signature du composable
+
+```kotlin
+@Composable
+fun LoginScreen(
+    viewModel: AuthViewModel,
+    onLoginSuccess: () -> Unit,
+    onNavigateRegister: () -> Unit,
+    onNavigateForgotPassword: () -> Unit
+)
+```
+
+### 4.3 États UX
+
+| État `loginState` | Champs email/password | Bouton "Se connecter" | Bouton Google | AuthErrorMessage |
+|-------------------|-----------------------|----------------------|---------------|-----------------|
+| `Idle` | enabled | enabled (si au moins 1 char dans chaque champ — voir §4.4) | enabled | invisible |
+| `Loading` | disabled | disabled + CircularProgressIndicator | disabled | invisible |
+| `Success` | — | — | — | — (LaunchedEffect → onLoginSuccess) |
+| `Error(msg)` | enabled | enabled | enabled | visible — msg au-dessus du CTA |
+
+> Note : L'implémentation actuelle dans `ui/screens/auth/LoginScreen.kt` désactive le bouton uniquement via `isLoading` (pas via validation de champs vides). Le test d'acceptation TA-L-04 (bouton disabled si champs vides) exige un ajustement : `enabled = email.isNotBlank() && password.isNotBlank() && !isLoading`.
+
+### 4.4 Logique locale (state holder)
+
+```kotlin
+var email    by remember { mutableStateOf("") }
+var password by remember { mutableStateOf("") }
+val isLoading = loginState is LoginUiState.Loading
+
+// Validation d'activation du bouton (à ajouter à l'implémentation actuelle)
+val isFormValid = email.isNotBlank() && password.isNotBlank()
+```
+
+### 4.5 Navigation après succès
+
+```kotlin
+LaunchedEffect(loginState) {
+    if (loginState is LoginUiState.Success) {
+        onLoginSuccess()
+    }
+}
+```
+
+Dans `NavGraph.kt`, `onLoginSuccess` est câblé comme :
+
+```kotlin
+navController.navigate(NavDestination.Sleep.route) {
+    popUpTo(NavDestination.Login.route) { inclusive = true }
+}
+```
+
+Le `popUpTo(inclusive = true)` est obligatoire pour empêcher le retour arrière vers Login après authentification.
+
+---
+
+## 5. Tokens design Compose
+
+### 5.1 Color.kt — tokens DataSaillance
+
+| Token Kotlin | Valeur hex | Role Material3 | Usage LoginScreen |
+|---|---|---|---|
+| `Teal700` | `#0E9EB0` | `primary` | Titre, bordures OutlinedTextField focus |
+| `Amber600` | `#D37C04` | `secondary` | CTA "Se connecter" (`containerColor`) |
+| `Cyan500` | `#07BCD3` | `tertiary` | Bouton Google, liens TextButton |
+| `Background` | `#191E22` | `background` dark | Surface pleine page (dark mode) |
+| `Surface` | `#232E32` | `surface` dark | Surfaces élevées (dark mode) |
+| `BackgroundLight` | `#FAFAFA` | `background` light | Surface pleine page (light mode) |
+| `SurfaceLight` | `#FFFFFF` | `surface` light | Surfaces élevées (light mode) |
+| `NeutralGray` | `#828587` | — | Placeholder, hint |
+
+Tokens interdits : `#6366f1` (indigo Tailwind), dégradés décoratifs, box-shadow glow.
+
+### 5.2 Typographie
+
+| Style Material3 | Famille | Poids | Taille | Usage |
+|---|---|---|---|---|
+| `headlineLarge` | Playfair Display | Bold | 32sp / 40sp | Titre "Connexion" |
+| `bodyLarge` | Inter | Regular | 16sp / 24sp | Labels champs |
+| `labelLarge` | Inter | Medium | 14sp / 20sp | Texte boutons |
+| `bodySmall` | Inter | Regular | 12sp / 16sp | Erreurs inline |
+
+> Divergence avec le brief : le brief mentionne la police Cairo. Le code existant dans `Type.kt` utilise Playfair Display (headings) + Inter (UI). Cette spec se conforme au code réel — Cairo est la police web (`static/`), non la police Android native. Si une migration vers Cairo est souhaitée pour Android, ouvrir une issue dédiée.
+
+### 5.3 NightfallTheme (dark + light — obligatoires)
+
+`NightfallTheme` expose les deux palettes via `darkColorScheme` et `lightColorScheme`. Chaque test Paparazzi doit capturer les deux modes (voir §7). Le switch se fait via `isSystemInDarkTheme()` en production — aucun override manuel dans `LoginScreen`.
+
+---
+
+## 6. Livrables
+
+### 6.1 Fichiers à modifier
+
+| Fichier | Modification |
+|---------|-------------|
+| `ui/navigation/NavGraph.kt` | Remplacer l'import `ui.screens.login.LoginScreen` par `ui.screens.auth.LoginScreen`. Instancier `AuthViewModel` (via `AppModule` ou factory locale). Passer `onNavigateRegister`, `onNavigateForgotPassword` à `LoginScreen`. |
+| `di/AppModule.kt` | Ajouter `fun provideAuthViewModel(api: NightfallApi, tokenDataStore: TokenDataStore): AuthViewModel`. |
+| `ui/screens/auth/LoginScreen.kt` | Ajouter la validation `isFormValid` pour désactiver le bouton si email ou password vides (TA-L-04). |
+
+### 6.2 Fichiers à supprimer
+
+| Fichier | Raison |
+|---------|--------|
+| `ui/screens/login/LoginScreen.kt` | Stub legacy — remplacé par `ui/screens/auth/LoginScreen.kt` câblé dans NavGraph |
+
+### 6.3 Fichiers inchangés (conformes à la spec)
+
+- `viewmodel/auth/AuthViewModel.kt` — complet, pas de modification
+- `viewmodel/auth/AuthUiState.kt` — complet, pas de modification
+- `data/http/AuthModels.kt` — complet, pas de modification
+- `data/auth/TokenDataStore.kt` — complet, pas de modification
+- `data/http/NightfallApi.kt` — `POST auth/login` présent
+- `ui/screens/auth/components/AuthTextField.kt` — toggle password présent
+- `ui/screens/auth/components/AuthPrimaryButton.kt` — CircularProgressIndicator present
+- `ui/screens/auth/components/AuthErrorMessage.kt` — liveRegion Polite présent
+- `ui/theme/Color.kt` — tokens DataSaillance complets
+- `ui/theme/NightfallTheme.kt` — dark + light schemes définis
+
+### 6.4 Fichiers de tests (à compléter)
+
+| Fichier | Statut |
+|---------|--------|
+| `src/test/…/ui/screens/auth/LoginScreenTest.kt` | RED existant — 4 cas Paparazzi. Passer GREEN après câblage NavGraph + ajout validation TA-L-04. |
+
+---
+
+## 7. Tests d'acceptation
+
+### TA-L-01 — Affichage initial (idle state)
+
+**Given** : l'app est lancée, `TokenDataStore.hasToken()` retourne `false`  
+**When** : `NavGraph` calcule `startDestination = NavDestination.Login.route`  
+**Then** : `LoginScreen` s'affiche avec champ email vide, champ password vide, bouton "Se connecter" disabled, aucun message d'erreur visible  
+**Implémentation** : test Compose UI (`composeTestRule.onNodeWithTag("btn_login").assertIsNotEnabled()`)
+
+### TA-L-02 — Login succès, navigation vers Sleep
+
+**Given** : `LoginScreen` affiché, email et password remplis  
+**When** : l'utilisateur appuie sur "Se connecter", `POST /auth/login` retourne HTTP 200 avec `access_token`  
+**Then** : `TokenDataStore.saveToken()` est appelé, `loginState` passe à `Success`, `navController` navigue vers `NavDestination.Sleep.route`, la back-stack ne contient plus `Login` (popUpTo inclusive)  
+**Implémentation** : test ViewModel (`AuthViewModelTest`) + test NavGraph avec `TestNavHostController`
+
+### TA-L-03 — Erreur 401, message inline
+
+**Given** : `LoginScreen` affiché, email et password remplis  
+**When** : l'utilisateur appuie sur "Se connecter", `POST /auth/login` retourne HTTP 401  
+**Then** : `loginState` passe à `Error("Email ou mot de passe incorrect")`, `AuthErrorMessage` devient visible sous les champs, aucune navigation ne se produit, les champs restent éditables  
+**Implémentation** : test Compose UI (`composeTestRule.onNodeWithText("Email ou mot de passe incorrect").assertIsDisplayed()`)
+
+### TA-L-04 — Champs vides, bouton disabled
+
+**Given** : `LoginScreen` vient d'être ouvert, email = "", password = ""  
+**When** : l'utilisateur n'a rien saisi  
+**Then** : le bouton "Se connecter" est disabled (`enabled = false`)  
+**Complément** : si l'un des deux champs est rempli mais pas l'autre, le bouton reste disabled  
+**Implémentation** : test Compose UI + vérification dans `LoginScreen.kt` que `enabled = email.isNotBlank() && password.isNotBlank() && !isLoading`
+
+> Note d'implémentation : l'ajout de `isFormValid` dans `LoginScreen.kt` est requis — l'implémentation actuelle ne valide pas les champs vides.
+
+### TA-L-05 — Paparazzi golden idle state (dark + light)
+
+**Given** : `LoginViewModel` dans l'état `Idle`, wrappé dans `NightfallTheme`  
+**When** : Paparazzi snapshot sur `DeviceConfig.PIXEL_5`  
+**Then** (dark) : fond `#191E22`, CTA amber `#D37C04`, liens cyan `#07BCD3` — snapshot valide vs golden  
+**Then** (light) : fond `#FAFAFA`, même CTA amber — snapshot valide vs golden  
+**Implémentation** : `LoginScreenTest.loginScreen_idle_dark()` et `loginScreen_idle_light()` dans le test existant  
+**Note** : la police Playfair Display / Inter ne se résoud pas en JVM Paparazzi — `FontLoadingStrategy.OptionalLocal` déjà en place dans `Type.kt`, le fallback système est attendu dans les goldens.
+
+### TA-L-06 — État Loading : champs et bouton désactivés
+
+**Given** : `AuthViewModel.login()` appelé, réponse HTTP en attente  
+**When** : `loginState == Loading`  
+**Then** : les champs email et password sont `enabled = false`, le bouton affiche un `CircularProgressIndicator` à la place du texte, `contentDescription = "Chargement en cours"`  
+**Implémentation** : `LoginScreenTest.loginScreen_loading_dark()` (snapshot existant) + test Compose UI sur `assertIsNotEnabled()`
+
+---
+
+## 8. Accessibilité
+
+| Élément | Exigence |
+|---------|----------|
+| Champ email | `testTag = "field_email"`, `contentDescription = "Adresse email"` |
+| Champ password | `testTag = "field_password"`, `contentDescription = "Mot de passe"` |
+| Toggle visibilité password | `contentDescription` dynamique : "Afficher le mot de passe" / "Masquer le mot de passe" |
+| Bouton CTA | `testTag = "btn_login"` |
+| Message d'erreur | `liveRegion = LiveRegionMode.Polite` (annonce TalkBack sans interrompre) |
+| Bouton Google | `testTag = "btn_google_oauth"` |
+| Lien mot de passe oublié | `testTag = "link_forgot_password"` |
+| Taille de cible minimale | 48dp × 48dp (Material3 guideline) — assuré par les composants Material par défaut |
+
+---
+
+## 9. Sécurité (C2 / C3)
+
+| Point | Contrainte |
+|-------|-----------|
+| JWT stockage | `EncryptedSharedPreferences` AES-256-GCM uniquement sur device réel — pas de fallback non chiffré en production (C2) |
+| Transport | TLS 1.3 via Caddy (sh-dev.datasaillance.fr) — `NightfallApi` utilise HTTPS, pas de `CLEARTEXT_TRAFFIC` |
+| Logging password | Interdit — `AuthViewModel` ne logue jamais les champs `email` ni `password` en clair |
+| Timeout réseau | OkHttp doit définir un `connectTimeout` et `readTimeout` (à vérifier dans `RetrofitClient`) — une erreur IOException est catchée et affichée inline |
+| Rate limiting | Le backend (Phase 1) implémente le rate limiting sur `POST /auth/login` — l'app Android affiche le message d'erreur HTTP 429 comme `"Erreur serveur (429)"` (mapHttpError fallback) |
+| Revue pentester | Toute PR touchant ce LoginScreen doit passer `/review` avec severity >= HIGH bloquante (C3) |
+
+---
+
+## 10. DI manuelle — pas de Hilt
+
+Hilt est exclu (issue #52 : incompatibilité Kotlin 2.x kapt). L'instanciation de `AuthViewModel` dans `NavGraph.kt` suit le pattern `remember {}` avec factory explicite :
+
+```kotlin
+// Dans NavGraph.kt, composable Login :
+composable(NavDestination.Login.route) {
+    val context = LocalContext.current
+    val viewModel = remember {
+        val tokenDataStore = AppModule.provideTokenDataStore(context)
+        val api = RetrofitClient.instance  // ou paramètre injecté dans NavGraph
+        AuthViewModel(api, tokenDataStore)
+    }
+    LoginScreen(
+        viewModel             = viewModel,
+        onLoginSuccess        = {
+            navController.navigate(NavDestination.Sleep.route) {
+                popUpTo(NavDestination.Login.route) { inclusive = true }
+            }
+        },
+        onNavigateRegister    = { navController.navigate(NavDestination.Register.route) },
+        onNavigateForgotPassword = { navController.navigate(NavDestination.ForgotPassword.route) }
+    )
+}
+```
+
+> `NavDestination.Register` et `NavDestination.ForgotPassword` ne sont pas encore dans le sealed class — à ajouter lors du câblage (hors scope strict de cette spec mais requis pour compiler).
+
+---
+
+## 11. Parite dark / light mode
+
+Les deux modes sont obligatoires (contrainte design). `NightfallTheme` expose déjà les deux color schemes. Aucune couleur hardcodée dans `LoginScreen.kt` — toutes les couleurs passent par `MaterialTheme.colorScheme.*`.
+
+| Variable Material3 | Dark | Light |
+|---|---|---|
+| `background` | `#191E22` | `#FAFAFA` |
+| `surface` | `#232E32` | `#FFFFFF` |
+| `onBackground` | `#E8E4DC` | `#1A1916` |
+| `secondary` (CTA) | `#D37C04` | `#D37C04` |
+| `tertiary` (liens) | `#07BCD3` | `#07BCD3` |
+| `error` | Material3 default red | Material3 default red |
+
+---
+
+## 12. Suite naturelle
+
+Une fois `LoginScreen` câblé et les tests TA-L-01 à TA-L-06 GREEN :
+
+1. **`spec-p5-dashboard-cards.md`** — premier écran de visualisation (Night Cards), désormais accessible après login
+2. Compléter les destinations manquantes dans `NavDestination` : `Register`, `ForgotPassword` (nécessaires pour compiler le NavGraph complet)
+3. `RegisterScreen` (`ui/screens/auth/RegisterScreen.kt`) et `ForgotPasswordScreen` existent déjà — les câbler dans le même NavGraph update
+
+L'ordre du plan master reste : login natif → night cards → hypnogram → timeline → radial clock → metrics cards.


### PR DESCRIPTION
## Summary

- Wire real `ui.screens.auth.LoginScreen` into NavGraph (delete stub at `ui.screens.login.LoginScreen`)
- Add `isFormValid = email.isNotBlank() && password.isNotBlank()` guard — button disabled until both fields filled (TA-L-04)
- Add `AppModule.provideAuthViewModel(api, tokenDataStore)` factory; NavGraph uses it when no ViewModel injected
- Add `NavDestination.Register` and `NavDestination.ForgotPassword`; wire Register and ForgotPassword routes
- Add behavioral tests: TA-L-01, TA-L-04 (button guard), TA-L-06 (Loading state disables all fields), TA-L-02 (login success → Sleep)

## Test plan

- [ ] All LoginScreenTest Paparazzi snapshots compile (RED until golden recorded)
- [ ] `loginScreen_button_disabled_when_fields_empty` → assertIsNotEnabled on btn_login
- [ ] `loginScreen_button_disabled_when_only_email_filled` → assertIsNotEnabled on btn_login
- [ ] `loginScreen_button_enabled_when_both_fields_filled` → assertIsEnabled on btn_login
- [ ] `loginScreen_loading_state_disables_all_interactive_elements` → all fields + button disabled
- [ ] `navGraph_login_success_navigates_to_sleep` → route == Sleep after storeTokenFromCallback
- [ ] `navGraph_login_screen_shows_real_loginscreen` → "Connexion" title + field_email testTag present
- [ ] Build passes (`./gradlew assembleDebug`)
- [ ] Manual: install on device, verify login screen renders with DataSaillance tokens (dark + light)
