### PR TITLE
feat(android): P5.1 SleepScreen Night Cards — barre colorée

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,10 +30,25 @@
 | Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`4dcf071`](#2026-05-07-4dcf071) |
 | Phase 4 Android WebView Bridge | `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallWebViewClient.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallJsInterface.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/WebViewScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/settings/SettingsDataStore.kt` | [`b7105b4`](#2026-05-07-b7105b4) |
 | P5.0 LoginScreen natif | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt` | [`2ccecfe`](#2026-05-08-2ccecfe) |
+| P5.1 SleepScreen Night Cards | `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt`, `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt` | [`TBD`](#2026-05-08-TBD) |
 
 ---
 
 ## Changelog
+
+### 2026-05-08 `TBD`
+feat: (android): P5.1 SleepScreen Night Cards — SleepViewModel, barre colorée, OffsetDateTime
+- SleepSessionResponse + SleepStageResponse — data classes @Serializable, @SerialName("stage_type") pour mapping JSON correct
+- SleepRepository (interface getSessions()) + SleepRepositoryImpl (Retrofit + TokenDataStore, Bearer token)
+- SleepUiState sealed class — Idle/Loading/Success/Error/Empty
+- SleepViewModel — loadSessions() + retry(), StateFlow<SleepUiState>, tri OffsetDateTime.toInstant() desc, yield() pour observabilité Loading en Robolectric
+- SleepNightCard — barre indicatrice 6dp (teal #0E9EB0 ≥7h / amber #D37C04 ≥5h / rouge #B00020 <5h), date OffsetDateTime + Locale.FRENCH ("Mer 7 mai"), durée "7h 23", score Profond X% conditionnel
+- SleepScreen (native) — remplace stub P4, états Loading/Success/Error/Empty avec testTags sleep_loading/sleep_list/sleep_card_{id}/sleep_error/sleep_retry/sleep_empty
+- SleepScreen (webview) — signature alignée (viewModel?, onSessionClick?) pour compatibilité NavGraph partagé
+- NightfallApi — getSleepSessions(@Header token, @Query from/to, include_stages=true)
+- NavGraph — route Sleep câblée avec SleepViewModel + NoOpSleepRepository
+- SleepScreenTest — 14 tests (4 Paparazzi goldens, 5 Robolectric interaction, 5 ViewModel JVM)
+- 119/119 tests GREEN — build native + webview SUCCESSFUL
 
 ### 2026-05-08 `2ccecfe`
 feat: (android): P5.0 LoginScreen natif — isFormValid, NavGraph wiring, AppModule.provideAuthViewModel

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -30,13 +30,13 @@
 | Phase 4 Android Import SAF | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/CountingRequestBody.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt` | [`4dcf071`](#2026-05-07-4dcf071) |
 | Phase 4 Android WebView Bridge | `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallWebViewClient.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/NightfallJsInterface.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/webview/WebViewScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/settings/SettingsDataStore.kt` | [`b7105b4`](#2026-05-07-b7105b4) |
 | P5.0 LoginScreen natif | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/auth/LoginScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/di/AppModule.kt` | [`2ccecfe`](#2026-05-08-2ccecfe) |
-| P5.1 SleepScreen Night Cards | `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt`, `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt` | [`TBD`](#2026-05-08-TBD) |
+| P5.1 SleepScreen Night Cards | `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt`, `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt` | [`54e9e54`](#2026-05-08-54e9e54) |
 
 ---
 
 ## Changelog
 
-### 2026-05-08 `TBD`
+### 2026-05-08 `54e9e54`
 feat: (android): P5.1 SleepScreen Night Cards — SleepViewModel, barre colorée, OffsetDateTime
 - SleepSessionResponse + SleepStageResponse — data classes @Serializable, @SerialName("stage_type") pour mapping JSON correct
 - SleepRepository (interface getSessions()) + SleepRepositoryImpl (Retrofit + TokenDataStore, Bearer token)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
@@ -1,5 +1,6 @@
 package fr.datasaillance.nightfall.data.http
 
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
@@ -8,6 +9,7 @@ import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Query
 
 @kotlinx.serialization.Serializable
 data class ImportApiResponse(val inserted: Int, val skipped: Int)
@@ -27,6 +29,14 @@ interface NightfallApi {
 
     @POST("auth/google/start")
     suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
+
+    @GET("api/sleep")
+    suspend fun getSleepSessions(
+        @Header("Authorization") token: String,
+        @Query("from") from: String? = null,
+        @Query("to") to: String? = null,
+        @Query("include_stages") includeStages: Boolean = true
+    ): List<SleepSessionResponse>
 
     @Multipart
     @POST("api/sleep/import")

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
@@ -1,0 +1,5 @@
+package fr.datasaillance.nightfall.data.sleep
+
+interface SleepRepository {
+    suspend fun getSessions(): Result<List<SleepSessionResponse>>
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import timber.log.Timber
+import java.io.IOException
+
+class SleepRepositoryImpl(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore
+) : SleepRepository {
+
+    override suspend fun getSessions(): Result<List<SleepSessionResponse>> {
+        val token = tokenDataStore.getToken()
+            ?: return Result.failure(IOException("No auth token"))
+        return try {
+            val sessions = api.getSleepSessions("Bearer $token")
+            Timber.i("sleep_sessions_fetched count=${sessions.size}")
+            Result.success(sessions)
+        } catch (e: retrofit2.HttpException) {
+            Timber.w("sleep_fetch_http_error code=${e.code()}")
+            Result.failure(e)
+        } catch (e: IOException) {
+            Timber.w("sleep_fetch_network_error")
+            Result.failure(e)
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.kt
@@ -1,0 +1,12 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SleepSessionResponse(
+    val id: String,
+    val sleep_start: String,
+    val sleep_end: String,
+    val created_at: String?,
+    val stages: List<SleepStageResponse>?
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.kt
@@ -1,0 +1,13 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SleepStageResponse(
+    val id: String,
+    val session_id: String,
+    @SerialName("stage_type") val stage: String,
+    val stage_start: String,
+    val stage_end: String
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -29,6 +29,8 @@ import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
@@ -42,6 +44,7 @@ import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
 import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
 import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
 import okhttp3.MultipartBody
 import retrofit2.Response
 
@@ -126,7 +129,10 @@ fun NavGraph(
                     onBack = { navController.popBackStack() }
                 )
             }
-            composable(NavDestination.Sleep.route)    { SleepScreen() }
+            composable(NavDestination.Sleep.route) {
+                val sleepViewModel = remember { SleepViewModel(NoOpSleepRepository()) }
+                SleepScreen(viewModel = sleepViewModel, onSessionClick = {})
+            }
             composable(NavDestination.Trends.route)   { TrendsScreen() }
             composable(NavDestination.Activity.route) { ActivityScreen() }
             composable(NavDestination.Profile.route) {
@@ -164,6 +170,11 @@ fun NavGraph(
     }
 }
 
+private class NoOpSleepRepository : SleepRepository {
+    override suspend fun getSessions(): Result<List<SleepSessionResponse>> =
+        Result.success(emptyList())
+}
+
 private class NoOpImportRepository : ImportRepository {
     override suspend fun pingBackend(): Boolean = false
 
@@ -191,6 +202,7 @@ private class NoOpNightfallApi : NightfallApi {
     override suspend fun importHeartRate(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importSteps(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importExercise(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun getSleepSessions(token: String, from: String?, to: String?, includeStages: Boolean): List<SleepSessionResponse> = emptyList()
 }
 
 /**

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.kt
@@ -1,0 +1,11 @@
+package fr.datasaillance.nightfall.viewmodel.sleep
+
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+
+sealed class SleepUiState {
+    object Idle : SleepUiState()
+    object Loading : SleepUiState()
+    object Empty : SleepUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : SleepUiState()
+    data class Error(val message: String) : SleepUiState()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt
@@ -1,0 +1,54 @@
+package fr.datasaillance.nightfall.viewmodel.sleep
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import timber.log.Timber
+import java.time.OffsetDateTime
+
+class SleepViewModel(private val repository: SleepRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SleepUiState>(SleepUiState.Idle)
+    val uiState: StateFlow<SleepUiState> = _uiState.asStateFlow()
+
+    fun loadSessions() {
+        _uiState.value = SleepUiState.Loading
+        viewModelScope.launch {
+            try {
+                yield()
+                val result = repository.getSessions()
+                _uiState.value = when {
+                    result.isFailure -> SleepUiState.Error(mapError(result.exceptionOrNull()))
+                    result.getOrNull().isNullOrEmpty() -> SleepUiState.Empty
+                    else -> SleepUiState.Success(
+                        result.getOrNull()!!.sortedByDescending { session ->
+                            runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }
+                                .getOrNull()
+                        }
+                    )
+                }
+                Timber.d("sleep_load_complete state=${_uiState.value::class.simpleName}")
+            } catch (e: Exception) {
+                Timber.w("sleep_load_error")
+                _uiState.value = SleepUiState.Error(mapError(e))
+            }
+        }
+    }
+
+    fun retry() = loadSessions()
+
+    private fun mapError(throwable: Throwable?): String = when (throwable) {
+        is java.io.IOException -> "Vérifiez votre connexion réseau"
+        is retrofit2.HttpException -> when (throwable.code()) {
+            401 -> "Session expirée, reconnectez-vous"
+            403 -> "Accès refusé"
+            else -> "Erreur serveur (${throwable.code()})"
+        }
+        else -> "Une erreur inattendue est survenue"
+    }
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt
@@ -1,0 +1,132 @@
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val FMT_NIGHT = DateTimeFormatter.ofPattern("EEE d MMM", Locale.FRENCH)
+private val FMT_TIME = DateTimeFormatter.ofPattern("HH:mm")
+
+private val ColorTeal = Color(0xFF0E9EB0)
+private val ColorAmber = Color(0xFFD37C04)
+private val ColorRed = Color(0xFFB00020)
+
+@Composable
+fun SleepNightCard(
+    session: SleepSessionResponse,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val start = remember(session.sleep_start) {
+        runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
+    }
+    val end = remember(session.sleep_end) {
+        runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+    }
+
+    val duration = if (start != null && end != null) Duration.between(start, end) else null
+    val hours = duration?.toHours() ?: 0L
+    val minutes = duration?.toMinutesPart() ?: 0
+
+    val indicatorColor = when {
+        hours >= 7 -> ColorTeal
+        hours >= 5 -> ColorAmber
+        else -> ColorRed
+    }
+
+    val nightLabel = start?.format(FMT_NIGHT)?.replaceFirstChar { it.uppercase() } ?: ""
+    val bedTime = start?.format(FMT_TIME) ?: ""
+    val wakeTime = end?.format(FMT_TIME) ?: ""
+    val durationText = if (duration != null) "${hours}h ${minutes.toString().padStart(2, '0')}" else ""
+
+    val deepScore = remember(session.stages, duration) {
+        val stages = session.stages
+        if (!stages.isNullOrEmpty() && duration != null && duration.toMinutes() > 0) {
+            val deepMinutes = stages
+                .filter { it.stage == "DEEP" }
+                .sumOf { stage ->
+                    val s = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull()
+                    val e = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull()
+                    if (s != null && e != null) Duration.between(s, e).toMinutes() else 0L
+                }
+            (deepMinutes * 100L / duration.toMinutes()).toInt()
+        } else null
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("sleep_card_${session.id}")
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+            Box(
+                modifier = Modifier
+                    .width(6.dp)
+                    .fillMaxHeight()
+                    .background(indicatorColor)
+            )
+            Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
+                Text(
+                    text = nightLabel,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = durationText,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row {
+                    Text(
+                        text = "Coucher $bedTime",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Réveil $wakeTime",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                    if (deepScore != null) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Profond $deepScore%",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = ColorTeal
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
@@ -1,9 +1,129 @@
 package fr.datasaillance.nightfall.ui.screens.sleep
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
 
 @Composable
-fun SleepScreen() {
-    Text("Phase 5 — Compose Canvas")
+fun SleepScreen(
+    viewModel: SleepViewModel,
+    onSessionClick: (String) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = "Mes nuits",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
+            )
+
+            when (val state = uiState) {
+                is SleepUiState.Idle -> {}
+
+                is SleepUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("sleep_loading"),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+
+                is SleepUiState.Success -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("sleep_list"),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        items(state.sessions, key = { it.id }) { session ->
+                            SleepNightCard(
+                                session = session,
+                                onClick = { onSessionClick(session.id) }
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+                    }
+                }
+
+                is SleepUiState.Empty -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("sleep_empty"),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Aucune nuit enregistrée",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+
+                is SleepUiState.Error -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
+                                .testTag("sleep_error"),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = state.message,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Button(
+                                onClick = { viewModel.retry() },
+                                modifier = Modifier.testTag("sleep_retry"),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary
+                                )
+                            ) {
+                                Text("Réessayer")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }

--- a/android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.kt
+++ b/android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.kt
@@ -1,0 +1,15 @@
+@file:JvmName("ComposeTestExtensionsKt")
+package androidx.compose.ui.test
+
+/**
+ * Top-level extension shims for SemanticsNodeInteraction.assertExists() and assertDoesNotExist().
+ * In compose-ui-test 1.7.x and 1.8.x, these are member functions on SemanticsNodeInteraction,
+ * not top-level extension functions. The test file imports them as top-level functions,
+ * so we provide these shims to bridge the gap.
+ */
+
+fun assertExists(node: SemanticsNodeInteraction): SemanticsNodeInteraction =
+    node.assertExists()
+
+fun assertDoesNotExist(node: SemanticsNodeInteraction) =
+    node.assertDoesNotExist()

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt
@@ -1,0 +1,578 @@
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+// spec: Tests d'acceptation TA-S-01, TA-S-02, TA-S-03, TA-S-04, TA-S-07, TA-S-07b, TA-S-08,
+//       TA-S-09, TA-S-10, TA-S-11, TA-S-12
+// spec: section "SleepScreen Night Cards" — layout, états, interactions, snapshots
+// RED by construction: the following classes do not exist yet and imports will fail at compile time:
+//   fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+//   fr.datasaillance.nightfall.data.sleep.SleepStageResponse
+//   fr.datasaillance.nightfall.data.sleep.SleepRepository
+//   fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState
+//   fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
+//   fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen  (stub will be replaced)
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+// ---------------------------------------------------------------------------
+// Test fixtures — shared across all three test classes
+// ---------------------------------------------------------------------------
+
+// spec: TA-S-03/TA-S-04 — session avec stages, durée 7h23
+private val session1 = fr.datasaillance.nightfall.data.sleep.SleepSessionResponse(
+    id = "aaa-111",
+    sleep_start = "2026-05-07T23:15:00+02:00",
+    sleep_end = "2026-05-08T06:38:00+02:00",
+    created_at = "2026-05-08T10:00:00Z",
+    stages = listOf(
+        fr.datasaillance.nightfall.data.sleep.SleepStageResponse(
+            id = "s1",
+            session_id = "aaa-111",
+            stage = "DEEP",
+            stage_start = "2026-05-08T01:00:00+02:00",
+            stage_end = "2026-05-08T02:30:00+02:00"
+        ),
+        fr.datasaillance.nightfall.data.sleep.SleepStageResponse(
+            id = "s2",
+            session_id = "aaa-111",
+            stage = "LIGHT",
+            stage_start = "2026-05-08T02:30:00+02:00",
+            stage_end = "2026-05-08T06:38:00+02:00"
+        )
+    )
+)
+
+// spec: TA-S-03/TA-S-04 — session sans stages, durée 6h00
+private val session2 = fr.datasaillance.nightfall.data.sleep.SleepSessionResponse(
+    id = "bbb-222",
+    sleep_start = "2026-05-06T00:00:00Z",
+    sleep_end = "2026-05-06T06:00:00Z",
+    created_at = null,
+    stages = null
+)
+
+// spec: TA-S-02 sort — session courte, durée 4h30 (oldest — must appear last after desc sort)
+private val session3 = fr.datasaillance.nightfall.data.sleep.SleepSessionResponse(
+    id = "ccc-333",
+    sleep_start = "2026-05-05T02:00:00Z",
+    sleep_end = "2026-05-05T06:30:00Z",
+    created_at = null,
+    stages = null
+)
+
+private val threeSessionsAscOrder = listOf(session3, session2, session1)
+
+// ---------------------------------------------------------------------------
+// Helper: inject state into SleepViewModel via reflection on _uiState
+// ---------------------------------------------------------------------------
+
+@Suppress("UNCHECKED_CAST")
+private fun injectSleepState(
+    viewModel: fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel,
+    state: fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState
+) {
+    val field = fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel::class.java
+        .getDeclaredField("_uiState")
+    field.isAccessible = true
+    (field.get(viewModel) as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState>)
+        .value = state
+}
+
+// ---------------------------------------------------------------------------
+// Class 1 — Paparazzi snapshot tests (no @RunWith — incompatible with Robolectric)
+// spec: TA-S-09, TA-S-10, TA-S-11, TA-S-12
+// ---------------------------------------------------------------------------
+
+class SleepScreenSnapshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(
+        repository: fr.datasaillance.nightfall.data.sleep.SleepRepository =
+            mock<fr.datasaillance.nightfall.data.sleep.SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel(repository)
+
+    // spec: TA-S-09 — SleepScreen dark mode, ViewModel en état Success avec 3 sessions
+    // spec: "Parité light / dark mode" — fond #191E22, surface #232E32, teal #0E9EB0
+    // RED by construction: SleepScreen and SleepViewModel do not exist yet
+    @Test
+    fun sleepScreen_success_dark() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success(
+                listOf(session1, session2, session3)
+            )
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-09 — SleepScreen receives SleepViewModel and onSessionClick callback
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-09 — snapshot dark: fond #191E22, 3 night cards visibles
+    }
+
+    // spec: TA-S-10 — SleepScreen light mode, même état Success
+    // spec: "Parité light / dark mode" — fond clair, même teal #0E9EB0 et amber #D37C04
+    // RED by construction: SleepScreen and SleepViewModel do not exist yet
+    @Test
+    fun sleepScreen_success_light() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success(
+                listOf(session1, session2, session3)
+            )
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = false) {
+                // spec: TA-S-10 — light mode snapshot: fond clair, night cards rendues
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-10 — snapshot light: fond #FAFAFA ou équivalent, 3 cards visibles
+    }
+
+    // spec: TA-S-11 — SleepScreen dark mode, ViewModel en état Loading
+    // RED by construction: SleepUiState.Loading does not exist yet
+    @Test
+    fun sleepScreen_loading_dark() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-11 — Loading state: CircularProgressIndicator ou skeleton visible
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-11 — snapshot dark Loading: indicateur de chargement présent, liste absente
+    }
+
+    // spec: TA-S-12 — SleepScreen dark mode, ViewModel en état Error
+    // RED by construction: SleepUiState.Error does not exist yet
+    @Test
+    fun sleepScreen_error_dark() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error(
+                "Vérifiez votre connexion réseau"
+            )
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-12 — Error state: message d'erreur + bouton retry visibles
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-12 — snapshot dark Error: "Vérifiez votre connexion réseau" visible, bouton retry présent
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 2 — Robolectric behavioral/interaction tests
+// spec: TA-S-01, TA-S-02, TA-S-07, TA-S-07b, TA-S-08
+// Separate class from Paparazzi: incompatible Rule lifecycles
+// ---------------------------------------------------------------------------
+
+// spec: TA-S-01 — Loading: sleep_loading visible, sleep_list absent
+// spec: TA-S-02 — Success(3): sleep_list visible, sleep_card_${id} pour chacune
+// spec: TA-S-07 — Error: sleep_error visible, sleep_retry visible
+// spec: TA-S-07b — click sleep_retry: state revient à Loading
+// spec: TA-S-08 — Empty: sleep_empty visible, sleep_list absent
+// RED by construction: SleepScreen test tags (sleep_loading, sleep_list, sleep_error,
+//   sleep_retry, sleep_empty, sleep_card_${id}) n'existent pas dans le stub actuel
+@RunWith(RobolectricTestRunner::class)
+class SleepScreenInteractionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun buildViewModel(
+        repository: fr.datasaillance.nightfall.data.sleep.SleepRepository =
+            mock<fr.datasaillance.nightfall.data.sleep.SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel(repository)
+
+    // spec: TA-S-01 — état Loading: sleep_loading assertExists, sleep_list assertDoesNotExist
+    // RED: le stub SleepScreen n'a pas de testTag "sleep_loading" ni "sleep_list"
+    @Test
+    fun sleepScreen_shows_loading_indicator() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-01 — SleepScreen avec ViewModel en Loading
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-01 — indicateur de chargement présent
+        composeTestRule
+            .onNode(hasTestTag("sleep_loading"))
+            .assertExists()
+
+        // spec: TA-S-01 — liste absente en état Loading
+        composeTestRule
+            .onNode(hasTestTag("sleep_list"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-S-02 — état Success(3 sessions): sleep_list assertExists,
+    //   sleep_card_aaa-111, sleep_card_bbb-222, sleep_card_ccc-333 assertExists chacun
+    // RED: le stub SleepScreen n'expose pas sleep_list ni sleep_card_${id}
+    @Test
+    fun sleepScreen_shows_list_when_success() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success(
+                listOf(session1, session2, session3)
+            )
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-02 — SleepScreen avec 3 sessions
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-02 — conteneur de liste présent
+        composeTestRule
+            .onNode(hasTestTag("sleep_list"))
+            .assertExists()
+
+        // spec: TA-S-02 — une card par session, testTag = "sleep_card_${session.id}"
+        composeTestRule
+            .onNode(hasTestTag("sleep_card_aaa-111"))
+            .assertExists()
+        composeTestRule
+            .onNode(hasTestTag("sleep_card_bbb-222"))
+            .assertExists()
+        composeTestRule
+            .onNode(hasTestTag("sleep_card_ccc-333"))
+            .assertExists()
+    }
+
+    // spec: TA-S-07 — état Error: sleep_error assertExists, sleep_retry assertExists
+    // RED: le stub SleepScreen n'expose pas sleep_error ni sleep_retry
+    @Test
+    fun sleepScreen_shows_error_with_retry_button() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error(
+                "Vérifiez votre connexion réseau"
+            )
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-07 — SleepScreen avec ViewModel en Error
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-07 — bloc d'erreur visible
+        composeTestRule
+            .onNode(hasTestTag("sleep_error"))
+            .assertExists()
+
+        // spec: TA-S-07 — bouton "Réessayer" visible en état Error
+        composeTestRule
+            .onNode(hasTestTag("sleep_retry"))
+            .assertExists()
+    }
+
+    // spec: TA-S-08 — état Empty: sleep_empty assertExists, sleep_list assertDoesNotExist
+    // RED: le stub SleepScreen n'expose pas sleep_empty
+    @Test
+    fun sleepScreen_shows_empty_state() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Empty
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-08 — SleepScreen avec ViewModel en Empty (aucune session importée)
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-08 — état vide visible (message "Aucune nuit enregistrée" ou équivalent)
+        composeTestRule
+            .onNode(hasTestTag("sleep_empty"))
+            .assertExists()
+
+        // spec: TA-S-08 — liste absente en état Empty
+        composeTestRule
+            .onNode(hasTestTag("sleep_list"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-S-07b — click sur sleep_retry: l'état repasse à Loading via SleepViewModel.loadSessions()
+    // RED: le stub SleepScreen n'a pas de bouton sleep_retry fonctionnel
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun sleepScreen_retry_button_triggers_reload() {
+        val repository = mock<fr.datasaillance.nightfall.data.sleep.SleepRepository>()
+        val viewModel = buildViewModel(repository)
+
+        // Pré-condition: state est Error pour que le bouton retry soit affiché
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error(
+                "Vérifiez votre connexion réseau"
+            )
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-07b — SleepScreen en Error avec bouton retry
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-07b — click sur le bouton retry
+        composeTestRule
+            .onNode(hasTestTag("sleep_retry"))
+            .performClick()
+
+        // spec: TA-S-07b — après le click, l'état doit repasser à Loading
+        // (SleepViewModel.loadSessions() remet _uiState = Loading avant l'appel réseau)
+        val uiStateField = fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel::class.java
+            .getDeclaredField("_uiState")
+        uiStateField.isAccessible = true
+        val stateFlow = uiStateField.get(viewModel)
+            as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState>
+        val stateAfterRetry = stateFlow.value
+
+        assert(stateAfterRetry is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading) {
+            "uiState must be SleepUiState.Loading after retry button click — spec: TA-S-07b, got: $stateAfterRetry"
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 3 — SleepViewModel unit tests (pure JVM, no Compose, no Robolectric)
+// spec: TA-S-03, TA-S-04, TA-S-07 logic, TA-S-08 logic, TA-S-02 sort
+// ---------------------------------------------------------------------------
+
+// spec: TA-S-03/TA-S-04 — SleepViewModel.loadSessions() success → SleepUiState.Success
+// spec: TA-S-07 logic — SleepViewModel.loadSessions() failure → SleepUiState.Error
+// spec: TA-S-08 logic — SleepViewModel.loadSessions() returns empty → SleepUiState.Empty
+// spec: TA-S-02 sort — sessions triées par sleep_start desc dans Success.sessions
+// RED by construction: SleepViewModel, SleepRepository, SleepUiState n'existent pas encore
+@OptIn(ExperimentalCoroutinesApi::class)
+class SleepViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: fr.datasaillance.nightfall.data.sleep.SleepRepository
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
+
+    @Before
+    fun setUp() {
+        // spec: TA-S-03 — viewModelScope utilise Dispatchers.Main; remplacé par testDispatcher
+        Dispatchers.setMain(testDispatcher)
+        repository = mock()
+        // spec: DI manuelle — pas de Hilt, SleepViewModel construit directement avec repository
+        viewModel = fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel(repository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-S-03 / TA-S-04 — loadSessions() success → SleepUiState.Success avec les sessions
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_emits_success_when_repository_returns_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(listOf(session1, session2))
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-03 — uiState doit être SleepUiState.Success après un appel réussi
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success) {
+            "uiState must be SleepUiState.Success when repository returns sessions — spec: TA-S-03, got: $state"
+        }
+
+        // spec: TA-S-04 — Success.sessions contient bien les sessions retournées
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success).sessions
+        assert(sessions.size == 2) {
+            "Success.sessions must contain 2 sessions — spec: TA-S-04, got: ${sessions.size}"
+        }
+    }
+
+    // spec: TA-S-07 logic — loadSessions() failure (IOException) → SleepUiState.Error
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_emits_error_when_repository_fails() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.failure(java.io.IOException("Connection refused"))
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-07 — uiState doit être SleepUiState.Error si le repository échoue
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error) {
+            "uiState must be SleepUiState.Error when repository returns failure — spec: TA-S-07, got: $state"
+        }
+
+        // spec: TA-S-07 — Error.message doit être non-null et non-vide
+        val message = (state as fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error).message
+        assert(message.isNotBlank()) {
+            "SleepUiState.Error.message must not be blank — spec: TA-S-07, got: '$message'"
+        }
+    }
+
+    // spec: TA-S-08 logic — loadSessions() returns empty list → SleepUiState.Empty
+    // RED: SleepViewModel.loadSessions() et SleepUiState.Empty n'existent pas encore
+    @Test
+    fun sleepViewModel_emits_empty_when_no_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(emptyList())
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-08 — uiState doit être SleepUiState.Empty si le repository retourne une liste vide
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Empty) {
+            "uiState must be SleepUiState.Empty when repository returns empty list — spec: TA-S-08, got: $state"
+        }
+    }
+
+    // spec: TA-S-02 sort — sessions triées par sleep_start descending dans Success.sessions
+    // 3 sessions données en ordre ascendant (session3=oldest → session1=newest)
+    // après loadSessions(), Success.sessions doit être [session1, session2, session3] (desc)
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_sorts_sessions_by_start_desc() = runTest {
+        // Données en ordre ascendant: oldest first (session3 < session2 < session1)
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(threeSessionsAscOrder)
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-02 sort — Success.sessions trié par sleep_start desc (newest first)
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success) {
+            "uiState must be SleepUiState.Success — spec: TA-S-02 sort, got: $state"
+        }
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success).sessions
+        assert(sessions.size == 3) {
+            "Success.sessions must contain 3 sessions — spec: TA-S-02 sort, got: ${sessions.size}"
+        }
+        // spec: TA-S-02 sort — premier élément = session la plus récente (session1: 2026-05-07T23:15)
+        assert(sessions[0].id == "aaa-111") {
+            "sessions[0] must be session1 (most recent) — spec: TA-S-02 sort, got id: ${sessions[0].id}"
+        }
+        // spec: TA-S-02 sort — deuxième élément = session2 (2026-05-06T00:00)
+        assert(sessions[1].id == "bbb-222") {
+            "sessions[1] must be session2 — spec: TA-S-02 sort, got id: ${sessions[1].id}"
+        }
+        // spec: TA-S-02 sort — troisième élément = session3 (oldest: 2026-05-05T02:00)
+        assert(sessions[2].id == "ccc-333") {
+            "sessions[2] must be session3 (oldest) — spec: TA-S-02 sort, got id: ${sessions[2].id}"
+        }
+    }
+
+    // spec: TA-S-03 — état Loading émis synchroniquement avant que la coroutine suspende
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_emits_loading_while_in_flight() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(listOf(session1))
+        )
+
+        // spec: TA-S-03 — _uiState = Loading doit être positionné AVANT que la coroutine atteigne getSessions()
+        viewModel.loadSessions()
+
+        // Avant advanceUntilIdle() — la coroutine est suspendue à getSessions()
+        val stateWhileInFlight = viewModel.uiState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading) {
+            "uiState must be SleepUiState.Loading immediately after loadSessions() — spec: TA-S-03, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+}

--- a/android-app/app/src/test/resources/robolectric.properties
+++ b/android-app/app/src/test/resources/robolectric.properties
@@ -1,1 +1,2 @@
 sdk=28
+looper.mode=PAUSED

--- a/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
+++ b/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
@@ -6,10 +6,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import fr.datasaillance.nightfall.data.auth.TokenDataStore
 import fr.datasaillance.nightfall.data.settings.SettingsDataStore
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
 import fr.datasaillance.nightfall.webview.WebViewScreen
 
 @Composable
 fun SleepScreen(
+    viewModel: SleepViewModel? = null,
+    onSessionClick: (String) -> Unit = {},
     tokenDataStore: TokenDataStore? = null,
     settingsDataStore: SettingsDataStore? = null,
     onOpenImport: () -> Unit = {},

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
-git_blob: 3f989123930d5deec5041d161889cc1dc163e6c3
-last_synced: '2026-05-07T03:10:49Z'
-loc: 46
+git_blob: 24d697e593df03b66599a41347b48275f055c5f1
+last_synced: '2026-05-08T01:27:05Z'
+loc: 56
 annotations: []
 imports: []
 exports: []
@@ -23,6 +23,7 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.data.http
 
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
@@ -31,6 +32,7 @@ import retrofit2.http.Header
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Query
 
 @kotlinx.serialization.Serializable
 data class ImportApiResponse(val inserted: Int, val skipped: Int)
@@ -50,6 +52,14 @@ interface NightfallApi {
 
     @POST("auth/google/start")
     suspend fun googleStart(@Body body: GoogleStartRequest): GoogleStartResponse
+
+    @GET("api/sleep")
+    suspend fun getSleepSessions(
+        @Header("Authorization") token: String,
+        @Query("from") from: String? = null,
+        @Query("to") to: String? = null,
+        @Query("include_stages") includeStages: Boolean = true
+    ): List<SleepSessionResponse>
 
     @Multipart
     @POST("api/sleep/import")
@@ -74,14 +84,15 @@ interface NightfallApi {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportApiResponse` (class) — lines 12-13
-- `NightfallApi` (class) — lines 15-46
-- `health` (function) — lines 16-17
-- `login` (function) — lines 19-20
-- `register` (function) — lines 22-23
-- `requestPasswordReset` (function) — lines 25-26
-- `googleStart` (function) — lines 28-29
-- `importSleep` (function) — lines 31-33
-- `importHeartRate` (function) — lines 35-37
-- `importSteps` (function) — lines 39-41
-- `importExercise` (function) — lines 43-45
+- `ImportApiResponse` (class) — lines 14-15
+- `NightfallApi` (class) — lines 17-56
+- `health` (function) — lines 18-19
+- `login` (function) — lines 21-22
+- `register` (function) — lines 24-25
+- `requestPasswordReset` (function) — lines 27-28
+- `googleStart` (function) — lines 30-31
+- `getSleepSessions` (function) — lines 33-39
+- `importSleep` (function) — lines 41-43
+- `importHeartRate` (function) — lines 45-47
+- `importSteps` (function) — lines 49-51
+- `importExercise` (function) — lines 53-55

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.md
@@ -1,0 +1,37 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
+git_blob: 364919410d349ed4baeb81b851d72150ee1c7d95
+last_synced: '2026-05-08T01:27:05Z'
+loc: 5
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+interface SleepRepository {
+    suspend fun getSessions(): Result<List<SleepSessionResponse>>
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepRepository` (class) — lines 3-5
+- `getSessions` (function) — lines 4-4

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.md
@@ -1,0 +1,60 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
+git_blob: 1d5121ead2f5371815083acc39d390e0ad0338e1
+last_synced: '2026-05-08T01:27:05Z'
+loc: 28
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import fr.datasaillance.nightfall.data.auth.TokenDataStore
+import fr.datasaillance.nightfall.data.http.NightfallApi
+import timber.log.Timber
+import java.io.IOException
+
+class SleepRepositoryImpl(
+    private val api: NightfallApi,
+    private val tokenDataStore: TokenDataStore
+) : SleepRepository {
+
+    override suspend fun getSessions(): Result<List<SleepSessionResponse>> {
+        val token = tokenDataStore.getToken()
+            ?: return Result.failure(IOException("No auth token"))
+        return try {
+            val sessions = api.getSleepSessions("Bearer $token")
+            Timber.i("sleep_sessions_fetched count=${sessions.size}")
+            Result.success(sessions)
+        } catch (e: retrofit2.HttpException) {
+            Timber.w("sleep_fetch_http_error code=${e.code()}")
+            Result.failure(e)
+        } catch (e: IOException) {
+            Timber.w("sleep_fetch_network_error")
+            Result.failure(e)
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepRepositoryImpl` (class) — lines 8-28
+- `getSessions` (function) — lines 13-27

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.md
@@ -1,0 +1,43 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.kt
+git_blob: d0fbe0e9c6f37a49ac5d75eb72cd3e7383172208
+last_synced: '2026-05-08T01:27:05Z'
+loc: 12
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepSessionResponse.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SleepSessionResponse(
+    val id: String,
+    val sleep_start: String,
+    val sleep_end: String,
+    val created_at: String?,
+    val stages: List<SleepStageResponse>?
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepSessionResponse` (class) — lines 5-12

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.md
@@ -1,0 +1,44 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.kt
+git_blob: 5606b9f467a7cc9214655fe191da408a366fecae
+last_synced: '2026-05-08T01:27:05Z'
+loc: 13
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepStageResponse.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SleepStageResponse(
+    val id: String,
+    val session_id: String,
+    @SerialName("stage_type") val stage: String,
+    val stage_start: String,
+    val stage_end: String
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepStageResponse` (class) — lines 6-13

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 46d256bd1d831cb160659cbd1f639a084851ca56
-last_synced: '2026-05-07T22:01:38Z'
-loc: 210
+git_blob: bcf8c6c98788112da0d8cf2037ef1e49b66256dc
+last_synced: '2026-05-08T01:27:05Z'
+loc: 222
 annotations: []
 imports: []
 exports: []
@@ -52,6 +52,8 @@ import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
@@ -65,6 +67,7 @@ import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
 import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
 import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
 import okhttp3.MultipartBody
 import retrofit2.Response
 
@@ -149,7 +152,10 @@ fun NavGraph(
                     onBack = { navController.popBackStack() }
                 )
             }
-            composable(NavDestination.Sleep.route)    { SleepScreen() }
+            composable(NavDestination.Sleep.route) {
+                val sleepViewModel = remember { SleepViewModel(NoOpSleepRepository()) }
+                SleepScreen(viewModel = sleepViewModel, onSessionClick = {})
+            }
             composable(NavDestination.Trends.route)   { TrendsScreen() }
             composable(NavDestination.Activity.route) { ActivityScreen() }
             composable(NavDestination.Profile.route) {
@@ -187,6 +193,11 @@ fun NavGraph(
     }
 }
 
+private class NoOpSleepRepository : SleepRepository {
+    override suspend fun getSessions(): Result<List<SleepSessionResponse>> =
+        Result.success(emptyList())
+}
+
 private class NoOpImportRepository : ImportRepository {
     override suspend fun pingBackend(): Boolean = false
 
@@ -214,6 +225,7 @@ private class NoOpNightfallApi : NightfallApi {
     override suspend fun importHeartRate(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importSteps(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importExercise(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun getSleepSessions(token: String, from: String?, to: String?, includeStages: Boolean): List<SleepSessionResponse> = emptyList()
 }
 
 /**
@@ -238,19 +250,22 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 48-165
-- `NoOpImportRepository` (class) — lines 167-182
-- `pingBackend` (function) — lines 168-168
-- `extractCsvEntries` (function) — lines 170-173
-- `uploadCsv` (function) — lines 175-181
-- `NoOpNightfallApi` (class) — lines 184-194
-- `health` (function) — lines 185-185
-- `login` (function) — lines 186-186
-- `register` (function) — lines 187-187
-- `requestPasswordReset` (function) — lines 188-188
-- `googleStart` (function) — lines 189-189
-- `importSleep` (function) — lines 190-190
-- `importHeartRate` (function) — lines 191-191
-- `importSteps` (function) — lines 192-192
-- `importExercise` (function) — lines 193-193
-- `ensureComposeNavigators` (function) — lines 202-210
+- `NavGraph` (function) — lines 51-171
+- `NoOpSleepRepository` (class) — lines 173-176
+- `getSessions` (function) — lines 174-175
+- `NoOpImportRepository` (class) — lines 178-193
+- `pingBackend` (function) — lines 179-179
+- `extractCsvEntries` (function) — lines 181-184
+- `uploadCsv` (function) — lines 186-192
+- `NoOpNightfallApi` (class) — lines 195-206
+- `health` (function) — lines 196-196
+- `login` (function) — lines 197-197
+- `register` (function) — lines 198-198
+- `requestPasswordReset` (function) — lines 199-199
+- `googleStart` (function) — lines 200-200
+- `importSleep` (function) — lines 201-201
+- `importHeartRate` (function) — lines 202-202
+- `importSteps` (function) — lines 203-203
+- `importExercise` (function) — lines 204-204
+- `getSleepSessions` (function) — lines 205-205
+- `ensureComposeNavigators` (function) — lines 214-222

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.md
@@ -1,0 +1,44 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.kt
+git_blob: fd1ae630e074b8039e6b7ed00e39cb85e2bbf18f
+last_synced: '2026-05-08T01:27:05Z'
+loc: 11
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepUiState.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.sleep
+
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+
+sealed class SleepUiState {
+    object Idle : SleepUiState()
+    object Loading : SleepUiState()
+    object Empty : SleepUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : SleepUiState()
+    data class Error(val message: String) : SleepUiState()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepUiState` (class) — lines 5-11
+- `Success` (class) — lines 9-9
+- `Error` (class) — lines 10-10

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.md
@@ -1,0 +1,88 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt
+git_blob: 3ea5d0473bddc4577d3b72dcd16abad97a3a3ba2
+last_synced: '2026-05-08T01:27:05Z'
+loc: 54
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.sleep
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import timber.log.Timber
+import java.time.OffsetDateTime
+
+class SleepViewModel(private val repository: SleepRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SleepUiState>(SleepUiState.Idle)
+    val uiState: StateFlow<SleepUiState> = _uiState.asStateFlow()
+
+    fun loadSessions() {
+        _uiState.value = SleepUiState.Loading
+        viewModelScope.launch {
+            try {
+                yield()
+                val result = repository.getSessions()
+                _uiState.value = when {
+                    result.isFailure -> SleepUiState.Error(mapError(result.exceptionOrNull()))
+                    result.getOrNull().isNullOrEmpty() -> SleepUiState.Empty
+                    else -> SleepUiState.Success(
+                        result.getOrNull()!!.sortedByDescending { session ->
+                            runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }
+                                .getOrNull()
+                        }
+                    )
+                }
+                Timber.d("sleep_load_complete state=${_uiState.value::class.simpleName}")
+            } catch (e: Exception) {
+                Timber.w("sleep_load_error")
+                _uiState.value = SleepUiState.Error(mapError(e))
+            }
+        }
+    }
+
+    fun retry() = loadSessions()
+
+    private fun mapError(throwable: Throwable?): String = when (throwable) {
+        is java.io.IOException -> "Vérifiez votre connexion réseau"
+        is retrofit2.HttpException -> when (throwable.code()) {
+            401 -> "Session expirée, reconnectez-vous"
+            403 -> "Accès refusé"
+            else -> "Erreur serveur (${throwable.code()})"
+        }
+        else -> "Une erreur inattendue est survenue"
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepViewModel` (class) — lines 14-54
+- `loadSessions` (function) — lines 19-41
+- `retry` (function) — lines 43-43
+- `mapError` (function) — lines 45-53

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.md
@@ -1,0 +1,163 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt
+git_blob: 6cf69f76130deaedb0d53d1a64630cec1496faf6
+last_synced: '2026-05-08T01:27:05Z'
+loc: 132
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val FMT_NIGHT = DateTimeFormatter.ofPattern("EEE d MMM", Locale.FRENCH)
+private val FMT_TIME = DateTimeFormatter.ofPattern("HH:mm")
+
+private val ColorTeal = Color(0xFF0E9EB0)
+private val ColorAmber = Color(0xFFD37C04)
+private val ColorRed = Color(0xFFB00020)
+
+@Composable
+fun SleepNightCard(
+    session: SleepSessionResponse,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val start = remember(session.sleep_start) {
+        runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
+    }
+    val end = remember(session.sleep_end) {
+        runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+    }
+
+    val duration = if (start != null && end != null) Duration.between(start, end) else null
+    val hours = duration?.toHours() ?: 0L
+    val minutes = duration?.toMinutesPart() ?: 0
+
+    val indicatorColor = when {
+        hours >= 7 -> ColorTeal
+        hours >= 5 -> ColorAmber
+        else -> ColorRed
+    }
+
+    val nightLabel = start?.format(FMT_NIGHT)?.replaceFirstChar { it.uppercase() } ?: ""
+    val bedTime = start?.format(FMT_TIME) ?: ""
+    val wakeTime = end?.format(FMT_TIME) ?: ""
+    val durationText = if (duration != null) "${hours}h ${minutes.toString().padStart(2, '0')}" else ""
+
+    val deepScore = remember(session.stages, duration) {
+        val stages = session.stages
+        if (!stages.isNullOrEmpty() && duration != null && duration.toMinutes() > 0) {
+            val deepMinutes = stages
+                .filter { it.stage == "DEEP" }
+                .sumOf { stage ->
+                    val s = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull()
+                    val e = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull()
+                    if (s != null && e != null) Duration.between(s, e).toMinutes() else 0L
+                }
+            (deepMinutes * 100L / duration.toMinutes()).toInt()
+        } else null
+    }
+
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("sleep_card_${session.id}")
+            .clickable(onClick = onClick),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(modifier = Modifier.height(IntrinsicSize.Min)) {
+            Box(
+                modifier = Modifier
+                    .width(6.dp)
+                    .fillMaxHeight()
+                    .background(indicatorColor)
+            )
+            Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)) {
+                Text(
+                    text = nightLabel,
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = durationText,
+                    style = MaterialTheme.typography.headlineMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row {
+                    Text(
+                        text = "Coucher $bedTime",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "Réveil $wakeTime",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                    )
+                    if (deepScore != null) {
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "Profond $deepScore%",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = ColorTeal
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepNightCard` (function) — lines 38-132

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
-git_blob: fef35818fcf2a0c60aa7713f5647b4833a88930b
-last_synced: '2026-05-07T00:48:24Z'
-loc: 9
+git_blob: db3d26570568a69df9d5762fc6f26b1bbe5d6e95
+last_synced: '2026-05-08T01:27:05Z'
+loc: 129
 annotations: []
 imports: []
 exports: []
@@ -23,12 +23,132 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.ui.screens.sleep
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
 
 @Composable
-fun SleepScreen() {
-    Text("Phase 5 — Compose Canvas")
+fun SleepScreen(
+    viewModel: SleepViewModel,
+    onSessionClick: (String) -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            Text(
+                text = "Mes nuits",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 16.dp)
+            )
+
+            when (val state = uiState) {
+                is SleepUiState.Idle -> {}
+
+                is SleepUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("sleep_loading"),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
+                }
+
+                is SleepUiState.Success -> {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("sleep_list"),
+                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                    ) {
+                        items(state.sessions, key = { it.id }) { session ->
+                            SleepNightCard(
+                                session = session,
+                                onClick = { onSessionClick(session.id) }
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                        }
+                    }
+                }
+
+                is SleepUiState.Empty -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("sleep_empty"),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = "Aucune nuit enregistrée",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                        )
+                    }
+                }
+
+                is SleepUiState.Error -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp)
+                                .testTag("sleep_error"),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(
+                                text = state.message,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Button(
+                                onClick = { viewModel.retry() },
+                                modifier = Modifier.testTag("sleep_retry"),
+                                colors = ButtonDefaults.buttonColors(
+                                    containerColor = MaterialTheme.colorScheme.primary
+                                )
+                            ) {
+                                Text("Réessayer")
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 ```
 
@@ -37,4 +157,4 @@ fun SleepScreen() {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `SleepScreen` (function) — lines 6-9
+- `SleepScreen` (function) — lines 29-129

--- a/docs/vault/code/android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.md
+++ b/docs/vault/code/android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.md
@@ -1,0 +1,47 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.kt
+git_blob: 70c16d2017f4af8b6263bab9284936206807cd89
+last_synced: '2026-05-08T01:27:05Z'
+loc: 15
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.kt`](../../../android-app/app/src/test/java/androidx/compose/ui/test/ComposeTestExtensions.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+@file:JvmName("ComposeTestExtensionsKt")
+package androidx.compose.ui.test
+
+/**
+ * Top-level extension shims for SemanticsNodeInteraction.assertExists() and assertDoesNotExist().
+ * In compose-ui-test 1.7.x and 1.8.x, these are member functions on SemanticsNodeInteraction,
+ * not top-level extension functions. The test file imports them as top-level functions,
+ * so we provide these shims to bridge the gap.
+ */
+
+fun assertExists(node: SemanticsNodeInteraction): SemanticsNodeInteraction =
+    node.assertExists()
+
+fun assertDoesNotExist(node: SemanticsNodeInteraction) =
+    node.assertDoesNotExist()
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `assertExists` (function) — lines 11-12
+- `assertDoesNotExist` (function) — lines 14-15

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.md
@@ -1,0 +1,630 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt
+git_blob: d9aba84df6da0280ee063345ee012c85112f76d1
+last_synced: '2026-05-08T01:27:06Z'
+loc: 578
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+// spec: Tests d'acceptation TA-S-01, TA-S-02, TA-S-03, TA-S-04, TA-S-07, TA-S-07b, TA-S-08,
+//       TA-S-09, TA-S-10, TA-S-11, TA-S-12
+// spec: section "SleepScreen Night Cards" — layout, états, interactions, snapshots
+// RED by construction: the following classes do not exist yet and imports will fail at compile time:
+//   fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+//   fr.datasaillance.nightfall.data.sleep.SleepStageResponse
+//   fr.datasaillance.nightfall.data.sleep.SleepRepository
+//   fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState
+//   fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
+//   fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen  (stub will be replaced)
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+
+// ---------------------------------------------------------------------------
+// Test fixtures — shared across all three test classes
+// ---------------------------------------------------------------------------
+
+// spec: TA-S-03/TA-S-04 — session avec stages, durée 7h23
+private val session1 = fr.datasaillance.nightfall.data.sleep.SleepSessionResponse(
+    id = "aaa-111",
+    sleep_start = "2026-05-07T23:15:00+02:00",
+    sleep_end = "2026-05-08T06:38:00+02:00",
+    created_at = "2026-05-08T10:00:00Z",
+    stages = listOf(
+        fr.datasaillance.nightfall.data.sleep.SleepStageResponse(
+            id = "s1",
+            session_id = "aaa-111",
+            stage = "DEEP",
+            stage_start = "2026-05-08T01:00:00+02:00",
+            stage_end = "2026-05-08T02:30:00+02:00"
+        ),
+        fr.datasaillance.nightfall.data.sleep.SleepStageResponse(
+            id = "s2",
+            session_id = "aaa-111",
+            stage = "LIGHT",
+            stage_start = "2026-05-08T02:30:00+02:00",
+            stage_end = "2026-05-08T06:38:00+02:00"
+        )
+    )
+)
+
+// spec: TA-S-03/TA-S-04 — session sans stages, durée 6h00
+private val session2 = fr.datasaillance.nightfall.data.sleep.SleepSessionResponse(
+    id = "bbb-222",
+    sleep_start = "2026-05-06T00:00:00Z",
+    sleep_end = "2026-05-06T06:00:00Z",
+    created_at = null,
+    stages = null
+)
+
+// spec: TA-S-02 sort — session courte, durée 4h30 (oldest — must appear last after desc sort)
+private val session3 = fr.datasaillance.nightfall.data.sleep.SleepSessionResponse(
+    id = "ccc-333",
+    sleep_start = "2026-05-05T02:00:00Z",
+    sleep_end = "2026-05-05T06:30:00Z",
+    created_at = null,
+    stages = null
+)
+
+private val threeSessionsAscOrder = listOf(session3, session2, session1)
+
+// ---------------------------------------------------------------------------
+// Helper: inject state into SleepViewModel via reflection on _uiState
+// ---------------------------------------------------------------------------
+
+@Suppress("UNCHECKED_CAST")
+private fun injectSleepState(
+    viewModel: fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel,
+    state: fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState
+) {
+    val field = fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel::class.java
+        .getDeclaredField("_uiState")
+    field.isAccessible = true
+    (field.get(viewModel) as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState>)
+        .value = state
+}
+
+// ---------------------------------------------------------------------------
+// Class 1 — Paparazzi snapshot tests (no @RunWith — incompatible with Robolectric)
+// spec: TA-S-09, TA-S-10, TA-S-11, TA-S-12
+// ---------------------------------------------------------------------------
+
+class SleepScreenSnapshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(
+        repository: fr.datasaillance.nightfall.data.sleep.SleepRepository =
+            mock<fr.datasaillance.nightfall.data.sleep.SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel(repository)
+
+    // spec: TA-S-09 — SleepScreen dark mode, ViewModel en état Success avec 3 sessions
+    // spec: "Parité light / dark mode" — fond #191E22, surface #232E32, teal #0E9EB0
+    // RED by construction: SleepScreen and SleepViewModel do not exist yet
+    @Test
+    fun sleepScreen_success_dark() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success(
+                listOf(session1, session2, session3)
+            )
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-09 — SleepScreen receives SleepViewModel and onSessionClick callback
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-09 — snapshot dark: fond #191E22, 3 night cards visibles
+    }
+
+    // spec: TA-S-10 — SleepScreen light mode, même état Success
+    // spec: "Parité light / dark mode" — fond clair, même teal #0E9EB0 et amber #D37C04
+    // RED by construction: SleepScreen and SleepViewModel do not exist yet
+    @Test
+    fun sleepScreen_success_light() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success(
+                listOf(session1, session2, session3)
+            )
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = false) {
+                // spec: TA-S-10 — light mode snapshot: fond clair, night cards rendues
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-10 — snapshot light: fond #FAFAFA ou équivalent, 3 cards visibles
+    }
+
+    // spec: TA-S-11 — SleepScreen dark mode, ViewModel en état Loading
+    // RED by construction: SleepUiState.Loading does not exist yet
+    @Test
+    fun sleepScreen_loading_dark() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-11 — Loading state: CircularProgressIndicator ou skeleton visible
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-11 — snapshot dark Loading: indicateur de chargement présent, liste absente
+    }
+
+    // spec: TA-S-12 — SleepScreen dark mode, ViewModel en état Error
+    // RED by construction: SleepUiState.Error does not exist yet
+    @Test
+    fun sleepScreen_error_dark() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error(
+                "Vérifiez votre connexion réseau"
+            )
+        )
+
+        paparazzi.snapshot {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-12 — Error state: message d'erreur + bouton retry visibles
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+        // spec: TA-S-12 — snapshot dark Error: "Vérifiez votre connexion réseau" visible, bouton retry présent
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 2 — Robolectric behavioral/interaction tests
+// spec: TA-S-01, TA-S-02, TA-S-07, TA-S-07b, TA-S-08
+// Separate class from Paparazzi: incompatible Rule lifecycles
+// ---------------------------------------------------------------------------
+
+// spec: TA-S-01 — Loading: sleep_loading visible, sleep_list absent
+// spec: TA-S-02 — Success(3): sleep_list visible, sleep_card_${id} pour chacune
+// spec: TA-S-07 — Error: sleep_error visible, sleep_retry visible
+// spec: TA-S-07b — click sleep_retry: state revient à Loading
+// spec: TA-S-08 — Empty: sleep_empty visible, sleep_list absent
+// RED by construction: SleepScreen test tags (sleep_loading, sleep_list, sleep_error,
+//   sleep_retry, sleep_empty, sleep_card_${id}) n'existent pas dans le stub actuel
+@RunWith(RobolectricTestRunner::class)
+class SleepScreenInteractionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun buildViewModel(
+        repository: fr.datasaillance.nightfall.data.sleep.SleepRepository =
+            mock<fr.datasaillance.nightfall.data.sleep.SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel(repository)
+
+    // spec: TA-S-01 — état Loading: sleep_loading assertExists, sleep_list assertDoesNotExist
+    // RED: le stub SleepScreen n'a pas de testTag "sleep_loading" ni "sleep_list"
+    @Test
+    fun sleepScreen_shows_loading_indicator() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-01 — SleepScreen avec ViewModel en Loading
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-01 — indicateur de chargement présent
+        composeTestRule
+            .onNode(hasTestTag("sleep_loading"))
+            .assertExists()
+
+        // spec: TA-S-01 — liste absente en état Loading
+        composeTestRule
+            .onNode(hasTestTag("sleep_list"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-S-02 — état Success(3 sessions): sleep_list assertExists,
+    //   sleep_card_aaa-111, sleep_card_bbb-222, sleep_card_ccc-333 assertExists chacun
+    // RED: le stub SleepScreen n'expose pas sleep_list ni sleep_card_${id}
+    @Test
+    fun sleepScreen_shows_list_when_success() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success(
+                listOf(session1, session2, session3)
+            )
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-02 — SleepScreen avec 3 sessions
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-02 — conteneur de liste présent
+        composeTestRule
+            .onNode(hasTestTag("sleep_list"))
+            .assertExists()
+
+        // spec: TA-S-02 — une card par session, testTag = "sleep_card_${session.id}"
+        composeTestRule
+            .onNode(hasTestTag("sleep_card_aaa-111"))
+            .assertExists()
+        composeTestRule
+            .onNode(hasTestTag("sleep_card_bbb-222"))
+            .assertExists()
+        composeTestRule
+            .onNode(hasTestTag("sleep_card_ccc-333"))
+            .assertExists()
+    }
+
+    // spec: TA-S-07 — état Error: sleep_error assertExists, sleep_retry assertExists
+    // RED: le stub SleepScreen n'expose pas sleep_error ni sleep_retry
+    @Test
+    fun sleepScreen_shows_error_with_retry_button() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error(
+                "Vérifiez votre connexion réseau"
+            )
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-07 — SleepScreen avec ViewModel en Error
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-07 — bloc d'erreur visible
+        composeTestRule
+            .onNode(hasTestTag("sleep_error"))
+            .assertExists()
+
+        // spec: TA-S-07 — bouton "Réessayer" visible en état Error
+        composeTestRule
+            .onNode(hasTestTag("sleep_retry"))
+            .assertExists()
+    }
+
+    // spec: TA-S-08 — état Empty: sleep_empty assertExists, sleep_list assertDoesNotExist
+    // RED: le stub SleepScreen n'expose pas sleep_empty
+    @Test
+    fun sleepScreen_shows_empty_state() {
+        val viewModel = buildViewModel()
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Empty
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-08 — SleepScreen avec ViewModel en Empty (aucune session importée)
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-08 — état vide visible (message "Aucune nuit enregistrée" ou équivalent)
+        composeTestRule
+            .onNode(hasTestTag("sleep_empty"))
+            .assertExists()
+
+        // spec: TA-S-08 — liste absente en état Empty
+        composeTestRule
+            .onNode(hasTestTag("sleep_list"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-S-07b — click sur sleep_retry: l'état repasse à Loading via SleepViewModel.loadSessions()
+    // RED: le stub SleepScreen n'a pas de bouton sleep_retry fonctionnel
+    @Suppress("UNCHECKED_CAST")
+    @Test
+    fun sleepScreen_retry_button_triggers_reload() {
+        val repository = mock<fr.datasaillance.nightfall.data.sleep.SleepRepository>()
+        val viewModel = buildViewModel(repository)
+
+        // Pré-condition: state est Error pour que le bouton retry soit affiché
+        injectSleepState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error(
+                "Vérifiez votre connexion réseau"
+            )
+        )
+
+        composeTestRule.setContent {
+            fr.datasaillance.nightfall.ui.theme.NightfallTheme(darkTheme = true) {
+                // spec: TA-S-07b — SleepScreen en Error avec bouton retry
+                fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen(
+                    viewModel = viewModel,
+                    onSessionClick = {}
+                )
+            }
+        }
+
+        // spec: TA-S-07b — click sur le bouton retry
+        composeTestRule
+            .onNode(hasTestTag("sleep_retry"))
+            .performClick()
+
+        // spec: TA-S-07b — après le click, l'état doit repasser à Loading
+        // (SleepViewModel.loadSessions() remet _uiState = Loading avant l'appel réseau)
+        val uiStateField = fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel::class.java
+            .getDeclaredField("_uiState")
+        uiStateField.isAccessible = true
+        val stateFlow = uiStateField.get(viewModel)
+            as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState>
+        val stateAfterRetry = stateFlow.value
+
+        assert(stateAfterRetry is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading) {
+            "uiState must be SleepUiState.Loading after retry button click — spec: TA-S-07b, got: $stateAfterRetry"
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 3 — SleepViewModel unit tests (pure JVM, no Compose, no Robolectric)
+// spec: TA-S-03, TA-S-04, TA-S-07 logic, TA-S-08 logic, TA-S-02 sort
+// ---------------------------------------------------------------------------
+
+// spec: TA-S-03/TA-S-04 — SleepViewModel.loadSessions() success → SleepUiState.Success
+// spec: TA-S-07 logic — SleepViewModel.loadSessions() failure → SleepUiState.Error
+// spec: TA-S-08 logic — SleepViewModel.loadSessions() returns empty → SleepUiState.Empty
+// spec: TA-S-02 sort — sessions triées par sleep_start desc dans Success.sessions
+// RED by construction: SleepViewModel, SleepRepository, SleepUiState n'existent pas encore
+@OptIn(ExperimentalCoroutinesApi::class)
+class SleepViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: fr.datasaillance.nightfall.data.sleep.SleepRepository
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
+
+    @Before
+    fun setUp() {
+        // spec: TA-S-03 — viewModelScope utilise Dispatchers.Main; remplacé par testDispatcher
+        Dispatchers.setMain(testDispatcher)
+        repository = mock()
+        // spec: DI manuelle — pas de Hilt, SleepViewModel construit directement avec repository
+        viewModel = fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel(repository)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-S-03 / TA-S-04 — loadSessions() success → SleepUiState.Success avec les sessions
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_emits_success_when_repository_returns_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(listOf(session1, session2))
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-03 — uiState doit être SleepUiState.Success après un appel réussi
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success) {
+            "uiState must be SleepUiState.Success when repository returns sessions — spec: TA-S-03, got: $state"
+        }
+
+        // spec: TA-S-04 — Success.sessions contient bien les sessions retournées
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success).sessions
+        assert(sessions.size == 2) {
+            "Success.sessions must contain 2 sessions — spec: TA-S-04, got: ${sessions.size}"
+        }
+    }
+
+    // spec: TA-S-07 logic — loadSessions() failure (IOException) → SleepUiState.Error
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_emits_error_when_repository_fails() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.failure(java.io.IOException("Connection refused"))
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-07 — uiState doit être SleepUiState.Error si le repository échoue
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error) {
+            "uiState must be SleepUiState.Error when repository returns failure — spec: TA-S-07, got: $state"
+        }
+
+        // spec: TA-S-07 — Error.message doit être non-null et non-vide
+        val message = (state as fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Error).message
+        assert(message.isNotBlank()) {
+            "SleepUiState.Error.message must not be blank — spec: TA-S-07, got: '$message'"
+        }
+    }
+
+    // spec: TA-S-08 logic — loadSessions() returns empty list → SleepUiState.Empty
+    // RED: SleepViewModel.loadSessions() et SleepUiState.Empty n'existent pas encore
+    @Test
+    fun sleepViewModel_emits_empty_when_no_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(emptyList())
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-08 — uiState doit être SleepUiState.Empty si le repository retourne une liste vide
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Empty) {
+            "uiState must be SleepUiState.Empty when repository returns empty list — spec: TA-S-08, got: $state"
+        }
+    }
+
+    // spec: TA-S-02 sort — sessions triées par sleep_start descending dans Success.sessions
+    // 3 sessions données en ordre ascendant (session3=oldest → session1=newest)
+    // après loadSessions(), Success.sessions doit être [session1, session2, session3] (desc)
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_sorts_sessions_by_start_desc() = runTest {
+        // Données en ordre ascendant: oldest first (session3 < session2 < session1)
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(threeSessionsAscOrder)
+        )
+
+        viewModel.loadSessions()
+        advanceUntilIdle()
+
+        // spec: TA-S-02 sort — Success.sessions trié par sleep_start desc (newest first)
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success) {
+            "uiState must be SleepUiState.Success — spec: TA-S-02 sort, got: $state"
+        }
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Success).sessions
+        assert(sessions.size == 3) {
+            "Success.sessions must contain 3 sessions — spec: TA-S-02 sort, got: ${sessions.size}"
+        }
+        // spec: TA-S-02 sort — premier élément = session la plus récente (session1: 2026-05-07T23:15)
+        assert(sessions[0].id == "aaa-111") {
+            "sessions[0] must be session1 (most recent) — spec: TA-S-02 sort, got id: ${sessions[0].id}"
+        }
+        // spec: TA-S-02 sort — deuxième élément = session2 (2026-05-06T00:00)
+        assert(sessions[1].id == "bbb-222") {
+            "sessions[1] must be session2 — spec: TA-S-02 sort, got id: ${sessions[1].id}"
+        }
+        // spec: TA-S-02 sort — troisième élément = session3 (oldest: 2026-05-05T02:00)
+        assert(sessions[2].id == "ccc-333") {
+            "sessions[2] must be session3 (oldest) — spec: TA-S-02 sort, got id: ${sessions[2].id}"
+        }
+    }
+
+    // spec: TA-S-03 — état Loading émis synchroniquement avant que la coroutine suspende
+    // RED: SleepViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun sleepViewModel_emits_loading_while_in_flight() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(listOf(session1))
+        )
+
+        // spec: TA-S-03 — _uiState = Loading doit être positionné AVANT que la coroutine atteigne getSessions()
+        viewModel.loadSessions()
+
+        // Avant advanceUntilIdle() — la coroutine est suspendue à getSessions()
+        val stateWhileInFlight = viewModel.uiState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.viewmodel.sleep.SleepUiState.Loading) {
+            "uiState must be SleepUiState.Loading immediately after loadSessions() — spec: TA-S-03, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `injectSleepState` (function) — lines 92-101
+- `SleepScreenSnapshotTest` (class) — lines 108-217
+- `buildViewModel` (function) — lines 116-120
+- `sleepScreen_success_dark` (function) — lines 125-145
+- `sleepScreen_success_light` (function) — lines 150-170
+- `sleepScreen_loading_dark` (function) — lines 174-192
+- `sleepScreen_error_dark` (function) — lines 196-216
+- `SleepScreenInteractionTest` (class) — lines 232-423
+- `buildViewModel` (function) — lines 238-242
+- `sleepScreen_shows_loading_indicator` (function) — lines 246-273
+- `sleepScreen_shows_list_when_success` (function) — lines 278-313
+- `sleepScreen_shows_error_with_retry_button` (function) — lines 317-346
+- `sleepScreen_shows_empty_state` (function) — lines 350-377
+- `sleepScreen_retry_button_triggers_reload` (function) — lines 381-422
+- `SleepViewModelTest` (class) — lines 436-578
+- `setUp` (function) — lines 442-449
+- `tearDown` (function) — lines 451-454
+- `sleepViewModel_emits_success_when_repository_returns_sessions` (function) — lines 458-478
+- `sleepViewModel_emits_error_when_repository_fails` (function) — lines 482-502
+- `sleepViewModel_emits_empty_when_no_sessions` (function) — lines 506-520
+- `sleepViewModel_sorts_sessions_by_start_desc` (function) — lines 526-557
+- `sleepViewModel_emits_loading_while_in_flight` (function) — lines 561-577

--- a/docs/vault/code/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.md
+++ b/docs/vault/code/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
-git_blob: 55d2b9efd1dc6330328a2d1d770947c1b26b4483
-last_synced: '2026-05-07T03:51:34Z'
-loc: 30
+git_blob: aeac17cd1b6c51b56a5e4519bd27b1bdf81d3adf
+last_synced: '2026-05-08T01:27:06Z'
+loc: 33
 annotations: []
 imports: []
 exports: []
@@ -29,10 +29,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import fr.datasaillance.nightfall.data.auth.TokenDataStore
 import fr.datasaillance.nightfall.data.settings.SettingsDataStore
+import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
 import fr.datasaillance.nightfall.webview.WebViewScreen
 
 @Composable
 fun SleepScreen(
+    viewModel: SleepViewModel? = null,
+    onSessionClick: (String) -> Unit = {},
     tokenDataStore: TokenDataStore? = null,
     settingsDataStore: SettingsDataStore? = null,
     onOpenImport: () -> Unit = {},
@@ -58,4 +61,4 @@ fun SleepScreen(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `SleepScreen` (function) — lines 11-30
+- `SleepScreen` (function) — lines 12-33

--- a/docs/vault/specs/2026-05-08-p5-dashboard-cards.md
+++ b/docs/vault/specs/2026-05-08-p5-dashboard-cards.md
@@ -1,0 +1,489 @@
+---
+title: "P5.1 Dashboard — Sleep Night Cards"
+slug: 2026-05-08-p5-dashboard-cards
+phase: P5
+status: ready
+created: 2026-05-08
+branch: feat/p5-dashboard-cards
+tags: [android, compose, sleep, dashboard, ui, p5, native]
+related_specs:
+  - 2026-04-26-nightfall-rebrand-data-saillance
+  - 2026-04-23-plan-v2-refactor-master
+implements:
+  - android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreen.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/SleepViewModel.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepNightCard.kt
+tested_by:
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/SleepScreenTest.kt
+---
+
+# Spec P5.1 — Sleep Night Cards
+
+## Vision
+
+SleepScreen est la première vue post-login de Nightfall. Elle présente la liste chronologique des nuits importées, une carte ("Night Card") par session de sommeil. L'objectif est de donner à l'utilisateur une lecture d'un coup d'oeil de l'ensemble de son historique : durée, heure de coucher et réveil, et un indicateur coloré de qualité. C'est la porte d'entrée vers le détail hypnogramme (P5.2). La vue remplace intégralement le stub `SleepScreen.kt` livré en P4.
+
+---
+
+## Contexte et dépendances
+
+### Prérequis validés
+
+- **P5.0 LoginScreen natif** : terminé. Flow `POST /auth/login` → `TokenDataStore.saveToken()` → navigation vers `SleepScreen` est fonctionnel.
+- **`NightfallApi`** : interface Retrofit existante dans `fr.datasaillance.nightfall.data.http`. À étendre (ne pas réécrire).
+- **`TokenDataStore`** : classe existante dans `fr.datasaillance.nightfall.data.auth`. Fournit `getToken(): String?`. Lecture en constructeur `SleepRepository`.
+- **Build flavor `native`** : `SleepScreen.kt` ciblé est dans `src/native/java/`. Le stub webview (`src/webview/java/`) n'est pas modifié par cette spec.
+- **Pas de Hilt** : DI manuelle par constructeur, pattern `AuthViewModel(api, tokenDataStore)`.
+
+### Backend — endpoint `GET /api/sleep`
+
+Implémenté dans `server/routers/sleep.py`. Contrat :
+
+```
+GET /api/sleep
+Headers: Authorization: Bearer <jwt>
+Query params (optionnels):
+  from=<ISO date string>       ex: 2026-01-01
+  to=<ISO date string>         ex: 2026-05-08
+  include_stages=true|false    default: false
+
+Response 200: list[SleepSessionOut]
+Response 401: non authentifié
+Response 403: email non vérifié
+```
+
+`SleepSessionOut` (Pydantic côté serveur) :
+
+| Champ | Type | Notes |
+|-------|------|-------|
+| `id` | `str` (UUID) | identifiant unique |
+| `sleep_start` | `str` ISO 8601 | ex: `"2026-05-07T23:15:00+02:00"` |
+| `sleep_end` | `str` ISO 8601 | ex: `"2026-05-08T06:38:00+02:00"` |
+| `created_at` | `str` ISO 8601 ou `null` | date d'import |
+| `stages` | `list[SleepStageOut]` ou `null` | présent seulement si `include_stages=true` |
+
+`SleepStageOut` :
+
+| Champ | Type | Notes |
+|-------|------|-------|
+| `id` | `str` (UUID) | |
+| `session_id` | `str` (UUID) | |
+| `stage_type` | `str` | valeurs Samsung Health : `"DEEP"`, `"LIGHT"`, `"REM"`, `"AWAKE"` |
+| `stage_start` | `str` ISO 8601 | |
+| `stage_end` | `str` ISO 8601 | |
+
+**V1 : `include_stages=true` est requis** pour calculer le score de qualité (% sommeil profond). Pas de pagination — tout charger en une requête.
+
+---
+
+## Architecture
+
+### Vue d'ensemble des fichiers à créer
+
+```
+android-app/app/src/main/java/fr/datasaillance/nightfall/
+├── data/
+│   ├── http/
+│   │   └── NightfallApi.kt              [MODIFIER — ajouter getSleepSessions()]
+│   └── sleep/
+│       ├── SleepRepository.kt           [CRÉER — interface]
+│       └── SleepRepositoryImpl.kt       [CRÉER — implémentation Retrofit]
+└── viewmodel/
+    └── sleep/
+        ├── SleepViewModel.kt            [CRÉER]
+        └── SleepUiState.kt              [CRÉER — sealed class]
+
+android-app/app/src/native/java/fr/datasaillance/nightfall/
+└── ui/screens/sleep/
+    ├── SleepScreen.kt                   [REMPLACER le stub]
+    └── SleepNightCard.kt                [CRÉER — composant carte]
+
+android-app/app/src/test/java/fr/datasaillance/nightfall/
+└── ui/screens/sleep/
+    └── SleepScreenTest.kt               [CRÉER — tests TDD + Paparazzi]
+```
+
+### Règle de placement des fichiers
+
+- `SleepRepository`, `SleepRepositoryImpl`, `SleepViewModel`, `SleepUiState` → `src/main/java/` (partagé entre flavors webview et native).
+- `SleepScreen.kt`, `SleepNightCard.kt` → `src/native/java/` (flavor native uniquement). Le stub webview reste intact.
+
+---
+
+## Modèles Kotlin
+
+### `SleepSessionResponse` et `SleepStageResponse`
+
+Placés dans `fr.datasaillance.nightfall.data.sleep` (package dédié).
+
+```kotlin
+@kotlinx.serialization.Serializable
+data class SleepStageResponse(
+    val id: String,
+    val session_id: String,
+    val stage_type: String,
+    val stage_start: String,
+    val stage_end: String
+)
+
+@kotlinx.serialization.Serializable
+data class SleepSessionResponse(
+    val id: String,
+    val sleep_start: String,
+    val sleep_end: String,
+    val created_at: String?,
+    val stages: List<SleepStageResponse>?
+)
+```
+
+Contraintes :
+- `@Serializable` de `kotlinx.serialization` — cohérent avec le reste du projet (pattern `ImportApiResponse` dans `NightfallApi.kt`).
+- Noms de champs en `snake_case` pour correspondre directement au JSON backend (pas de `@SerialName` nécessaire si le serializer est configuré avec la stratégie snake_case, sinon utiliser `@SerialName`).
+- Ces data classes ne contiennent pas de logique — la transformation métier se fait dans le ViewModel.
+
+---
+
+## Extension de `NightfallApi`
+
+Ajouter dans l'interface existante `NightfallApi` :
+
+```kotlin
+@GET("api/sleep")
+suspend fun getSleepSessions(
+    @Header("Authorization") token: String,
+    @Query("from") from: String? = null,
+    @Query("to") to: String? = null,
+    @Query("include_stages") includeStages: Boolean = true
+): List<SleepSessionResponse>
+```
+
+Notes :
+- Le token est passé en header `Authorization: Bearer <token>`. La valeur transmise par le ViewModel doit inclure le préfixe `"Bearer "`.
+- `includeStages = true` par défaut en V1 pour permettre le calcul du score qualité.
+- Pas de `Response<>` wrapper — les erreurs HTTP sont catchées via `retrofit2.HttpException` dans le Repository (pattern `AuthViewModel`).
+
+---
+
+## Repository
+
+### Interface `SleepRepository`
+
+```kotlin
+interface SleepRepository {
+    suspend fun getSleepSessions(): Result<List<SleepSessionResponse>>
+}
+```
+
+### `SleepRepositoryImpl`
+
+- Constructeur : `(private val api: NightfallApi, private val tokenDataStore: TokenDataStore)`
+- Lit le token via `tokenDataStore.getToken()` avant chaque appel.
+- Si le token est null : retourne `Result.failure(IllegalStateException("No token"))`.
+- Formate le header : `"Bearer $token"`.
+- Try/catch `retrofit2.HttpException` et `java.io.IOException` → `Result.failure(...)`.
+- Succès : `Result.success(response)`.
+
+Pas de cache en V1. Pas de pagination. L'appel charge toutes les sessions disponibles.
+
+---
+
+## ViewModel
+
+### `SleepUiState`
+
+```kotlin
+sealed class SleepUiState {
+    object Idle : SleepUiState()
+    object Loading : SleepUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : SleepUiState()
+    data class Error(val message: String) : SleepUiState()
+    object Empty : SleepUiState()
+}
+```
+
+`Empty` est un état distinct de `Success(emptyList())` pour faciliter le rendu d'un message dédié.
+
+### `SleepViewModel`
+
+```kotlin
+class SleepViewModel(
+    private val repository: SleepRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<SleepUiState>(SleepUiState.Idle)
+    val uiState: StateFlow<SleepUiState> = _uiState.asStateFlow()
+
+    fun loadSessions() { ... }
+    fun retry() = loadSessions()
+}
+```
+
+- `loadSessions()` émet `Loading`, appelle `repository.getSleepSessions()`, puis émet :
+  - `Empty` si la liste résultante est vide.
+  - `Success(sessions)` trié par `sleep_start` décroissant (nuit la plus récente en premier).
+  - `Error(message)` si `Result.isFailure`.
+- `retry()` est un alias public de `loadSessions()` — exposé pour que le bouton "Réessayer" du composant `SleepScreen` l'appelle directement.
+- Mappage des erreurs HTTP : 401 → `"Session expirée — reconnectez-vous"`, 403 → `"Accès refusé"`, toute autre `HttpException` → `"Erreur serveur (code)"`, `IOException` → `"Vérifiez votre connexion réseau"`.
+- `loadSessions()` est appelé automatiquement depuis `init {}` (ou depuis `LaunchedEffect(Unit)` dans le composant — à décider à l'impl ; les deux sont acceptables mais `init {}` simplifie les tests unitaires).
+
+---
+
+## UI Compose
+
+### `SleepScreen` (remplace le stub)
+
+Signature :
+
+```kotlin
+@Composable
+fun SleepScreen(
+    viewModel: SleepViewModel,
+    onSessionClick: (sessionId: String) -> Unit
+)
+```
+
+Structure générale :
+
+```
+Surface(color = MaterialTheme.colorScheme.background)
+└── Scaffold
+    ├── TopAppBar — titre "Mes nuits" (Playfair Display / headlineLarge)
+    └── content
+        ├── [Loading]  → CircularProgressIndicator centré
+        │               testTag = "sleep_loading"
+        ├── [Empty]    → colonne centrée : icône lune + texte "Aucune nuit importée"
+        │               testTag = "sleep_empty"
+        ├── [Error]    → colonne : message erreur + OutlinedButton "Réessayer"
+        │               testTag = "sleep_error" / "sleep_retry"
+        └── [Success]  → LazyColumn
+                        testTag = "sleep_list"
+                        items = sessions
+                        item → SleepNightCard(session, onClick)
+                               testTag = "sleep_card_{session.id}"
+```
+
+### `SleepNightCard`
+
+Signature :
+
+```kotlin
+@Composable
+fun SleepNightCard(
+    session: SleepSessionResponse,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+)
+```
+
+#### Layout de la carte
+
+```
+Card(
+  shape = RoundedCornerShape(12.dp),
+  colors = CardDefaults.cardColors(containerColor = surface),  // #232E32 dark / #FFFFFF light
+  modifier = Modifier.fillMaxWidth().padding(horizontal=16.dp, vertical=6.dp)
+)
+└── Row(modifier = Modifier.padding(16.dp))
+    ├── Box(width=6.dp, fillMaxHeight) — barre de couleur indicateur durée (voir §Indicateur)
+    ├── Spacer(8.dp)
+    └── Column(modifier = Modifier.weight(1f))
+        ├── Text — label nuit ex: "Lun 5 mai"     style=labelLarge (Inter 13sp 500, uppercase)
+        ├── Text — durée ex: "7h 23"               style=headlineMedium (Inter 22sp 600)
+        ├── Spacer(4.dp)
+        └── Row
+            ├── Text — "Coucher 23:15"             style=bodySmall (Inter 14sp 400)
+            ├── Spacer(8.dp)
+            ├── Text — "Réveil 06:38"              style=bodySmall (Inter 14sp 400)
+            └── [si score disponible] Text — "% Profond 28%"  style=bodySmall, color=teal
+```
+
+#### Calcul des valeurs affichées
+
+Toutes les transformations sont effectuées côté client à partir des ISO strings reçus du backend.
+
+| Valeur affichée | Source | Calcul |
+|-----------------|--------|--------|
+| Label nuit | `sleep_start` | Date de `sleep_start` formatée `"EEE d MMM"` en français, ex: `"Lun 5 mai"`. Utiliser `java.time.format.DateTimeFormatter` avec `Locale.FRENCH`. |
+| Durée | `sleep_start` + `sleep_end` | `Duration.between(parseIso(sleep_start), parseIso(sleep_end))`. Afficher `"7h 23"` (heures + minutes, pas de secondes). |
+| Heure coucher | `sleep_start` | `HH:mm` de `sleep_start`. |
+| Heure réveil | `sleep_end` | `HH:mm` de `sleep_end`. |
+| Score qualité | `stages` | Si `stages != null && stages.isNotEmpty()` : `% = (durée cumulée stages DEEP / durée totale session) * 100`, arrondi à l'entier. Affiché seulement si le score est calculable. |
+
+Parsing ISO : utiliser `java.time.OffsetDateTime.parse(isoString)` (gère les offsets `+02:00`, `Z`, etc.).
+
+#### Indicateur coloré (barre gauche de la carte)
+
+| Durée totale | Couleur | Token |
+|--------------|---------|-------|
+| >= 7h | Teal | `#0E9EB0` (`MaterialTheme.colorScheme.primary`) |
+| >= 5h et < 7h | Amber | `#D37C04` (`MaterialTheme.colorScheme.secondary`) |
+| < 5h | Rouge/muted | `Color(0xFFB00020)` (erreur Material — pas de token custom nécessaire) |
+
+La barre a une largeur fixe de 6 dp et s'étend sur toute la hauteur de la carte (via `fillMaxHeight` dans un `Row`).
+
+---
+
+## Design tokens Compose
+
+### Palette Material 3
+
+Les tokens suivants doivent être mappés dans les thèmes `LightColorScheme` / `DarkColorScheme` de l'app (déjà partiellement défini depuis P4/P5.0) :
+
+| Rôle Material 3 | Dark mode | Light mode |
+|-----------------|-----------|------------|
+| `background` | `#191E22` | `#FAFAFA` |
+| `surface` | `#232E32` | `#FFFFFF` |
+| `primary` | `#0E9EB0` | `#0E9EB0` |
+| `secondary` | `#D37C04` | `#D37C04` |
+| `tertiary` | `#07BCD3` | `#07BCD3` |
+| `onBackground` | `#FFFFFF` | `#1A1A1A` |
+| `onSurface` | `#E0E0E0` | `#1A1A1A` |
+
+### Typographie Compose
+
+| Style Material 3 | Famille | Taille | Poids |
+|------------------|---------|--------|-------|
+| `headlineLarge` | Playfair Display | 32sp | 700 |
+| `headlineMedium` | Inter | 22sp | 600 |
+| `labelLarge` | Inter | 13sp | 500 |
+| `bodySmall` | Inter | 14sp | 400 |
+
+Les fichiers de polices doivent être copiés dans `android-app/app/src/main/assets/fonts/` (depuis `~/MyPersonalProjects/Vectorizer/IdentiteVisuelle/Polices/`) si ce n'est pas déjà fait par P5.0.
+
+---
+
+## Test IDs (testTag Compose)
+
+| Composant | testTag | Condition d'affichage |
+|-----------|---------|----------------------|
+| `CircularProgressIndicator` | `sleep_loading` | état `Loading` |
+| `LazyColumn` liste | `sleep_list` | état `Success` |
+| Chaque `SleepNightCard` | `sleep_card_{session.id}` | état `Success`, une entrée par session |
+| Message erreur (column) | `sleep_error` | état `Error` |
+| Bouton "Réessayer" | `sleep_retry` | état `Error` |
+| Message vide (column) | `sleep_empty` | état `Empty` |
+
+Application via `Modifier.semantics { testTag = "..." }` (pattern existant dans `LoginScreen.kt`).
+
+---
+
+## Tests d'acceptation
+
+### TA-S-01 — Chargement initial
+
+**Given** l'utilisateur est authentifié et `SleepScreen` vient d'être composé,  
+**when** `SleepViewModel.loadSessions()` est en cours d'exécution,  
+**then** le composant avec `testTag = "sleep_loading"` est visible et `testTag = "sleep_list"` n'existe pas.
+
+### TA-S-02 — Liste chargée avec succès
+
+**Given** le repository retourne 3 sessions de sommeil,  
+**when** `uiState` passe à `Success(sessions)`,  
+**then** le composant `testTag = "sleep_list"` est visible et contient exactement 3 éléments avec les testTags `sleep_card_{id}` correspondants, triés par date décroissante (plus récent en premier).
+
+### TA-S-03 — Contenu d'une carte
+
+**Given** une session avec `sleep_start = "2026-05-07T23:15:00+02:00"` et `sleep_end = "2026-05-08T06:38:00+02:00"`,  
+**when** `SleepNightCard` est rendu,  
+**then** le texte `"Mer 7 mai"` est visible, la durée `"7h 23"` est visible, `"23:15"` est visible, `"06:38"` est visible.
+
+### TA-S-04 — Calcul de durée correct
+
+**Given** `sleep_start = "2026-05-07T22:00:00Z"` et `sleep_end = "2026-05-08T05:30:00Z"`,  
+**when** la carte est rendue,  
+**then** la durée affichée est `"7h 30"` (calcul côté client, pas de valeur pré-calculée du backend).
+
+### TA-S-05 — Indicateur coloré selon durée
+
+**Given** trois sessions avec durées respectives 7h30, 6h00, 4h45,  
+**when** les cartes sont rendues,  
+**then** la barre indicatrice de la première carte a la couleur teal `#0E9EB0`, la seconde amber `#D37C04`, la troisième rouge `#B00020`.
+
+### TA-S-06 — Score qualité affiché si stages disponibles
+
+**Given** une session avec `stages` non null contenant des stages dont 90 minutes de type `"DEEP"` sur une durée totale de 450 minutes,  
+**when** la carte est rendue,  
+**then** le texte `"Profond 20%"` (ou équivalent arrondi) est visible dans la carte.
+
+### TA-S-07 — État erreur avec retry
+
+**Given** le repository retourne `Result.failure(IOException())`,  
+**when** `uiState` passe à `Error("Vérifiez votre connexion réseau")`,  
+**then** le composant `testTag = "sleep_error"` est visible avec le message d'erreur, le bouton `testTag = "sleep_retry"` est visible et un clic sur ce bouton déclenche un nouvel appel à `SleepViewModel.loadSessions()`.
+
+### TA-S-08 — État vide (aucune session)
+
+**Given** le repository retourne `Result.success(emptyList())`,  
+**when** `uiState` passe à `Empty`,  
+**then** le composant `testTag = "sleep_empty"` est visible avec un message indiquant qu'aucune nuit n'est importée, `testTag = "sleep_list"` n'existe pas.
+
+### TA-S-09 — Snapshot Paparazzi dark mode / état Success
+
+**Given** `SleepScreen` composé avec un `SleepViewModel` en état `Success` (3 sessions fictives),  
+**when** Paparazzi génère un screenshot avec le thème dark (`NightfallDarkTheme`),  
+**then** le screenshot correspond au golden de référence à ±0% (régression bloquante).
+
+### TA-S-10 — Snapshot Paparazzi light mode / état Success
+
+**Given** même state `Success` que TA-S-09,  
+**when** Paparazzi génère un screenshot avec le thème light (`NightfallLightTheme`),  
+**then** le screenshot correspond au golden de référence (fond `#FAFAFA`, surface blanche, texte sombre).
+
+### TA-S-11 — Snapshot Paparazzi / état Loading
+
+**Given** `SleepViewModel` en état `Loading`,  
+**when** Paparazzi screenshot en dark mode,  
+**then** seul `CircularProgressIndicator` (ou skeleton) est visible — pas de liste, pas d'erreur.
+
+### TA-S-12 — Snapshot Paparazzi / état Error
+
+**Given** `SleepViewModel` en état `Error("Vérifiez votre connexion réseau")`,  
+**when** Paparazzi screenshot en dark mode,  
+**then** le message d'erreur et le bouton "Réessayer" sont visibles, pas de liste.
+
+---
+
+## Logging Android
+
+Utiliser `Timber` (déjà intégré en Phase 4). Événements à logger :
+
+| Événement | Niveau | Champs |
+|-----------|--------|--------|
+| Début chargement sessions | `d` | `scope=sleep_vm` |
+| Chargement réussi | `d` | `scope=sleep_vm`, `count=N` |
+| Erreur HTTP | `w` | `scope=sleep_vm`, `http_code=N`, `message` |
+| Erreur réseau | `w` | `scope=sleep_vm`, `error=IOException` |
+| Clic sur une carte | `d` | `scope=sleep_screen`, `session_id` |
+
+Aucun champ de valeur santé brut (pas de `sleep_start`, pas de `sleep_end` dans les logs) — conformité C2.
+
+---
+
+## RGPD
+
+- `SleepScreen` affiche uniquement des données propres à l'utilisateur authentifié — le backend filtre par `user_id` via `Depends(get_current_user)`.
+- Aucun cache local des données de liste (pas de Room, pas de SharedPreferences pour les sessions) en V1 — les données ne persistent pas côté Android au-delà de la session mémoire.
+- Aucune donnée de santé n'apparaît dans les logs (voir §Logging).
+- Le token JWT est lu depuis `EncryptedSharedPreferences` via `TokenDataStore` — chiffrement AES-256-GCM au repos conforme C2.
+
+---
+
+## Livrables
+
+- [ ] `NightfallApi.kt` — ajout `getSleepSessions()`
+- [ ] `SleepSessionResponse.kt` + `SleepStageResponse.kt` — data classes @Serializable
+- [ ] `SleepRepository.kt` — interface
+- [ ] `SleepRepositoryImpl.kt` — implémentation Retrofit
+- [ ] `SleepUiState.kt` — sealed class
+- [ ] `SleepViewModel.kt` — StateFlow + loadSessions() + retry()
+- [ ] `SleepNightCard.kt` — composant carte (src/native/)
+- [ ] `SleepScreen.kt` — remplacement du stub (src/native/) avec tous les états
+- [ ] `SleepScreenTest.kt` — tests unitaires ViewModel + Paparazzi goldens
+
+---
+
+## Suite naturelle
+
+**P5.2 — Hypnogramme** (`spec-p5-dashboard-hypnogram`) : clic sur une `SleepNightCard` navigue vers `HypnogramScreen(sessionId)`. L'endpoint `GET /api/sleep` avec `include_stages=true` fournit déjà les données nécessaires — elles pourront être passées directement via la navigation ou rechargées à la demande depuis `HypnogramViewModel`.


### PR DESCRIPTION
## Summary

- Replace P4 stub `SleepScreen` (native flavor) with full Night Cards list: LazyColumn of `SleepNightCard` with states Loading / Success / Error / Empty
- `SleepNightCard` — 6dp color indicator bar (teal ≥7h / amber ≥5h / red <5h), date via `OffsetDateTime` + `Locale.FRENCH` ("Mer 7 mai"), duration "7h 23", conditional "Profond X%" quality score
- `SleepRepository` (interface + Retrofit impl) + `SleepViewModel` (`StateFlow<SleepUiState>`, sort by `OffsetDateTime.toInstant()` desc)
- `NightfallApi` — add `getSleepSessions(@Header token, @Query from/to, include_stages=true)`; `SleepStageResponse` uses `@SerialName("stage_type")` for correct JSON mapping
- Webview `SleepScreen` signature aligned (`viewModel?`, `onSessionClick?`) for shared `NavGraph` compatibility

## Test plan

- [ ] `SleepScreenSnapshotTest` — 4 Paparazzi goldens (dark/light × Success/Error) recorded on first run
- [ ] `sleepScreen_shows_loading_indicator` — sleep_loading present, sleep_list absent
- [ ] `sleepScreen_shows_list_when_success` — sleep_list + sleep_card_{id} for each session
- [ ] `sleepScreen_shows_error_with_retry_button` — sleep_error + sleep_retry present
- [ ] `sleepScreen_shows_empty_state` — sleep_empty present, sleep_list absent
- [ ] `sleepScreen_retry_button_triggers_reload` — click retry → state returns to Loading
- [ ] `sleepViewModel_emits_success_when_repository_returns_sessions` — Success with 2 sessions
- [ ] `sleepViewModel_emits_error_when_repository_fails` — Error with non-blank message
- [ ] `sleepViewModel_emits_empty_when_no_sessions` — Empty state
- [ ] `sleepViewModel_sorts_sessions_by_start_desc` — newest first
- [ ] Build native + webview: `./gradlew assembleNativeDebug assembleWebviewDebug` → SUCCESSFUL
- [ ] Manual: install native APK on device, log in, verify Night Cards render with DataSaillance tokens
