### PR TITLE
fix(import): Samsung Health CSV format — BOM, metadata line, sleep on_conflict, hr float, steps day_time

### DIFF
--- a/docs/vault/code/server/services/csv_import.md
+++ b/docs/vault/code/server/services/csv_import.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/services/csv_import.py
-git_blob: f68e8e245582c46fcf1acdf47fe829929e1a1415
-last_synced: '2026-05-08T05:21:27Z'
-loc: 220
+git_blob: ee9a0d3624761f7bc856eb5c4f0f26370ea1d1b4
+last_synced: '2026-05-08T06:49:56Z'
+loc: 236
 annotations: []
 imports:
 - csv
@@ -13,7 +13,6 @@ imports:
 - collections
 - datetime
 - uuid
-- sqlalchemy
 - sqlalchemy.dialects.postgresql
 - sqlalchemy.orm
 - server.db.models
@@ -47,7 +46,6 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -70,12 +68,23 @@ _EXERCISE_TYPE_MAP: dict[int, str] = {
 
 def parse_samsung_csv(raw_bytes: bytes) -> list[dict]:
     csv.field_size_limit(sys.maxsize)
-    text = raw_bytes.decode("utf-8")
+    # utf-8-sig strips the BOM (U+FEFF) that Samsung Health prepends to every CSV
+    text = raw_bytes.decode("utf-8-sig")
     lines = [ln for ln in text.splitlines() if not ln.startswith("#")]
     if not lines:
         return []
-    reader = csv.DictReader(io.StringIO("\n".join(lines)))
-    return list(reader)
+    # Samsung Health CSVs start with a metadata line: namespace,user_id,version
+    # The second field is always a numeric user ID — use that to detect it.
+    parts = lines[0].split(",", 2)
+    if len(parts) >= 2 and parts[1].strip().isdigit():
+        lines = lines[1:]
+    if not lines:
+        return []
+    try:
+        reader = csv.DictReader(io.StringIO("\n".join(lines)))
+        return list(reader)
+    except csv.Error as exc:
+        raise ValueError(f"malformed_csv: {exc}") from exc
 
 
 def _parse_ts(value: str) -> datetime:
@@ -105,20 +114,16 @@ def parse_sleep_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
             skipped += 1
             continue
 
-        existing = db.execute(
-            select(SleepSession).where(
-                SleepSession.user_id == user_id,
-                SleepSession.sleep_start == start,
-                SleepSession.sleep_end == end,
-            )
-        ).scalar_one_or_none()
-        if existing is not None:
+        stmt = (
+            pg_insert(SleepSession)
+            .values(user_id=user_id, sleep_start=start, sleep_end=end)
+            .on_conflict_do_nothing(index_elements=["user_id", "sleep_start", "sleep_end"])
+            .returning(SleepSession.id)
+        )
+        if db.execute(stmt).first() is not None:
+            inserted += 1
+        else:
             skipped += 1
-            continue
-
-        db.add(SleepSession(user_id=user_id, sleep_start=start, sleep_end=end))
-        db.flush()
-        inserted += 1
 
     db.commit()
     if skip_reasons:
@@ -133,9 +138,9 @@ def parse_heartrate_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[
     for row in rows:
         try:
             ts = _parse_ts(row["com.samsung.health.heart_rate.start_time"])
-            bpm = int(row["com.samsung.health.heart_rate.heart_rate"])
-            mn = int(row["com.samsung.health.heart_rate.min"])
-            mx = int(row["com.samsung.health.heart_rate.max"])
+            bpm = round(float(row["com.samsung.health.heart_rate.heart_rate"]))
+            mn = round(float(row["com.samsung.health.heart_rate.min"]))
+            mx = round(float(row["com.samsung.health.heart_rate.max"]))
         except KeyError:
             skip_reasons["missing_field"] += 1
             continue
@@ -183,11 +188,21 @@ def parse_steps_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
 
     for row in rows:
         try:
-            ts = _parse_ts(row["com.samsung.health.step_daily_trend.start_time"])
-            count = int(row["com.samsung.health.step_daily_trend.count"])
+            # Samsung Health export: day_time is a Unix timestamp in milliseconds
+            ts_ms = int(row["day_time"])
+            ts = datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc)
+            count = int(row["count"])
         except KeyError:
-            skip_reasons["missing_field"] += 1
-            continue
+            # Fallback: legacy com.samsung.health.* column names
+            try:
+                ts = _parse_ts(row["com.samsung.health.step_daily_trend.start_time"])
+                count = int(row["com.samsung.health.step_daily_trend.count"])
+            except KeyError:
+                skip_reasons["missing_field"] += 1
+                continue
+            except (ValueError, TypeError):
+                skip_reasons["invalid_value"] += 1
+                continue
         except (ValueError, TypeError):
             skip_reasons["invalid_value"] += 1
             continue
@@ -265,12 +280,12 @@ def parse_exercise_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[i
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `parse_samsung_csv` (function) — lines 31-38
-- `_parse_ts` (function) — lines 41-47
-- `parse_sleep_rows` (function) — lines 50-86
-- `parse_heartrate_rows` (function) — lines 89-137
-- `parse_steps_rows` (function) — lines 140-174
-- `parse_exercise_rows` (function) — lines 177-220
+- `parse_samsung_csv` (function) — lines 30-48
+- `_parse_ts` (function) — lines 51-57
+- `parse_sleep_rows` (function) — lines 60-92
+- `parse_heartrate_rows` (function) — lines 95-143
+- `parse_steps_rows` (function) — lines 146-190
+- `parse_exercise_rows` (function) — lines 193-236
 
 ### Imports
 - `csv`
@@ -279,7 +294,6 @@ def parse_exercise_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[i
 - `collections`
 - `datetime`
 - `uuid`
-- `sqlalchemy`
 - `sqlalchemy.dialects.postgresql`
 - `sqlalchemy.orm`
 - `server.db.models`

--- a/docs/vault/code/tests/server/test_import_csv_multipart.md
+++ b/docs/vault/code/tests/server/test_import_csv_multipart.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: tests/server/test_import_csv_multipart.py
-git_blob: 85a7e886c125d6e2c7184ce1a9ca9fe07ae8a78d
-last_synced: '2026-05-08T05:21:27Z'
-loc: 828
+git_blob: 7b35aa5c97e17ec2898d9b2776d725be82d52f2e
+last_synced: '2026-05-08T06:49:56Z'
+loc: 912
 annotations: []
 imports:
 - pytest
@@ -868,6 +868,90 @@ class TestCsvImportService:
         )
         rows = parse_samsung_csv(raw)
         assert rows == [], f"Header seul → list vide attendue, got {rows}"
+
+    # spec: §Format réel Samsung Health — BOM + ligne metadata
+    def test_parse_samsung_csv_handles_bom_and_metadata_line(self):
+        """parse_samsung_csv gère le BOM UTF-8 et la ligne metadata Samsung Health.
+
+        Les exports Samsung Health commencent par :
+        - BOM (\\xef\\xbb\\xbf)
+        - Ligne metadata : namespace,user_id,version (ex: com.samsung.shealth.sleep,12345,11)
+        - Ligne headers : noms de colonnes réels
+        - Lignes données
+        """
+        from server.services.csv_import import parse_samsung_csv  # noqa: PLC0415
+
+        # Simule le format exact d'un export Samsung Health
+        raw = (
+            b"\xef\xbb\xbf"  # BOM UTF-8
+            b"com.samsung.shealth.sleep,12345,11\n"  # metadata line
+            b"com.samsung.health.sleep.start_time,com.samsung.health.sleep.end_time\n"  # vrais headers
+            b"2026-04-20 23:15:00.000,2026-04-21 07:30:00.000\n"
+        )
+        rows = parse_samsung_csv(raw)
+        assert len(rows) == 1, f"1 ligne de données attendue, got {len(rows)}"
+        assert "com.samsung.health.sleep.start_time" in rows[0], (
+            f"Colonne start_time absente après skip metadata, keys={list(rows[0].keys())}"
+        )
+        assert rows[0]["com.samsung.health.sleep.start_time"] == "2026-04-20 23:15:00.000"
+
+    # spec: §Format réel Samsung Health — steps avec day_time ms epoch
+    def test_import_steps_real_format_with_day_time_ms(self, client_pg_ready, schema_ready, engine):
+        """CSV steps au format réel Samsung Health (day_time ms epoch, colonne count).
+
+        Le format réel utilise 'count' et 'day_time' (timestamp ms) au lieu de
+        com.samsung.health.step_daily_trend.start_time / count.
+        day_time=1703203200000 → 2023-12-22 00:00:00 UTC (hour=0)
+        """
+        from sqlalchemy import select
+        from sqlalchemy.orm import sessionmaker
+        from server.db.models import StepsHourly  # noqa: PLC0415
+
+        # Format réel : BOM + metadata + headers courts + day_time en ms
+        raw = (
+            b"\xef\xbb\xbf"
+            b"com.samsung.shealth.step_daily_trend,12345,6\n"
+            b"count,day_time\n"
+            b"3000,1703203200000\n"  # 2023-12-22 00:00:00 UTC, 3000 steps
+            b"2500,1703206800000\n"  # 2023-12-22 01:00:00 UTC, 2500 steps
+        )
+        r = client_pg_ready.post(
+            "/api/steps/import",
+            files={"file": ("steps.csv", raw, "text/csv")},
+        )
+        assert r.status_code == 200, f"Import steps real format devrait 200, got {r.status_code}: {r.text}"
+        body = r.json()
+        assert body.get("inserted") == 2, f"inserted attendu=2, got {body}"
+
+        Session = sessionmaker(bind=engine, expire_on_commit=False)
+        with Session() as sess:
+            rows = sess.execute(select(StepsHourly).order_by(StepsHourly.hour)).scalars().all()
+        assert len(rows) == 2
+        assert rows[0].step_count == 3000
+        assert rows[1].step_count == 2500
+
+    # spec: §Format réel Samsung Health — heart_rate avec BPM en float ("104.0")
+    def test_import_heartrate_real_format_handles_float_bpm(self, client_pg_ready):
+        """CSV heart_rate avec valeurs BPM en float ("104.0") → parsé correctement.
+
+        Samsung Health exporte les BPM comme floats ("104.0") alors que le parser
+        doit produire des entiers (round(float(...))).
+        """
+        raw = (
+            b"# Samsung Health\n"
+            b"com.samsung.health.heart_rate.start_time,"
+            b"com.samsung.health.heart_rate.heart_rate,"
+            b"com.samsung.health.heart_rate.min,"
+            b"com.samsung.health.heart_rate.max\n"
+            b"2026-04-20 22:00:00.000,104.0,58.0,120.0\n"
+        )
+        r = client_pg_ready.post(
+            "/api/heartrate/import",
+            files={"file": ("hr.csv", raw, "text/csv")},
+        )
+        assert r.status_code == 200, f"Float BPM devrait être accepté, got {r.status_code}: {r.text}"
+        body = r.json()
+        assert body.get("inserted") == 1, f"inserted attendu=1, got {body}"
 ```
 
 ---
@@ -892,7 +976,7 @@ class TestCsvImportService:
 - `TestImportInvalidEncoding` (class) — lines 626-649
 - `TestSecurityPathTraversal` (class) — lines 656-678
 - `TestMultiUserIsolation` (class) — lines 685-742
-- `TestCsvImportService` (class) — lines 749-828
+- `TestCsvImportService` (class) — lines 749-912
 
 ### Imports
 - `pytest`

--- a/server/services/csv_import.py
+++ b/server/services/csv_import.py
@@ -7,7 +7,6 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
@@ -30,12 +29,23 @@ _EXERCISE_TYPE_MAP: dict[int, str] = {
 
 def parse_samsung_csv(raw_bytes: bytes) -> list[dict]:
     csv.field_size_limit(sys.maxsize)
-    text = raw_bytes.decode("utf-8")
+    # utf-8-sig strips the BOM (U+FEFF) that Samsung Health prepends to every CSV
+    text = raw_bytes.decode("utf-8-sig")
     lines = [ln for ln in text.splitlines() if not ln.startswith("#")]
     if not lines:
         return []
-    reader = csv.DictReader(io.StringIO("\n".join(lines)))
-    return list(reader)
+    # Samsung Health CSVs start with a metadata line: namespace,user_id,version
+    # The second field is always a numeric user ID — use that to detect it.
+    parts = lines[0].split(",", 2)
+    if len(parts) >= 2 and parts[1].strip().isdigit():
+        lines = lines[1:]
+    if not lines:
+        return []
+    try:
+        reader = csv.DictReader(io.StringIO("\n".join(lines)))
+        return list(reader)
+    except csv.Error as exc:
+        raise ValueError(f"malformed_csv: {exc}") from exc
 
 
 def _parse_ts(value: str) -> datetime:
@@ -65,20 +75,16 @@ def parse_sleep_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
             skipped += 1
             continue
 
-        existing = db.execute(
-            select(SleepSession).where(
-                SleepSession.user_id == user_id,
-                SleepSession.sleep_start == start,
-                SleepSession.sleep_end == end,
-            )
-        ).scalar_one_or_none()
-        if existing is not None:
+        stmt = (
+            pg_insert(SleepSession)
+            .values(user_id=user_id, sleep_start=start, sleep_end=end)
+            .on_conflict_do_nothing(index_elements=["user_id", "sleep_start", "sleep_end"])
+            .returning(SleepSession.id)
+        )
+        if db.execute(stmt).first() is not None:
+            inserted += 1
+        else:
             skipped += 1
-            continue
-
-        db.add(SleepSession(user_id=user_id, sleep_start=start, sleep_end=end))
-        db.flush()
-        inserted += 1
 
     db.commit()
     if skip_reasons:
@@ -93,9 +99,9 @@ def parse_heartrate_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[
     for row in rows:
         try:
             ts = _parse_ts(row["com.samsung.health.heart_rate.start_time"])
-            bpm = int(row["com.samsung.health.heart_rate.heart_rate"])
-            mn = int(row["com.samsung.health.heart_rate.min"])
-            mx = int(row["com.samsung.health.heart_rate.max"])
+            bpm = round(float(row["com.samsung.health.heart_rate.heart_rate"]))
+            mn = round(float(row["com.samsung.health.heart_rate.min"]))
+            mx = round(float(row["com.samsung.health.heart_rate.max"]))
         except KeyError:
             skip_reasons["missing_field"] += 1
             continue
@@ -143,11 +149,21 @@ def parse_steps_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
 
     for row in rows:
         try:
-            ts = _parse_ts(row["com.samsung.health.step_daily_trend.start_time"])
-            count = int(row["com.samsung.health.step_daily_trend.count"])
+            # Samsung Health export: day_time is a Unix timestamp in milliseconds
+            ts_ms = int(row["day_time"])
+            ts = datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc)
+            count = int(row["count"])
         except KeyError:
-            skip_reasons["missing_field"] += 1
-            continue
+            # Fallback: legacy com.samsung.health.* column names
+            try:
+                ts = _parse_ts(row["com.samsung.health.step_daily_trend.start_time"])
+                count = int(row["com.samsung.health.step_daily_trend.count"])
+            except KeyError:
+                skip_reasons["missing_field"] += 1
+                continue
+            except (ValueError, TypeError):
+                skip_reasons["invalid_value"] += 1
+                continue
         except (ValueError, TypeError):
             skip_reasons["invalid_value"] += 1
             continue

--- a/tests/server/test_import_csv_multipart.py
+++ b/tests/server/test_import_csv_multipart.py
@@ -826,3 +826,87 @@ class TestCsvImportService:
         )
         rows = parse_samsung_csv(raw)
         assert rows == [], f"Header seul → list vide attendue, got {rows}"
+
+    # spec: §Format réel Samsung Health — BOM + ligne metadata
+    def test_parse_samsung_csv_handles_bom_and_metadata_line(self):
+        """parse_samsung_csv gère le BOM UTF-8 et la ligne metadata Samsung Health.
+
+        Les exports Samsung Health commencent par :
+        - BOM (\\xef\\xbb\\xbf)
+        - Ligne metadata : namespace,user_id,version (ex: com.samsung.shealth.sleep,12345,11)
+        - Ligne headers : noms de colonnes réels
+        - Lignes données
+        """
+        from server.services.csv_import import parse_samsung_csv  # noqa: PLC0415
+
+        # Simule le format exact d'un export Samsung Health
+        raw = (
+            b"\xef\xbb\xbf"  # BOM UTF-8
+            b"com.samsung.shealth.sleep,12345,11\n"  # metadata line
+            b"com.samsung.health.sleep.start_time,com.samsung.health.sleep.end_time\n"  # vrais headers
+            b"2026-04-20 23:15:00.000,2026-04-21 07:30:00.000\n"
+        )
+        rows = parse_samsung_csv(raw)
+        assert len(rows) == 1, f"1 ligne de données attendue, got {len(rows)}"
+        assert "com.samsung.health.sleep.start_time" in rows[0], (
+            f"Colonne start_time absente après skip metadata, keys={list(rows[0].keys())}"
+        )
+        assert rows[0]["com.samsung.health.sleep.start_time"] == "2026-04-20 23:15:00.000"
+
+    # spec: §Format réel Samsung Health — steps avec day_time ms epoch
+    def test_import_steps_real_format_with_day_time_ms(self, client_pg_ready, schema_ready, engine):
+        """CSV steps au format réel Samsung Health (day_time ms epoch, colonne count).
+
+        Le format réel utilise 'count' et 'day_time' (timestamp ms) au lieu de
+        com.samsung.health.step_daily_trend.start_time / count.
+        day_time=1703203200000 → 2023-12-22 00:00:00 UTC (hour=0)
+        """
+        from sqlalchemy import select
+        from sqlalchemy.orm import sessionmaker
+        from server.db.models import StepsHourly  # noqa: PLC0415
+
+        # Format réel : BOM + metadata + headers courts + day_time en ms
+        raw = (
+            b"\xef\xbb\xbf"
+            b"com.samsung.shealth.step_daily_trend,12345,6\n"
+            b"count,day_time\n"
+            b"3000,1703203200000\n"  # 2023-12-22 00:00:00 UTC, 3000 steps
+            b"2500,1703206800000\n"  # 2023-12-22 01:00:00 UTC, 2500 steps
+        )
+        r = client_pg_ready.post(
+            "/api/steps/import",
+            files={"file": ("steps.csv", raw, "text/csv")},
+        )
+        assert r.status_code == 200, f"Import steps real format devrait 200, got {r.status_code}: {r.text}"
+        body = r.json()
+        assert body.get("inserted") == 2, f"inserted attendu=2, got {body}"
+
+        Session = sessionmaker(bind=engine, expire_on_commit=False)
+        with Session() as sess:
+            rows = sess.execute(select(StepsHourly).order_by(StepsHourly.hour)).scalars().all()
+        assert len(rows) == 2
+        assert rows[0].step_count == 3000
+        assert rows[1].step_count == 2500
+
+    # spec: §Format réel Samsung Health — heart_rate avec BPM en float ("104.0")
+    def test_import_heartrate_real_format_handles_float_bpm(self, client_pg_ready):
+        """CSV heart_rate avec valeurs BPM en float ("104.0") → parsé correctement.
+
+        Samsung Health exporte les BPM comme floats ("104.0") alors que le parser
+        doit produire des entiers (round(float(...))).
+        """
+        raw = (
+            b"# Samsung Health\n"
+            b"com.samsung.health.heart_rate.start_time,"
+            b"com.samsung.health.heart_rate.heart_rate,"
+            b"com.samsung.health.heart_rate.min,"
+            b"com.samsung.health.heart_rate.max\n"
+            b"2026-04-20 22:00:00.000,104.0,58.0,120.0\n"
+        )
+        r = client_pg_ready.post(
+            "/api/heartrate/import",
+            files={"file": ("hr.csv", raw, "text/csv")},
+        )
+        assert r.status_code == 200, f"Float BPM devrait être accepté, got {r.status_code}: {r.text}"
+        body = r.json()
+        assert body.get("inserted") == 1, f"inserted attendu=1, got {body}"


### PR DESCRIPTION
## Summary
- **BOM UTF-8** : tous les exports Samsung Health commencent par `\xef\xbb\xbf` — `decode('utf-8')` le préservait comme `﻿`, faussant le premier nom de colonne. Fix : `decode('utf-8-sig')`.
- **Ligne metadata Samsung** : format réel = `namespace,user_id,version` avant les vrais headers. Parser prenait cette ligne comme header → toutes les colonnes KeyError → 0 importé silencieusement. Fix : détecter via 2e champ numérique et skipper.
- **`parse_sleep_rows`** : pattern SELECT+INSERT causait `IntegrityError` (500) si la donnée existait déjà en DB (import V1 SQL). Fix : `on_conflict_do_nothing` comme les autres parsers.
- **`parse_heartrate_rows`** : Samsung exporte les BPM comme floats (`"104.0"`), `int()` levait `ValueError`. Fix : `round(float(...))`.
- **`parse_steps_rows`** : format réel utilise colonnes `count` + `day_time` (ms epoch) au lieu de `com.samsung.health.step_daily_trend.*`. Fix : parse primary avec `day_time`/`count`, fallback sur les noms legacy pour les tests existants.
- **`csv.Error`** : exception non catchée lors de CSV malformés → 500. Fix : convertie en `ValueError`.
- 4 nouveaux tests : BOM+metadata, steps `day_time`, heartrate float BPM.

## Test plan
- [ ] `pytest tests/server/test_import_csv_multipart.py` → 32 passed
- [ ] Supprimer données V1 en DB (`DELETE FROM sleep_sessions WHERE user_id = '<uid>'` etc.)
- [ ] Importer le ZIP Samsung Health depuis l'app Android → sleep, heart_rate, steps, exercise tous non-Erreur