### PR TITLE
feat(android): P5.3 Timeline Circadienne

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 
 private fun iconForDestination(destination: NavDestination): ImageVector = when (destination) {
     is NavDestination.Sleep    -> Icons.Default.Home
-    is NavDestination.Trends   -> Icons.Default.ShowChart
+    is NavDestination.Timeline -> Icons.Default.ShowChart
     is NavDestination.Activity -> Icons.Default.FitnessCenter
     is NavDestination.Profile  -> Icons.Default.AccountCircle
     else                       -> Icons.Default.Home

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
@@ -8,7 +8,7 @@ sealed class NavDestination(
     object Register       : NavDestination("register",        "Créer un compte")
     object ForgotPassword : NavDestination("forgot_password", "Mot de passe oublié")
     object Sleep    : NavDestination("sleep",    "Sommeil")
-    object Trends   : NavDestination("trends",   "Tendances")
+    object Timeline : NavDestination("timeline", "Timeline")
     object Activity : NavDestination("activity", "Activité")
     object Profile  : NavDestination("profile",  "Profil")
     object Import   : NavDestination("import",   "Importer")
@@ -18,6 +18,6 @@ sealed class NavDestination(
     }
 
     companion object {
-        fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Trends, Activity, Profile)
+        fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Timeline, Activity, Profile)
     }
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.ComposeNavigator
@@ -44,11 +45,12 @@ import fr.datasaillance.nightfall.ui.screens.profile.ProfileScreen
 import fr.datasaillance.nightfall.ui.screens.settings.SettingsScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.HypnogramScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
-import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
+import fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen
 import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
 import fr.datasaillance.nightfall.viewmodel.sleep.HypnogramViewModel
 import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
+import fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
 import okhttp3.MultipartBody
 import retrofit2.Response
 
@@ -60,10 +62,14 @@ fun NavGraph(
     onSaveUrl: (String) -> Unit = {},
     api: NightfallApi? = null,
     tokenDataStore: TokenDataStore? = null,
+    authViewModel: AuthViewModel? = null,
 ) {
     val startDestination = if (hasToken) NavDestination.Sleep.route else NavDestination.Login.route
-    val authViewModel = remember(api, tokenDataStore) {
-        if (api != null && tokenDataStore != null) AuthViewModel(api, tokenDataStore) else null
+    val context = LocalContext.current
+    val authViewModel = authViewModel ?: remember(api, tokenDataStore) {
+        val resolvedApi = api ?: NoOpNightfallApi()
+        val resolvedStore = tokenDataStore ?: TokenDataStore(context)
+        AuthViewModel(resolvedApi, resolvedStore)
     }
 
     // Adds ComposeNavigator/DialogNavigator to the navigator provider when absent.
@@ -74,7 +80,7 @@ fun NavGraph(
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 
-    val showBottomBar = currentRoute in setOf("sleep", "trends", "activity", "profile")
+    val showBottomBar = currentRoute in setOf("sleep", "timeline", "activity", "profile")
 
     Scaffold(
         bottomBar = {
@@ -98,38 +104,32 @@ fun NavGraph(
             modifier         = Modifier.padding(innerPadding)
         ) {
             composable(NavDestination.Login.route) {
-                if (authViewModel != null) {
-                    LoginScreen(
-                        viewModel            = authViewModel,
-                        onLoginSuccess       = {
-                            navController.navigate(NavDestination.Sleep.route) {
-                                popUpTo(NavDestination.Login.route) { inclusive = true }
-                            }
-                        },
-                        onNavigateRegister   = { navController.navigate(NavDestination.Register.route) },
-                        onNavigateForgotPassword = { navController.navigate(NavDestination.ForgotPassword.route) },
-                    )
-                }
+                LoginScreen(
+                    viewModel            = authViewModel,
+                    onLoginSuccess       = {
+                        navController.navigate(NavDestination.Sleep.route) {
+                            popUpTo(NavDestination.Login.route) { inclusive = true }
+                        }
+                    },
+                    onNavigateRegister   = { navController.navigate(NavDestination.Register.route) },
+                    onNavigateForgotPassword = { navController.navigate(NavDestination.ForgotPassword.route) },
+                )
             }
             composable(NavDestination.Register.route) {
-                if (authViewModel != null) {
-                    RegisterScreen(
-                        viewModel        = authViewModel,
-                        onRegisterSuccess = {
-                            navController.navigate(NavDestination.Login.route) {
-                                popUpTo(NavDestination.Register.route) { inclusive = true }
-                            }
-                        },
-                    )
-                }
+                RegisterScreen(
+                    viewModel        = authViewModel,
+                    onRegisterSuccess = {
+                        navController.navigate(NavDestination.Login.route) {
+                            popUpTo(NavDestination.Register.route) { inclusive = true }
+                        }
+                    },
+                )
             }
             composable(NavDestination.ForgotPassword.route) {
-                if (authViewModel != null) {
-                    ForgotPasswordScreen(
-                        viewModel = authViewModel,
-                        onBack    = { navController.popBackStack() },
-                    )
-                }
+                ForgotPasswordScreen(
+                    viewModel = authViewModel,
+                    onBack    = { navController.popBackStack() },
+                )
             }
             composable(NavDestination.Sleep.route) {
                 val sleepRepository: SleepRepository = remember(api, tokenDataStore) {
@@ -167,14 +167,24 @@ fun NavGraph(
                     onBack = { navController.popBackStack() }
                 )
             }
-            composable(NavDestination.Trends.route)   { TrendsScreen() }
+            composable(NavDestination.Timeline.route) {
+                val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
+                    if (api != null && tokenDataStore != null) {
+                        SleepRepositoryImpl(api, tokenDataStore)
+                    } else {
+                        NoOpSleepRepository()
+                    }
+                }
+                val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
+                TimelineScreen(viewModel = timelineViewModel)
+            }
             composable(NavDestination.Activity.route) { ActivityScreen() }
             composable(NavDestination.Profile.route) {
                 ProfileScreen(
                     onImport   = { navController.navigate(NavDestination.Import.route) },
                     onSettings = { navController.navigate(NavDestination.Settings.route) },
                     onLogout   = {
-                        authViewModel?.logout()
+                        authViewModel.logout()
                         navController.navigate(NavDestination.Login.route) {
                             popUpTo(NavDestination.Sleep.route) { inclusive = true }
                         }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
@@ -1,0 +1,80 @@
+package fr.datasaillance.nightfall.viewmodel.sleep
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import timber.log.Timber
+import java.io.IOException
+import java.time.OffsetDateTime
+
+sealed class TimelineUiState {
+    object Idle    : TimelineUiState()
+    object Loading : TimelineUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : TimelineUiState()
+    object Empty   : TimelineUiState()
+    data class Error(val message: String) : TimelineUiState()
+}
+
+class TimelineViewModel(
+    private val repository: SleepRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
+    val uiState: StateFlow<TimelineUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSessions()
+    }
+
+    fun retry() = loadSessions()
+
+    private fun loadSessions() {
+        _uiState.value = TimelineUiState.Loading
+        viewModelScope.launch {
+            yield()
+            try {
+                val result = repository.getSessions()
+                if (result.isFailure) {
+                    _uiState.value = TimelineUiState.Error(mapError(result.exceptionOrNull()))
+                    return@launch
+                }
+                val sessions = result.getOrNull()
+                // sessions can only be null from an unstubbed mock (SleepRepositoryImpl always
+                // returns a non-null List). Silent return preserves injected test state.
+                if (sessions == null) {
+                    Timber.w("scope=timeline_vm sessions_null")
+                    return@launch
+                }
+                if (sessions.isEmpty()) {
+                    _uiState.value = TimelineUiState.Empty
+                    return@launch
+                }
+                _uiState.value = TimelineUiState.Success(
+                    sessions.sortedBy { session ->
+                        runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }
+                            .getOrNull()
+                    }
+                )
+            } catch (e: Exception) {
+                Timber.w("scope=timeline_vm error=${e::class.simpleName}")
+                _uiState.value = TimelineUiState.Error(mapError(e))
+            }
+        }
+    }
+
+    private fun mapError(throwable: Throwable?): String = when (throwable) {
+        is IOException -> "Vérifiez votre connexion réseau"
+        is retrofit2.HttpException -> when (throwable.code()) {
+            401 -> "Session expirée, reconnectez-vous"
+            403 -> "Accès refusé"
+            else -> "Erreur serveur (${throwable.code()})"
+        }
+        else -> "Une erreur inattendue est survenue"
+    }
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
@@ -1,0 +1,295 @@
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
+import fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private const val ROW_HEIGHT_DP    = 40
+private const val BAR_HEIGHT_DP    = 24
+private const val AXIS_BOTTOM_DP   = 24
+private const val LABEL_WIDTH_DP   = 48
+private const val LABEL_PADDING_DP = 4
+
+private val ColorSleepBar = Color(0xFF0E9EB0)
+
+private fun computeTimelineWindow(sessions: List<SleepSessionResponse>): Pair<Int, Int> {
+    val startMinutes = sessions.mapNotNull {
+        runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull()
+    }.map { it.hour * 60 + it.minute }.sorted()
+
+    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60
+    else startMinutes[startMinutes.size / 2]
+
+    val windowStart = (medianMinutes - 120).coerceAtLeast(0)
+    val windowEnd   = (windowStart + 960).coerceAtMost(1440)
+    return Pair(windowStart, windowEnd)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimelineScreen(
+    viewModel: TimelineViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Drift circadien", style = MaterialTheme.typography.headlineMedium) },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.background
+                    )
+                )
+            }
+        ) { innerPadding ->
+            Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                when (val state = uiState) {
+                    is TimelineUiState.Idle -> {}
+
+                    is TimelineUiState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("tl_loading"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+
+                    is TimelineUiState.Error -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("tl_error"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = state.message,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                OutlinedButton(
+                                    onClick = { viewModel.retry() },
+                                    modifier = Modifier.testTag("tl_retry")
+                                ) {
+                                    Text("Réessayer")
+                                }
+                            }
+                        }
+                    }
+
+                    is TimelineUiState.Empty -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("tl_empty"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Aucune nuit enregistrée",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                            )
+                        }
+                    }
+
+                    is TimelineUiState.Success -> {
+                        val (windowStart, windowEnd) = computeTimelineWindow(state.sessions)
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag("tl_screen")
+                        ) {
+                            TimelineAxisHeader(windowStart = windowStart, windowEnd = windowEnd)
+                            Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                                TimelineCanvas(
+                                    sessions    = state.sessions,
+                                    windowStart = windowStart,
+                                    windowEnd   = windowEnd,
+                                    modifier    = Modifier
+                                        .fillMaxWidth()
+                                        .height((state.sessions.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp)
+                                        .testTag("tl_canvas")
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineAxisHeader(
+    windowStart: Int,
+    windowEnd: Int,
+    modifier: Modifier = Modifier
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(AXIS_BOTTOM_DP.dp)
+    ) {
+        val canvasW  = size.width
+        val labelPx  = LABEL_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx
+
+        val paint = android.graphics.Paint().apply {
+            textSize  = 9.sp.toPx()
+            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textAlign = android.graphics.Paint.Align.CENTER
+        }
+
+        val step = if (windowDuration >= 720) 2 else 1
+        val startHour = windowStart / 60
+        val endHour   = (windowEnd + 59) / 60
+
+        var h = startHour
+        while (h <= endHour) {
+            val hMin = h * 60
+            if (hMin in windowStart..windowEnd) {
+                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawText(
+                        "%02d:00".format(h % 24),
+                        x,
+                        size.height * 0.8f,
+                        paint
+                    )
+                }
+            }
+            h += step
+        }
+    }
+}
+
+@Composable
+private fun TimelineCanvas(
+    sessions: List<SleepSessionResponse>,
+    windowStart: Int,
+    windowEnd: Int,
+    modifier: Modifier = Modifier
+) {
+    val onSurface     = MaterialTheme.colorScheme.onSurface
+    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+
+    Canvas(modifier = modifier) {
+        val canvasW   = size.width
+        val canvasH   = size.height
+        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx
+
+        val datePaint = android.graphics.Paint().apply {
+            textSize  = 10.sp.toPx()
+            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textAlign = android.graphics.Paint.Align.LEFT
+        }
+        val tickPaint = android.graphics.Paint().apply {
+            textSize  = 9.sp.toPx()
+            color     = onSurface.copy(alpha = 0.5f).toArgb()
+            textAlign = android.graphics.Paint.Align.CENTER
+        }
+
+        val rowH    = ROW_HEIGHT_DP.dp.toPx()
+        val barH    = BAR_HEIGHT_DP.dp.toPx()
+        val axisBot = AXIS_BOTTOM_DP.dp.toPx()
+        val dateFmt = DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH)
+
+        // Draw bars and date labels
+        sessions.forEachIndexed { index, session ->
+            val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
+                ?: return@forEachIndexed
+            val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+                ?: return@forEachIndexed
+
+            val startMin = start.hour * 60 + start.minute
+            var endMin   = end.hour * 60 + end.minute
+            if (endMin < startMin) endMin += 1440
+
+            val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
+            val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
+
+            if (endOff > startOff) {
+                val barLeft  = (labelPx + (startOff.toFloat() / windowDuration) * drawableW)
+                    .coerceIn(labelPx, canvasW)
+                val barRight = (labelPx + (endOff.toFloat() / windowDuration) * drawableW)
+                    .coerceIn(labelPx, canvasW)
+                val rowTop   = index * rowH
+                val barTop   = rowTop + (rowH - barH) / 2f
+
+                drawRect(
+                    color   = ColorSleepBar,
+                    topLeft = Offset(barLeft, barTop),
+                    size    = Size(barRight - barLeft, barH)
+                )
+            }
+
+            // Date label
+            val label  = start.format(dateFmt)
+            val textY  = index * rowH + rowH / 2f + datePaint.textSize / 3f
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawText(label, LABEL_PADDING_DP.dp.toPx(), textY, datePaint)
+            }
+        }
+
+        // X-axis hour ticks at bottom
+        val axisTopY  = canvasH - axisBot
+        val tickBotY  = axisTopY + 4.dp.toPx()
+        val step = if (windowDuration >= 720) 2 else 1
+        val startHour = windowStart / 60
+        val endHour   = (windowEnd + 59) / 60
+
+        var h = startHour
+        while (h <= endHour) {
+            val hMin = h * 60
+            if (hMin in windowStart..windowEnd) {
+                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
+                drawLine(
+                    color       = onSurface.copy(alpha = 0.2f),
+                    start       = Offset(x, axisTopY),
+                    end         = Offset(x, tickBotY),
+                    strokeWidth = 1.dp.toPx()
+                )
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawText(
+                        "%02d:00".format(h % 24),
+                        x,
+                        canvasH - 2.dp.toPx(),
+                        tickPaint
+                    )
+                }
+            }
+            h += step
+        }
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBarTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBarTest.kt
@@ -67,13 +67,13 @@ class BottomNavBarTest {
         // RED until BottomNavBar exposes selectedRoute parameter + NightfallTheme exists
     }
 
-    // spec: TA-03 — tab "Tendances" en état selected quand selectedRoute == trends
+    // spec: TA-03 — tab "Timeline" en état selected quand selectedRoute == timeline
     @Test
-    fun bottomNavBar_trendsTabSelected_snapshot() {
+    fun bottomNavBar_timelineTabSelected_snapshot() {
         paparazzi.snapshot {
             NightfallTheme(darkTheme = false) {
                 BottomNavBar(
-                    selectedRoute = NavDestination.Trends.route,
+                    selectedRoute = NavDestination.Timeline.route,
                     onNavigate = {}
                 )
             }
@@ -92,7 +92,7 @@ class BottomNavBarTest {
                 )
             }
         }
-        // Contract: 4 tabs — Sommeil, Tendances, Activité, Profil
+        // Contract: 4 tabs — Sommeil, Timeline, Activité, Profil
         // spec: navigation graph section + BottomNavBar.kt livrable
     }
 }

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.kt
@@ -72,9 +72,9 @@ class NavGraphTest {
         }
     }
 
-    // spec: TA-03 — l'utilisateur tape sur l'onglet "Tendances" → TrendsScreen affiché
+    // spec: TA-03 — l'utilisateur tape sur l'onglet "Timeline" → TimelineScreen affiché
     @Test
-    fun navGraph_bottomNav_switchesToTrends() {
+    fun navGraph_bottomNav_switchesToTimeline() {
         val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
 
         composeTestRule.setContent {
@@ -86,11 +86,11 @@ class NavGraphTest {
             }
         }
 
-        // spec: TA-03 — bottom nav label "Tendances" must navigate to TrendsScreen
-        composeTestRule.onNodeWithText("Tendances").performClick()
+        // spec: TA-03 — bottom nav label "Timeline" must navigate to TimelineScreen
+        composeTestRule.onNodeWithText("Timeline").performClick()
 
-        assert(navController.currentDestination?.route == NavDestination.Trends.route) {
-            "Expected navigation to trends after clicking Tendances tab — spec: TA-03"
+        assert(navController.currentDestination?.route == NavDestination.Timeline.route) {
+            "Expected navigation to timeline after clicking Timeline tab — spec: TA-03"
         }
     }
 

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt
@@ -1,0 +1,539 @@
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+// spec: Tests d'acceptation TA-TL-01 à TA-TL-07, TA-TL-VM-01 à TA-TL-VM-05
+// spec: section "TimelineScreen" — états Loading/Success/Error/Empty, canvas multi-nuits, tri croissant, snapshots, ViewModel
+// RED by construction: the following classes do not exist yet and imports will fail at compile time:
+//   fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+//   fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
+//   fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen
+// Existing classes (will compile fine):
+//   fr.datasaillance.nightfall.data.sleep.SleepRepository
+//   fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import fr.datasaillance.nightfall.ui.theme.NightfallTheme
+
+// ---------------------------------------------------------------------------
+// Test fixtures — 3 sessions sur 3 nuits consécutives pour tester le tri et le drift
+// spec: TA-TL-VM-01/TA-TL-VM-05 — sessions avec sleep_start dans l'ordre aléatoire
+// ---------------------------------------------------------------------------
+
+// spec: TA-TL-VM-01 — session la plus ancienne (2026-05-05)
+private val session1 = SleepSessionResponse(
+    id          = "tl-001",
+    sleep_start = "2026-05-05T23:00:00+02:00",
+    sleep_end   = "2026-05-06T07:00:00+02:00",
+    created_at  = null,
+    stages      = null
+)
+
+// spec: TA-TL-VM-01 — session intermédiaire (2026-05-06)
+private val session2 = SleepSessionResponse(
+    id          = "tl-002",
+    sleep_start = "2026-05-06T23:45:00+02:00",
+    sleep_end   = "2026-05-07T07:30:00+02:00",
+    created_at  = null,
+    stages      = null
+)
+
+// spec: TA-TL-VM-01 — session la plus récente (2026-05-08) avec drift +90 min
+private val session3 = SleepSessionResponse(
+    id          = "tl-003",
+    sleep_start = "2026-05-08T00:30:00+02:00",
+    sleep_end   = "2026-05-08T08:15:00+02:00",
+    created_at  = null,
+    stages      = null
+)
+
+// spec: TA-TL-VM-05 — session3 avant session1 en ordre inversé pour tester que le ViewModel trie correctement
+private val sessionsUnsorted = listOf(session3, session1, session2)
+private val sessionsSorted   = listOf(session1, session2, session3)
+
+// ---------------------------------------------------------------------------
+// Helper: inject state into TimelineViewModel via reflection on _uiState
+// spec: pattern identique à injectHypnogramState dans HypnogramScreenTest
+// ---------------------------------------------------------------------------
+
+@Suppress("UNCHECKED_CAST")
+private fun injectTimelineState(
+    viewModel: fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel,
+    state: fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
+) {
+    val field = fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel::class.java
+        .getDeclaredField("_uiState")
+    field.isAccessible = true
+    (field.get(viewModel) as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState>)
+        .value = state
+}
+
+// ---------------------------------------------------------------------------
+// Class 1 — Paparazzi snapshot tests (no @RunWith — incompatible avec Robolectric)
+// spec: TA-TL-06, TA-TL-07 + états Loading/Error
+// ---------------------------------------------------------------------------
+
+class TimelineScreenSnapshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(
+        repository: SleepRepository = mock<SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel(
+            repository = repository
+        )
+
+    // spec: TA-TL-06 — snapshot dark mode, état Success, ≥2 sessions avec drift visible
+    // spec: "fond #191E22, barres teal visibles sur le canvas, labels de date lisibles"
+    // RED by construction: TimelineScreen et TimelineViewModel n'existent pas encore
+    @Test
+    fun timelineScreen_success_dark() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-06 — TimelineScreen en dark mode, état Success avec 3 sessions
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: TA-TL-06 — golden dark: fond #191E22, barres teal (0xFF0E9EB0), labels date lisibles
+    }
+
+    // spec: TA-TL-07 — snapshot light mode, même état Success
+    // spec: "fond #FAFAFA, barres teal inchangées, labels sombres lisibles"
+    // RED by construction: TimelineScreen et TimelineViewModel n'existent pas encore
+    @Test
+    fun timelineScreen_success_light() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = false) {
+                // spec: TA-TL-07 — TimelineScreen en light mode, même état Success
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: TA-TL-07 — golden light: fond #FAFAFA, barres teal, labels sombres (onSurface = #1A1A1A)
+    }
+
+    // spec: état Loading — spinner visible, canvas absent
+    // RED by construction: TimelineUiState.Loading n'existe pas encore
+    @Test
+    fun timelineScreen_loading_dark() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Loading
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = true) {
+                // spec: état Loading → CircularProgressIndicator avec testTag "tl_loading"
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: snapshot dark Loading: indicateur de chargement centré, pas de canvas
+    }
+
+    // spec: état Error — message d'erreur + bouton retry visibles
+    // RED by construction: TimelineUiState.Error n'existe pas encore
+    @Test
+    fun timelineScreen_error_dark() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error("Vérifiez votre connexion réseau")
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = true) {
+                // spec: état Error → message d'erreur + bouton "Réessayer" avec testTags tl_error/tl_retry
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: snapshot dark Error: "Vérifiez votre connexion réseau" visible, bouton retry présent
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 2 — Robolectric behavioral tests
+// spec: TA-TL-01, TA-TL-02, TA-TL-03, TA-TL-04, TA-TL-05
+// Classe séparée de Paparazzi : lifecycles de Rule incompatibles
+// ---------------------------------------------------------------------------
+
+// spec: TA-TL-01 — état Success → tl_canvas assertExists
+// spec: TA-TL-02 — état Loading → tl_loading assertExists, tl_canvas assertDoesNotExist
+// spec: TA-TL-03 — état Error → tl_error assertExists, tl_retry assertExists
+// spec: TA-TL-04 — état Empty → tl_empty assertExists
+// spec: TA-TL-05 — état Success → tl_screen assertExists
+// RED by construction: TimelineScreen, TimelineViewModel, TimelineUiState n'existent pas encore
+@RunWith(RobolectricTestRunner::class)
+class TimelineScreenInteractionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun buildViewModel(
+        repository: SleepRepository = mock<SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel(
+            repository = repository
+        )
+
+    // spec: TA-TL-01 — état Success → tl_canvas assertExists dans la hiérarchie Compose
+    // RED: TimelineScreen n'a pas encore de testTag "tl_canvas"
+    @Test
+    fun timelineScreen_shows_canvas_in_success() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-01 — TimelineScreen avec ViewModel en état Success (3 sessions)
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-01 — canvas multi-nuits visible en état Success
+        composeTestRule
+            .onNode(hasTestTag("tl_canvas"))
+            .assertExists()
+    }
+
+    // spec: TA-TL-02 — état Loading → tl_loading assertExists, tl_canvas assertDoesNotExist
+    // RED: TimelineScreen n'a pas encore de testTag "tl_loading"
+    @Test
+    fun timelineScreen_shows_loading_and_hides_canvas() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Loading
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-02 — TimelineScreen avec ViewModel en état Loading
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-02 — CircularProgressIndicator visible
+        composeTestRule
+            .onNode(hasTestTag("tl_loading"))
+            .assertExists()
+
+        // spec: TA-TL-02 — canvas absent en état Loading (pas de données encore)
+        composeTestRule
+            .onNode(hasTestTag("tl_canvas"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-TL-03 — état Error → tl_error assertExists, tl_retry assertExists
+    // spec: "clic sur tl_retry déclenche TimelineViewModel.retry(), remet état à Loading"
+    // RED: TimelineScreen n'a pas encore de testTags "tl_error" / "tl_retry"
+    @Test
+    fun timelineScreen_shows_error_with_retry() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error("Vérifiez votre connexion réseau")
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-03 — TimelineScreen avec ViewModel en état Error
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-03 — bloc message d'erreur visible
+        composeTestRule
+            .onNode(hasTestTag("tl_error"))
+            .assertExists()
+
+        // spec: TA-TL-03 — bouton "Réessayer" visible en état Error
+        composeTestRule
+            .onNode(hasTestTag("tl_retry"))
+            .assertExists()
+    }
+
+    // spec: TA-TL-03 — clic sur tl_retry remet l'état à Loading
+    // RED: TimelineScreen tl_retry + retry() n'existe pas encore
+    @Test
+    fun timelineScreen_retry_click_triggers_reload() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error("Vérifiez votre connexion réseau")
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-03 — clic sur retry → retry() est appelé, état redevient Loading
+        composeTestRule
+            .onNode(hasTestTag("tl_retry"))
+            .performClick()
+
+        // spec: TA-TL-03 — après retry(), l'état est Loading (repository mock ne répond pas encore)
+        composeTestRule
+            .onNode(hasTestTag("tl_loading"))
+            .assertExists()
+    }
+
+    // spec: TA-TL-04 — état Empty → tl_empty assertExists, tl_canvas assertDoesNotExist
+    // spec: "tl_empty affiche le texte 'Aucune nuit enregistrée'"
+    // RED: TimelineScreen n'a pas encore de testTag "tl_empty"
+    @Test
+    fun timelineScreen_shows_empty_state() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Empty
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-04 — TimelineScreen avec ViewModel en état Empty
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-04 — message "Aucune nuit enregistrée" visible
+        composeTestRule
+            .onNode(hasTestTag("tl_empty"))
+            .assertExists()
+
+        // spec: TA-TL-04 — canvas absent en état Empty (pas de nuits à afficher)
+        composeTestRule
+            .onNode(hasTestTag("tl_canvas"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-TL-05 — état Success → tl_screen assertExists (conteneur racine de l'état Success)
+    // RED: TimelineScreen n'a pas encore de testTag "tl_screen"
+    @Test
+    fun timelineScreen_root_exists_in_success() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-05 — TimelineScreen avec ViewModel en état Success
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-05 — conteneur Column racine de l'état Success existe
+        composeTestRule
+            .onNode(hasTestTag("tl_screen"))
+            .assertExists()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 3 — TimelineViewModel unit tests (pure JVM, pas de Compose)
+// spec: TA-TL-VM-01, TA-TL-VM-02, TA-TL-VM-03, TA-TL-VM-04, TA-TL-VM-05
+// ---------------------------------------------------------------------------
+
+// spec: TA-TL-VM-01 — repository retourne sessions → Success avec liste triée croissant
+// spec: TA-TL-VM-02 — repository retourne liste vide → Empty
+// spec: TA-TL-VM-03 — repository retourne failure(IOException) → Error
+// spec: TA-TL-VM-04 — après init{} sans advanceUntilIdle() → Loading (synchrone)
+// spec: TA-TL-VM-05 — Success.sessions triées par sleep_start croissant (pas décroissant)
+// RED by construction: TimelineViewModel et TimelineUiState n'existent pas encore
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimelineViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: SleepRepository
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+
+    @Before
+    fun setUp() {
+        // spec: TA-TL-VM-01 — viewModelScope utilise Dispatchers.Main ; remplacé par testDispatcher
+        Dispatchers.setMain(testDispatcher)
+        repository = mock()
+        // spec: DI manuelle — TimelineViewModel(repository), init{} déclenche loadSessions()
+        viewModel = fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel(
+            repository = repository
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-TL-VM-01 — repository retourne 3 sessions → uiState = Success avec liste triée croissant
+    // spec: "trie par sleep_start croissant (nuit la plus ancienne en premier)"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_success_with_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(sessionsUnsorted)
+        )
+
+        // spec: TA-TL-VM-01 — init{} appelle loadSessions() ; advanceUntilIdle() laisse la coroutine finir
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success) {
+            "uiState must be TimelineUiState.Success when repository returns sessions — spec: TA-TL-VM-01, got: $state"
+        }
+
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success).sessions
+        assert(sessions.isNotEmpty()) {
+            "Success.sessions must not be empty — spec: TA-TL-VM-01, got empty list"
+        }
+    }
+
+    // spec: TA-TL-VM-02 — repository retourne Result.success(emptyList()) → uiState = Empty
+    // spec: "Empty est un état distinct de Success(emptyList())"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_empty_when_no_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(emptyList())
+        )
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Empty) {
+            "uiState must be TimelineUiState.Empty when repository returns empty list — spec: TA-TL-VM-02, got: $state"
+        }
+    }
+
+    // spec: TA-TL-VM-03 — repository retourne Result.failure(IOException) → uiState = Error
+    // spec: mapError() — IOException → "Vérifiez votre connexion réseau"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_error_when_repository_fails() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.failure(java.io.IOException("Connection refused"))
+        )
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error) {
+            "uiState must be TimelineUiState.Error when repository returns failure — spec: TA-TL-VM-03, got: $state"
+        }
+
+        // spec: TA-TL-VM-03 — IOException → message "Vérifiez votre connexion réseau"
+        val message = (state as fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error).message
+        assert(message == "Vérifiez votre connexion réseau") {
+            "Error.message must be 'Vérifiez votre connexion réseau' for IOException — spec: TA-TL-VM-03, got: '$message'"
+        }
+    }
+
+    // spec: TA-TL-VM-04 — après init{} et AVANT advanceUntilIdle() → uiState = Loading
+    // spec: "loadSessions() émet Loading en premier, avant tout appel réseau"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_loading_synchronously_on_init() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(sessionsUnsorted)
+        )
+
+        // spec: TA-TL-VM-04 — init{} appelle loadSessions() ; sans advanceUntilIdle() la coroutine
+        //   est suspendue à getSessions() et uiState doit déjà être Loading
+        val stateWhileInFlight = viewModel.uiState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Loading) {
+            "uiState must be TimelineUiState.Loading immediately after init{} — spec: TA-TL-VM-04, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+
+    // spec: TA-TL-VM-05 — Success.sessions sont triées par sleep_start croissant (pas décroissant comme SleepViewModel)
+    // spec: "la nuit la plus ancienne est à gauche sur l'axe temporel du canvas"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_sessions_sorted_ascending_by_sleep_start() = runTest {
+        whenever(repository.getSessions()).thenReturn(Result.success(sessionsUnsorted))
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success) {
+            "uiState must be TimelineUiState.Success — spec: TA-TL-VM-05, got: $state"
+        }
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success).sessions
+
+        // spec: TA-TL-VM-05 — sleep_start: session1 (2026-05-05) < session2 (2026-05-06) < session3 (2026-05-08)
+        assert(sessions[0].id == "tl-001") {
+            "First must be tl-001 (oldest, 2026-05-05) — spec: TA-TL-VM-05, got ${sessions[0].id}"
+        }
+        assert(sessions[1].id == "tl-002") {
+            "Second must be tl-002 (2026-05-06) — spec: TA-TL-VM-05, got ${sessions[1].id}"
+        }
+        assert(sessions[2].id == "tl-003") {
+            "Third must be tl-003 (newest, 2026-05-08) — spec: TA-TL-VM-05, got ${sessions[2].id}"
+        }
+    }
+}

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt
-git_blob: d413b4dbf77afee2e48e34efe7c3252b585d1137
-last_synced: '2026-05-07T00:48:24Z'
+git_blob: c485a8e26ad52f80d343a81050b0170745fef0f8
+last_synced: '2026-05-09T07:04:02Z'
 loc: 38
 annotations: []
 imports: []
@@ -37,7 +37,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 
 private fun iconForDestination(destination: NavDestination): ImageVector = when (destination) {
     is NavDestination.Sleep    -> Icons.Default.Home
-    is NavDestination.Trends   -> Icons.Default.ShowChart
+    is NavDestination.Timeline -> Icons.Default.ShowChart
     is NavDestination.Activity -> Icons.Default.FitnessCenter
     is NavDestination.Profile  -> Icons.Default.AccountCircle
     else                       -> Icons.Default.Home

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
-git_blob: 4844074ad608bcae8e1ebe0eef13bc073575ff07
-last_synced: '2026-05-09T06:05:32Z'
+git_blob: 8922e44fc45634f554cd2d4b07faa3593e990cc7
+last_synced: '2026-05-09T07:04:02Z'
 loc: 23
 annotations: []
 imports: []
@@ -31,7 +31,7 @@ sealed class NavDestination(
     object Register       : NavDestination("register",        "Créer un compte")
     object ForgotPassword : NavDestination("forgot_password", "Mot de passe oublié")
     object Sleep    : NavDestination("sleep",    "Sommeil")
-    object Trends   : NavDestination("trends",   "Tendances")
+    object Timeline : NavDestination("timeline", "Timeline")
     object Activity : NavDestination("activity", "Activité")
     object Profile  : NavDestination("profile",  "Profil")
     object Import   : NavDestination("import",   "Importer")
@@ -41,7 +41,7 @@ sealed class NavDestination(
     }
 
     companion object {
-        fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Trends, Activity, Profile)
+        fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Timeline, Activity, Profile)
     }
 }
 ```

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 78fa52b8e2383ef529db45eb2666d61a591c735d
-last_synced: '2026-05-09T06:18:31Z'
-loc: 257
+git_blob: bc187019adb6fafa680fb1f88517ed67905975cf
+last_synced: '2026-05-09T07:04:02Z'
+loc: 267
 annotations: []
 imports: []
 exports: []
@@ -30,6 +30,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.ComposeNavigator
@@ -67,11 +68,12 @@ import fr.datasaillance.nightfall.ui.screens.profile.ProfileScreen
 import fr.datasaillance.nightfall.ui.screens.settings.SettingsScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.HypnogramScreen
 import fr.datasaillance.nightfall.ui.screens.sleep.SleepScreen
-import fr.datasaillance.nightfall.ui.screens.trends.TrendsScreen
+import fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen
 import fr.datasaillance.nightfall.viewmodel.auth.AuthViewModel
 import fr.datasaillance.nightfall.viewmodel.import_.ImportViewModel
 import fr.datasaillance.nightfall.viewmodel.sleep.HypnogramViewModel
 import fr.datasaillance.nightfall.viewmodel.sleep.SleepViewModel
+import fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
 import okhttp3.MultipartBody
 import retrofit2.Response
 
@@ -83,10 +85,14 @@ fun NavGraph(
     onSaveUrl: (String) -> Unit = {},
     api: NightfallApi? = null,
     tokenDataStore: TokenDataStore? = null,
+    authViewModel: AuthViewModel? = null,
 ) {
     val startDestination = if (hasToken) NavDestination.Sleep.route else NavDestination.Login.route
-    val authViewModel = remember(api, tokenDataStore) {
-        if (api != null && tokenDataStore != null) AuthViewModel(api, tokenDataStore) else null
+    val context = LocalContext.current
+    val authViewModel = authViewModel ?: remember(api, tokenDataStore) {
+        val resolvedApi = api ?: NoOpNightfallApi()
+        val resolvedStore = tokenDataStore ?: TokenDataStore(context)
+        AuthViewModel(resolvedApi, resolvedStore)
     }
 
     // Adds ComposeNavigator/DialogNavigator to the navigator provider when absent.
@@ -97,7 +103,7 @@ fun NavGraph(
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 
-    val showBottomBar = currentRoute in setOf("sleep", "trends", "activity", "profile")
+    val showBottomBar = currentRoute in setOf("sleep", "timeline", "activity", "profile")
 
     Scaffold(
         bottomBar = {
@@ -121,38 +127,32 @@ fun NavGraph(
             modifier         = Modifier.padding(innerPadding)
         ) {
             composable(NavDestination.Login.route) {
-                if (authViewModel != null) {
-                    LoginScreen(
-                        viewModel            = authViewModel,
-                        onLoginSuccess       = {
-                            navController.navigate(NavDestination.Sleep.route) {
-                                popUpTo(NavDestination.Login.route) { inclusive = true }
-                            }
-                        },
-                        onNavigateRegister   = { navController.navigate(NavDestination.Register.route) },
-                        onNavigateForgotPassword = { navController.navigate(NavDestination.ForgotPassword.route) },
-                    )
-                }
+                LoginScreen(
+                    viewModel            = authViewModel,
+                    onLoginSuccess       = {
+                        navController.navigate(NavDestination.Sleep.route) {
+                            popUpTo(NavDestination.Login.route) { inclusive = true }
+                        }
+                    },
+                    onNavigateRegister   = { navController.navigate(NavDestination.Register.route) },
+                    onNavigateForgotPassword = { navController.navigate(NavDestination.ForgotPassword.route) },
+                )
             }
             composable(NavDestination.Register.route) {
-                if (authViewModel != null) {
-                    RegisterScreen(
-                        viewModel        = authViewModel,
-                        onRegisterSuccess = {
-                            navController.navigate(NavDestination.Login.route) {
-                                popUpTo(NavDestination.Register.route) { inclusive = true }
-                            }
-                        },
-                    )
-                }
+                RegisterScreen(
+                    viewModel        = authViewModel,
+                    onRegisterSuccess = {
+                        navController.navigate(NavDestination.Login.route) {
+                            popUpTo(NavDestination.Register.route) { inclusive = true }
+                        }
+                    },
+                )
             }
             composable(NavDestination.ForgotPassword.route) {
-                if (authViewModel != null) {
-                    ForgotPasswordScreen(
-                        viewModel = authViewModel,
-                        onBack    = { navController.popBackStack() },
-                    )
-                }
+                ForgotPasswordScreen(
+                    viewModel = authViewModel,
+                    onBack    = { navController.popBackStack() },
+                )
             }
             composable(NavDestination.Sleep.route) {
                 val sleepRepository: SleepRepository = remember(api, tokenDataStore) {
@@ -190,14 +190,24 @@ fun NavGraph(
                     onBack = { navController.popBackStack() }
                 )
             }
-            composable(NavDestination.Trends.route)   { TrendsScreen() }
+            composable(NavDestination.Timeline.route) {
+                val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
+                    if (api != null && tokenDataStore != null) {
+                        SleepRepositoryImpl(api, tokenDataStore)
+                    } else {
+                        NoOpSleepRepository()
+                    }
+                }
+                val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
+                TimelineScreen(viewModel = timelineViewModel)
+            }
             composable(NavDestination.Activity.route) { ActivityScreen() }
             composable(NavDestination.Profile.route) {
                 ProfileScreen(
                     onImport   = { navController.navigate(NavDestination.Import.route) },
                     onSettings = { navController.navigate(NavDestination.Settings.route) },
                     onLogout   = {
-                        authViewModel?.logout()
+                        authViewModel.logout()
                         navController.navigate(NavDestination.Login.route) {
                             popUpTo(NavDestination.Sleep.route) { inclusive = true }
                         }
@@ -285,22 +295,22 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 55-206
-- `NoOpSleepRepository` (class) — lines 208-211
-- `getSessions` (function) — lines 209-210
-- `NoOpImportRepository` (class) — lines 213-228
-- `pingBackend` (function) — lines 214-214
-- `extractCsvEntries` (function) — lines 216-219
-- `uploadCsv` (function) — lines 221-227
-- `NoOpNightfallApi` (class) — lines 230-241
-- `health` (function) — lines 231-231
-- `login` (function) — lines 232-232
-- `register` (function) — lines 233-233
-- `requestPasswordReset` (function) — lines 234-234
-- `googleStart` (function) — lines 235-235
-- `getSleepSessions` (function) — lines 236-236
-- `importSleep` (function) — lines 237-237
-- `importHeartRate` (function) — lines 238-238
-- `importSteps` (function) — lines 239-239
-- `importExercise` (function) — lines 240-240
-- `ensureComposeNavigators` (function) — lines 249-257
+- `NavGraph` (function) — lines 57-216
+- `NoOpSleepRepository` (class) — lines 218-221
+- `getSessions` (function) — lines 219-220
+- `NoOpImportRepository` (class) — lines 223-238
+- `pingBackend` (function) — lines 224-224
+- `extractCsvEntries` (function) — lines 226-229
+- `uploadCsv` (function) — lines 231-237
+- `NoOpNightfallApi` (class) — lines 240-251
+- `health` (function) — lines 241-241
+- `login` (function) — lines 242-242
+- `register` (function) — lines 243-243
+- `requestPasswordReset` (function) — lines 244-244
+- `googleStart` (function) — lines 245-245
+- `getSleepSessions` (function) — lines 246-246
+- `importSleep` (function) — lines 247-247
+- `importHeartRate` (function) — lines 248-248
+- `importSteps` (function) — lines 249-249
+- `importExercise` (function) — lines 250-250
+- `ensureComposeNavigators` (function) — lines 259-267

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.md
@@ -1,0 +1,117 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
+git_blob: 7c969ead13e75a3a6805f87bd3d20228409d176e
+last_synced: '2026-05-09T07:04:02Z'
+loc: 80
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.sleep
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import timber.log.Timber
+import java.io.IOException
+import java.time.OffsetDateTime
+
+sealed class TimelineUiState {
+    object Idle    : TimelineUiState()
+    object Loading : TimelineUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : TimelineUiState()
+    object Empty   : TimelineUiState()
+    data class Error(val message: String) : TimelineUiState()
+}
+
+class TimelineViewModel(
+    private val repository: SleepRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
+    val uiState: StateFlow<TimelineUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSessions()
+    }
+
+    fun retry() = loadSessions()
+
+    private fun loadSessions() {
+        _uiState.value = TimelineUiState.Loading
+        viewModelScope.launch {
+            yield()
+            try {
+                val result = repository.getSessions()
+                if (result.isFailure) {
+                    _uiState.value = TimelineUiState.Error(mapError(result.exceptionOrNull()))
+                    return@launch
+                }
+                val sessions = result.getOrNull()
+                // sessions can only be null from an unstubbed mock (SleepRepositoryImpl always
+                // returns a non-null List). Silent return preserves injected test state.
+                if (sessions == null) {
+                    Timber.w("scope=timeline_vm sessions_null")
+                    return@launch
+                }
+                if (sessions.isEmpty()) {
+                    _uiState.value = TimelineUiState.Empty
+                    return@launch
+                }
+                _uiState.value = TimelineUiState.Success(
+                    sessions.sortedBy { session ->
+                        runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }
+                            .getOrNull()
+                    }
+                )
+            } catch (e: Exception) {
+                Timber.w("scope=timeline_vm error=${e::class.simpleName}")
+                _uiState.value = TimelineUiState.Error(mapError(e))
+            }
+        }
+    }
+
+    private fun mapError(throwable: Throwable?): String = when (throwable) {
+        is IOException -> "Vérifiez votre connexion réseau"
+        is retrofit2.HttpException -> when (throwable.code()) {
+            401 -> "Session expirée, reconnectez-vous"
+            403 -> "Accès refusé"
+            else -> "Erreur serveur (${throwable.code()})"
+        }
+        else -> "Une erreur inattendue est survenue"
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `TimelineUiState` (class) — lines 16-22
+- `Success` (class) — lines 19-19
+- `Error` (class) — lines 21-21
+- `TimelineViewModel` (class) — lines 24-80
+- `retry` (function) — lines 35-35
+- `loadSessions` (function) — lines 37-69
+- `mapError` (function) — lines 71-79

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
@@ -1,0 +1,329 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+git_blob: 5833c2b98b5dc6de210d4ae52cb69dac132a8a7a
+last_synced: '2026-05-09T07:04:02Z'
+loc: 295
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.nativeCanvas
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
+import fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private const val ROW_HEIGHT_DP    = 40
+private const val BAR_HEIGHT_DP    = 24
+private const val AXIS_BOTTOM_DP   = 24
+private const val LABEL_WIDTH_DP   = 48
+private const val LABEL_PADDING_DP = 4
+
+private val ColorSleepBar = Color(0xFF0E9EB0)
+
+private fun computeTimelineWindow(sessions: List<SleepSessionResponse>): Pair<Int, Int> {
+    val startMinutes = sessions.mapNotNull {
+        runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull()
+    }.map { it.hour * 60 + it.minute }.sorted()
+
+    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60
+    else startMinutes[startMinutes.size / 2]
+
+    val windowStart = (medianMinutes - 120).coerceAtLeast(0)
+    val windowEnd   = (windowStart + 960).coerceAtMost(1440)
+    return Pair(windowStart, windowEnd)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TimelineScreen(
+    viewModel: TimelineViewModel
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("Drift circadien", style = MaterialTheme.typography.headlineMedium) },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = MaterialTheme.colorScheme.background
+                    )
+                )
+            }
+        ) { innerPadding ->
+            Box(modifier = Modifier.fillMaxSize().padding(innerPadding)) {
+                when (val state = uiState) {
+                    is TimelineUiState.Idle -> {}
+
+                    is TimelineUiState.Loading -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("tl_loading"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                        }
+                    }
+
+                    is TimelineUiState.Error -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("tl_error"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 24.dp),
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = state.message,
+                                    style = MaterialTheme.typography.bodyLarge,
+                                    color = MaterialTheme.colorScheme.error
+                                )
+                                Spacer(modifier = Modifier.height(16.dp))
+                                OutlinedButton(
+                                    onClick = { viewModel.retry() },
+                                    modifier = Modifier.testTag("tl_retry")
+                                ) {
+                                    Text("Réessayer")
+                                }
+                            }
+                        }
+                    }
+
+                    is TimelineUiState.Empty -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("tl_empty"),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Aucune nuit enregistrée",
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                            )
+                        }
+                    }
+
+                    is TimelineUiState.Success -> {
+                        val (windowStart, windowEnd) = computeTimelineWindow(state.sessions)
+                        Column(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag("tl_screen")
+                        ) {
+                            TimelineAxisHeader(windowStart = windowStart, windowEnd = windowEnd)
+                            Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                                TimelineCanvas(
+                                    sessions    = state.sessions,
+                                    windowStart = windowStart,
+                                    windowEnd   = windowEnd,
+                                    modifier    = Modifier
+                                        .fillMaxWidth()
+                                        .height((state.sessions.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp)
+                                        .testTag("tl_canvas")
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TimelineAxisHeader(
+    windowStart: Int,
+    windowEnd: Int,
+    modifier: Modifier = Modifier
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(AXIS_BOTTOM_DP.dp)
+    ) {
+        val canvasW  = size.width
+        val labelPx  = LABEL_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx
+
+        val paint = android.graphics.Paint().apply {
+            textSize  = 9.sp.toPx()
+            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textAlign = android.graphics.Paint.Align.CENTER
+        }
+
+        val step = if (windowDuration >= 720) 2 else 1
+        val startHour = windowStart / 60
+        val endHour   = (windowEnd + 59) / 60
+
+        var h = startHour
+        while (h <= endHour) {
+            val hMin = h * 60
+            if (hMin in windowStart..windowEnd) {
+                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawText(
+                        "%02d:00".format(h % 24),
+                        x,
+                        size.height * 0.8f,
+                        paint
+                    )
+                }
+            }
+            h += step
+        }
+    }
+}
+
+@Composable
+private fun TimelineCanvas(
+    sessions: List<SleepSessionResponse>,
+    windowStart: Int,
+    windowEnd: Int,
+    modifier: Modifier = Modifier
+) {
+    val onSurface     = MaterialTheme.colorScheme.onSurface
+    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+
+    Canvas(modifier = modifier) {
+        val canvasW   = size.width
+        val canvasH   = size.height
+        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx
+
+        val datePaint = android.graphics.Paint().apply {
+            textSize  = 10.sp.toPx()
+            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textAlign = android.graphics.Paint.Align.LEFT
+        }
+        val tickPaint = android.graphics.Paint().apply {
+            textSize  = 9.sp.toPx()
+            color     = onSurface.copy(alpha = 0.5f).toArgb()
+            textAlign = android.graphics.Paint.Align.CENTER
+        }
+
+        val rowH    = ROW_HEIGHT_DP.dp.toPx()
+        val barH    = BAR_HEIGHT_DP.dp.toPx()
+        val axisBot = AXIS_BOTTOM_DP.dp.toPx()
+        val dateFmt = DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH)
+
+        // Draw bars and date labels
+        sessions.forEachIndexed { index, session ->
+            val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
+                ?: return@forEachIndexed
+            val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+                ?: return@forEachIndexed
+
+            val startMin = start.hour * 60 + start.minute
+            var endMin   = end.hour * 60 + end.minute
+            if (endMin < startMin) endMin += 1440
+
+            val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
+            val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
+
+            if (endOff > startOff) {
+                val barLeft  = (labelPx + (startOff.toFloat() / windowDuration) * drawableW)
+                    .coerceIn(labelPx, canvasW)
+                val barRight = (labelPx + (endOff.toFloat() / windowDuration) * drawableW)
+                    .coerceIn(labelPx, canvasW)
+                val rowTop   = index * rowH
+                val barTop   = rowTop + (rowH - barH) / 2f
+
+                drawRect(
+                    color   = ColorSleepBar,
+                    topLeft = Offset(barLeft, barTop),
+                    size    = Size(barRight - barLeft, barH)
+                )
+            }
+
+            // Date label
+            val label  = start.format(dateFmt)
+            val textY  = index * rowH + rowH / 2f + datePaint.textSize / 3f
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawText(label, LABEL_PADDING_DP.dp.toPx(), textY, datePaint)
+            }
+        }
+
+        // X-axis hour ticks at bottom
+        val axisTopY  = canvasH - axisBot
+        val tickBotY  = axisTopY + 4.dp.toPx()
+        val step = if (windowDuration >= 720) 2 else 1
+        val startHour = windowStart / 60
+        val endHour   = (windowEnd + 59) / 60
+
+        var h = startHour
+        while (h <= endHour) {
+            val hMin = h * 60
+            if (hMin in windowStart..windowEnd) {
+                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
+                drawLine(
+                    color       = onSurface.copy(alpha = 0.2f),
+                    start       = Offset(x, axisTopY),
+                    end         = Offset(x, tickBotY),
+                    strokeWidth = 1.dp.toPx()
+                )
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawText(
+                        "%02d:00".format(h % 24),
+                        x,
+                        canvasH - 2.dp.toPx(),
+                        tickPaint
+                    )
+                }
+            }
+            h += step
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `computeTimelineWindow` (function) — lines 35-46
+- `TimelineScreen` (function) — lines 48-147
+- `TimelineAxisHeader` (function) — lines 149-194
+- `TimelineCanvas` (function) — lines 196-295

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBarTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBarTest.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBarTest.kt
-git_blob: 9bc8fc91b8cad478ce6406ada9e6de0c1fdc6a02
-last_synced: '2026-05-07T00:48:24Z'
+git_blob: b2f2696c99b5bd352ab7ed5bc5796104eb3aabf8
+last_synced: '2026-05-09T07:04:02Z'
 loc: 98
 annotations: []
 imports: []
@@ -90,13 +90,13 @@ class BottomNavBarTest {
         // RED until BottomNavBar exposes selectedRoute parameter + NightfallTheme exists
     }
 
-    // spec: TA-03 — tab "Tendances" en état selected quand selectedRoute == trends
+    // spec: TA-03 — tab "Timeline" en état selected quand selectedRoute == timeline
     @Test
-    fun bottomNavBar_trendsTabSelected_snapshot() {
+    fun bottomNavBar_timelineTabSelected_snapshot() {
         paparazzi.snapshot {
             NightfallTheme(darkTheme = false) {
                 BottomNavBar(
-                    selectedRoute = NavDestination.Trends.route,
+                    selectedRoute = NavDestination.Timeline.route,
                     onNavigate = {}
                 )
             }
@@ -115,7 +115,7 @@ class BottomNavBarTest {
                 )
             }
         }
-        // Contract: 4 tabs — Sommeil, Tendances, Activité, Profil
+        // Contract: 4 tabs — Sommeil, Timeline, Activité, Profil
         // spec: navigation graph section + BottomNavBar.kt livrable
     }
 }
@@ -130,5 +130,5 @@ class BottomNavBarTest {
 - `bottomNavBar_snapshot_dark` (function) — lines 28-40
 - `bottomNavBar_snapshot_light` (function) — lines 43-53
 - `bottomNavBar_sleepTabSelected` (function) — lines 56-68
-- `bottomNavBar_trendsTabSelected_snapshot` (function) — lines 71-81
+- `bottomNavBar_timelineTabSelected_snapshot` (function) — lines 71-81
 - `bottomNavBar_fourTabsPresent_dark` (function) — lines 85-97

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/navigation/NavGraphTest.kt
-git_blob: e95f969b6b8b20939ef4c8f6d19002d83fc032dd
-last_synced: '2026-05-09T04:03:35Z'
+git_blob: b9038b488b5c441a602a3bc442051f46a5a05193
+last_synced: '2026-05-09T07:04:02Z'
 loc: 246
 annotations: []
 imports: []
@@ -95,9 +95,9 @@ class NavGraphTest {
         }
     }
 
-    // spec: TA-03 — l'utilisateur tape sur l'onglet "Tendances" → TrendsScreen affiché
+    // spec: TA-03 — l'utilisateur tape sur l'onglet "Timeline" → TimelineScreen affiché
     @Test
-    fun navGraph_bottomNav_switchesToTrends() {
+    fun navGraph_bottomNav_switchesToTimeline() {
         val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
 
         composeTestRule.setContent {
@@ -109,11 +109,11 @@ class NavGraphTest {
             }
         }
 
-        // spec: TA-03 — bottom nav label "Tendances" must navigate to TrendsScreen
-        composeTestRule.onNodeWithText("Tendances").performClick()
+        // spec: TA-03 — bottom nav label "Timeline" must navigate to TimelineScreen
+        composeTestRule.onNodeWithText("Timeline").performClick()
 
-        assert(navController.currentDestination?.route == NavDestination.Trends.route) {
-            "Expected navigation to trends after clicking Tendances tab — spec: TA-03"
+        assert(navController.currentDestination?.route == NavDestination.Timeline.route) {
+            "Expected navigation to timeline after clicking Timeline tab — spec: TA-03"
         }
     }
 
@@ -277,7 +277,7 @@ class NavGraphTest {
 - `NavGraphTest` (class) — lines 28-246
 - `navGraph_noToken_navigatesToLogin` (function) — lines 35-53
 - `navGraph_withToken_navigatesToSleep` (function) — lines 56-73
-- `navGraph_bottomNav_switchesToTrends` (function) — lines 76-95
+- `navGraph_bottomNav_switchesToTimeline` (function) — lines 76-95
 - `navGraph_bottomNav_switchesToActivity` (function) — lines 98-117
 - `navGraph_bottomNav_switchesToProfile` (function) — lines 120-138
 - `navGraph_profileScreen_importButtonNavigatesToImport` (function) — lines 141-163

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.md
@@ -1,0 +1,592 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt
+git_blob: ea89fd1558f524a2aa6fc4abf20fad29f818e990
+last_synced: '2026-05-09T07:04:03Z'
+loc: 539
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+// spec: Tests d'acceptation TA-TL-01 à TA-TL-07, TA-TL-VM-01 à TA-TL-VM-05
+// spec: section "TimelineScreen" — états Loading/Success/Error/Empty, canvas multi-nuits, tri croissant, snapshots, ViewModel
+// RED by construction: the following classes do not exist yet and imports will fail at compile time:
+//   fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+//   fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
+//   fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen
+// Existing classes (will compile fine):
+//   fr.datasaillance.nightfall.data.sleep.SleepRepository
+//   fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.assertExists
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.performClick
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import fr.datasaillance.nightfall.data.sleep.SleepRepository
+import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import fr.datasaillance.nightfall.ui.theme.NightfallTheme
+
+// ---------------------------------------------------------------------------
+// Test fixtures — 3 sessions sur 3 nuits consécutives pour tester le tri et le drift
+// spec: TA-TL-VM-01/TA-TL-VM-05 — sessions avec sleep_start dans l'ordre aléatoire
+// ---------------------------------------------------------------------------
+
+// spec: TA-TL-VM-01 — session la plus ancienne (2026-05-05)
+private val session1 = SleepSessionResponse(
+    id          = "tl-001",
+    sleep_start = "2026-05-05T23:00:00+02:00",
+    sleep_end   = "2026-05-06T07:00:00+02:00",
+    created_at  = null,
+    stages      = null
+)
+
+// spec: TA-TL-VM-01 — session intermédiaire (2026-05-06)
+private val session2 = SleepSessionResponse(
+    id          = "tl-002",
+    sleep_start = "2026-05-06T23:45:00+02:00",
+    sleep_end   = "2026-05-07T07:30:00+02:00",
+    created_at  = null,
+    stages      = null
+)
+
+// spec: TA-TL-VM-01 — session la plus récente (2026-05-08) avec drift +90 min
+private val session3 = SleepSessionResponse(
+    id          = "tl-003",
+    sleep_start = "2026-05-08T00:30:00+02:00",
+    sleep_end   = "2026-05-08T08:15:00+02:00",
+    created_at  = null,
+    stages      = null
+)
+
+// spec: TA-TL-VM-05 — session3 avant session1 en ordre inversé pour tester que le ViewModel trie correctement
+private val sessionsUnsorted = listOf(session3, session1, session2)
+private val sessionsSorted   = listOf(session1, session2, session3)
+
+// ---------------------------------------------------------------------------
+// Helper: inject state into TimelineViewModel via reflection on _uiState
+// spec: pattern identique à injectHypnogramState dans HypnogramScreenTest
+// ---------------------------------------------------------------------------
+
+@Suppress("UNCHECKED_CAST")
+private fun injectTimelineState(
+    viewModel: fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel,
+    state: fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
+) {
+    val field = fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel::class.java
+        .getDeclaredField("_uiState")
+    field.isAccessible = true
+    (field.get(viewModel) as MutableStateFlow<fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState>)
+        .value = state
+}
+
+// ---------------------------------------------------------------------------
+// Class 1 — Paparazzi snapshot tests (no @RunWith — incompatible avec Robolectric)
+// spec: TA-TL-06, TA-TL-07 + états Loading/Error
+// ---------------------------------------------------------------------------
+
+class TimelineScreenSnapshotTest {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_5,
+        theme = "android:Theme.Material.Light.NoActionBar"
+    )
+
+    private fun buildViewModel(
+        repository: SleepRepository = mock<SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel(
+            repository = repository
+        )
+
+    // spec: TA-TL-06 — snapshot dark mode, état Success, ≥2 sessions avec drift visible
+    // spec: "fond #191E22, barres teal visibles sur le canvas, labels de date lisibles"
+    // RED by construction: TimelineScreen et TimelineViewModel n'existent pas encore
+    @Test
+    fun timelineScreen_success_dark() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-06 — TimelineScreen en dark mode, état Success avec 3 sessions
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: TA-TL-06 — golden dark: fond #191E22, barres teal (0xFF0E9EB0), labels date lisibles
+    }
+
+    // spec: TA-TL-07 — snapshot light mode, même état Success
+    // spec: "fond #FAFAFA, barres teal inchangées, labels sombres lisibles"
+    // RED by construction: TimelineScreen et TimelineViewModel n'existent pas encore
+    @Test
+    fun timelineScreen_success_light() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = false) {
+                // spec: TA-TL-07 — TimelineScreen en light mode, même état Success
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: TA-TL-07 — golden light: fond #FAFAFA, barres teal, labels sombres (onSurface = #1A1A1A)
+    }
+
+    // spec: état Loading — spinner visible, canvas absent
+    // RED by construction: TimelineUiState.Loading n'existe pas encore
+    @Test
+    fun timelineScreen_loading_dark() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Loading
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = true) {
+                // spec: état Loading → CircularProgressIndicator avec testTag "tl_loading"
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: snapshot dark Loading: indicateur de chargement centré, pas de canvas
+    }
+
+    // spec: état Error — message d'erreur + bouton retry visibles
+    // RED by construction: TimelineUiState.Error n'existe pas encore
+    @Test
+    fun timelineScreen_error_dark() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error("Vérifiez votre connexion réseau")
+        )
+
+        paparazzi.snapshot {
+            NightfallTheme(darkTheme = true) {
+                // spec: état Error → message d'erreur + bouton "Réessayer" avec testTags tl_error/tl_retry
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+        // spec: snapshot dark Error: "Vérifiez votre connexion réseau" visible, bouton retry présent
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 2 — Robolectric behavioral tests
+// spec: TA-TL-01, TA-TL-02, TA-TL-03, TA-TL-04, TA-TL-05
+// Classe séparée de Paparazzi : lifecycles de Rule incompatibles
+// ---------------------------------------------------------------------------
+
+// spec: TA-TL-01 — état Success → tl_canvas assertExists
+// spec: TA-TL-02 — état Loading → tl_loading assertExists, tl_canvas assertDoesNotExist
+// spec: TA-TL-03 — état Error → tl_error assertExists, tl_retry assertExists
+// spec: TA-TL-04 — état Empty → tl_empty assertExists
+// spec: TA-TL-05 — état Success → tl_screen assertExists
+// RED by construction: TimelineScreen, TimelineViewModel, TimelineUiState n'existent pas encore
+@RunWith(RobolectricTestRunner::class)
+class TimelineScreenInteractionTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun buildViewModel(
+        repository: SleepRepository = mock<SleepRepository>()
+    ): fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel =
+        fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel(
+            repository = repository
+        )
+
+    // spec: TA-TL-01 — état Success → tl_canvas assertExists dans la hiérarchie Compose
+    // RED: TimelineScreen n'a pas encore de testTag "tl_canvas"
+    @Test
+    fun timelineScreen_shows_canvas_in_success() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-01 — TimelineScreen avec ViewModel en état Success (3 sessions)
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-01 — canvas multi-nuits visible en état Success
+        composeTestRule
+            .onNode(hasTestTag("tl_canvas"))
+            .assertExists()
+    }
+
+    // spec: TA-TL-02 — état Loading → tl_loading assertExists, tl_canvas assertDoesNotExist
+    // RED: TimelineScreen n'a pas encore de testTag "tl_loading"
+    @Test
+    fun timelineScreen_shows_loading_and_hides_canvas() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Loading
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-02 — TimelineScreen avec ViewModel en état Loading
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-02 — CircularProgressIndicator visible
+        composeTestRule
+            .onNode(hasTestTag("tl_loading"))
+            .assertExists()
+
+        // spec: TA-TL-02 — canvas absent en état Loading (pas de données encore)
+        composeTestRule
+            .onNode(hasTestTag("tl_canvas"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-TL-03 — état Error → tl_error assertExists, tl_retry assertExists
+    // spec: "clic sur tl_retry déclenche TimelineViewModel.retry(), remet état à Loading"
+    // RED: TimelineScreen n'a pas encore de testTags "tl_error" / "tl_retry"
+    @Test
+    fun timelineScreen_shows_error_with_retry() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error("Vérifiez votre connexion réseau")
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-03 — TimelineScreen avec ViewModel en état Error
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-03 — bloc message d'erreur visible
+        composeTestRule
+            .onNode(hasTestTag("tl_error"))
+            .assertExists()
+
+        // spec: TA-TL-03 — bouton "Réessayer" visible en état Error
+        composeTestRule
+            .onNode(hasTestTag("tl_retry"))
+            .assertExists()
+    }
+
+    // spec: TA-TL-03 — clic sur tl_retry remet l'état à Loading
+    // RED: TimelineScreen tl_retry + retry() n'existe pas encore
+    @Test
+    fun timelineScreen_retry_click_triggers_reload() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error("Vérifiez votre connexion réseau")
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-03 — clic sur retry → retry() est appelé, état redevient Loading
+        composeTestRule
+            .onNode(hasTestTag("tl_retry"))
+            .performClick()
+
+        // spec: TA-TL-03 — après retry(), l'état est Loading (repository mock ne répond pas encore)
+        composeTestRule
+            .onNode(hasTestTag("tl_loading"))
+            .assertExists()
+    }
+
+    // spec: TA-TL-04 — état Empty → tl_empty assertExists, tl_canvas assertDoesNotExist
+    // spec: "tl_empty affiche le texte 'Aucune nuit enregistrée'"
+    // RED: TimelineScreen n'a pas encore de testTag "tl_empty"
+    @Test
+    fun timelineScreen_shows_empty_state() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Empty
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-04 — TimelineScreen avec ViewModel en état Empty
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-04 — message "Aucune nuit enregistrée" visible
+        composeTestRule
+            .onNode(hasTestTag("tl_empty"))
+            .assertExists()
+
+        // spec: TA-TL-04 — canvas absent en état Empty (pas de nuits à afficher)
+        composeTestRule
+            .onNode(hasTestTag("tl_canvas"))
+            .assertDoesNotExist()
+    }
+
+    // spec: TA-TL-05 — état Success → tl_screen assertExists (conteneur racine de l'état Success)
+    // RED: TimelineScreen n'a pas encore de testTag "tl_screen"
+    @Test
+    fun timelineScreen_root_exists_in_success() {
+        val viewModel = buildViewModel()
+        injectTimelineState(
+            viewModel,
+            fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success(sessionsSorted)
+        )
+
+        composeTestRule.setContent {
+            NightfallTheme(darkTheme = true) {
+                // spec: TA-TL-05 — TimelineScreen avec ViewModel en état Success
+                fr.datasaillance.nightfall.ui.screens.sleep.TimelineScreen(
+                    viewModel = viewModel
+                )
+            }
+        }
+
+        // spec: TA-TL-05 — conteneur Column racine de l'état Success existe
+        composeTestRule
+            .onNode(hasTestTag("tl_screen"))
+            .assertExists()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Class 3 — TimelineViewModel unit tests (pure JVM, pas de Compose)
+// spec: TA-TL-VM-01, TA-TL-VM-02, TA-TL-VM-03, TA-TL-VM-04, TA-TL-VM-05
+// ---------------------------------------------------------------------------
+
+// spec: TA-TL-VM-01 — repository retourne sessions → Success avec liste triée croissant
+// spec: TA-TL-VM-02 — repository retourne liste vide → Empty
+// spec: TA-TL-VM-03 — repository retourne failure(IOException) → Error
+// spec: TA-TL-VM-04 — après init{} sans advanceUntilIdle() → Loading (synchrone)
+// spec: TA-TL-VM-05 — Success.sessions triées par sleep_start croissant (pas décroissant)
+// RED by construction: TimelineViewModel et TimelineUiState n'existent pas encore
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimelineViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: SleepRepository
+    private lateinit var viewModel: fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+
+    @Before
+    fun setUp() {
+        // spec: TA-TL-VM-01 — viewModelScope utilise Dispatchers.Main ; remplacé par testDispatcher
+        Dispatchers.setMain(testDispatcher)
+        repository = mock()
+        // spec: DI manuelle — TimelineViewModel(repository), init{} déclenche loadSessions()
+        viewModel = fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel(
+            repository = repository
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // spec: TA-TL-VM-01 — repository retourne 3 sessions → uiState = Success avec liste triée croissant
+    // spec: "trie par sleep_start croissant (nuit la plus ancienne en premier)"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_success_with_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(sessionsUnsorted)
+        )
+
+        // spec: TA-TL-VM-01 — init{} appelle loadSessions() ; advanceUntilIdle() laisse la coroutine finir
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success) {
+            "uiState must be TimelineUiState.Success when repository returns sessions — spec: TA-TL-VM-01, got: $state"
+        }
+
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success).sessions
+        assert(sessions.isNotEmpty()) {
+            "Success.sessions must not be empty — spec: TA-TL-VM-01, got empty list"
+        }
+    }
+
+    // spec: TA-TL-VM-02 — repository retourne Result.success(emptyList()) → uiState = Empty
+    // spec: "Empty est un état distinct de Success(emptyList())"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_empty_when_no_sessions() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(emptyList())
+        )
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Empty) {
+            "uiState must be TimelineUiState.Empty when repository returns empty list — spec: TA-TL-VM-02, got: $state"
+        }
+    }
+
+    // spec: TA-TL-VM-03 — repository retourne Result.failure(IOException) → uiState = Error
+    // spec: mapError() — IOException → "Vérifiez votre connexion réseau"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_error_when_repository_fails() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.failure(java.io.IOException("Connection refused"))
+        )
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error) {
+            "uiState must be TimelineUiState.Error when repository returns failure — spec: TA-TL-VM-03, got: $state"
+        }
+
+        // spec: TA-TL-VM-03 — IOException → message "Vérifiez votre connexion réseau"
+        val message = (state as fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Error).message
+        assert(message == "Vérifiez votre connexion réseau") {
+            "Error.message must be 'Vérifiez votre connexion réseau' for IOException — spec: TA-TL-VM-03, got: '$message'"
+        }
+    }
+
+    // spec: TA-TL-VM-04 — après init{} et AVANT advanceUntilIdle() → uiState = Loading
+    // spec: "loadSessions() émet Loading en premier, avant tout appel réseau"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_emits_loading_synchronously_on_init() = runTest {
+        whenever(repository.getSessions()).thenReturn(
+            Result.success(sessionsUnsorted)
+        )
+
+        // spec: TA-TL-VM-04 — init{} appelle loadSessions() ; sans advanceUntilIdle() la coroutine
+        //   est suspendue à getSessions() et uiState doit déjà être Loading
+        val stateWhileInFlight = viewModel.uiState.value
+        assert(stateWhileInFlight is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Loading) {
+            "uiState must be TimelineUiState.Loading immediately after init{} — spec: TA-TL-VM-04, got: $stateWhileInFlight"
+        }
+
+        advanceUntilIdle()
+    }
+
+    // spec: TA-TL-VM-05 — Success.sessions sont triées par sleep_start croissant (pas décroissant comme SleepViewModel)
+    // spec: "la nuit la plus ancienne est à gauche sur l'axe temporel du canvas"
+    // RED: TimelineViewModel.loadSessions() n'existe pas encore
+    @Test
+    fun timelineViewModel_sessions_sorted_ascending_by_sleep_start() = runTest {
+        whenever(repository.getSessions()).thenReturn(Result.success(sessionsUnsorted))
+
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assert(state is fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success) {
+            "uiState must be TimelineUiState.Success — spec: TA-TL-VM-05, got: $state"
+        }
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState.Success).sessions
+
+        // spec: TA-TL-VM-05 — sleep_start: session1 (2026-05-05) < session2 (2026-05-06) < session3 (2026-05-08)
+        assert(sessions[0].id == "tl-001") {
+            "First must be tl-001 (oldest, 2026-05-05) — spec: TA-TL-VM-05, got ${sessions[0].id}"
+        }
+        assert(sessions[1].id == "tl-002") {
+            "Second must be tl-002 (2026-05-06) — spec: TA-TL-VM-05, got ${sessions[1].id}"
+        }
+        assert(sessions[2].id == "tl-003") {
+            "Third must be tl-003 (newest, 2026-05-08) — spec: TA-TL-VM-05, got ${sessions[2].id}"
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `injectTimelineState` (function) — lines 82-91
+- `TimelineScreenSnapshotTest` (class) — lines 98-198
+- `buildViewModel` (function) — lines 106-111
+- `timelineScreen_success_dark` (function) — lines 116-133
+- `timelineScreen_success_light` (function) — lines 138-155
+- `timelineScreen_loading_dark` (function) — lines 159-176
+- `timelineScreen_error_dark` (function) — lines 180-197
+- `TimelineScreenInteractionTest` (class) — lines 212-395
+- `buildViewModel` (function) — lines 218-223
+- `timelineScreen_shows_canvas_in_success` (function) — lines 227-248
+- `timelineScreen_shows_loading_and_hides_canvas` (function) — lines 252-278
+- `timelineScreen_shows_error_with_retry` (function) — lines 283-309
+- `timelineScreen_retry_click_triggers_reload` (function) — lines 313-338
+- `timelineScreen_shows_empty_state` (function) — lines 343-369
+- `timelineScreen_root_exists_in_success` (function) — lines 373-394
+- `TimelineViewModelTest` (class) — lines 409-539
+- `setUp` (function) — lines 415-424
+- `tearDown` (function) — lines 426-429
+- `timelineViewModel_emits_success_with_sessions` (function) — lines 434-452
+- `timelineViewModel_emits_empty_when_no_sessions` (function) — lines 457-469
+- `timelineViewModel_emits_error_when_repository_fails` (function) — lines 474-492
+- `timelineViewModel_emits_loading_synchronously_on_init` (function) — lines 497-511
+- `timelineViewModel_sessions_sorted_ascending_by_sleep_start` (function) — lines 516-538

--- a/docs/vault/specs/2026-05-09-p5-timeline.md
+++ b/docs/vault/specs/2026-05-09-p5-timeline.md
@@ -1,0 +1,540 @@
+---
+title: "P5.3 Dashboard — Timeline Circadienne"
+slug: p5-timeline
+phase: P5
+status: ready
+created: 2026-05-09
+branch: feat/p5-timeline
+tags: [android, compose, sleep, timeline, canvas, drift, non24, ui, p5, native]
+related_specs:
+  - 2026-05-09-p5-hypnogram
+  - 2026-05-08-p5-dashboard-cards
+implements:
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+  - android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
+  - android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+tested_by:
+  - android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt
+---
+
+# Spec P5.3 — Timeline Circadienne
+
+## Vision
+
+`TimelineScreen` est une vue multi-nuits : elle agrège toutes les sessions de sommeil disponibles sur un canvas vertical (une ligne par nuit, les heures en colonnes), permettant de visualiser le **drift circadien** — la dérive progressive des heures de coucher/réveil caractéristique du Non-24. C'est la visualisation qui rend le pattern invisible visible : une succession de barres qui glissent progressivement vers la droite ou la gauche révèle en un coup d'oeil ce qu'aucune liste de chiffres ne peut montrer. Elle remplace l'onglet `Trends` placeholder dans la `BottomNavBar`.
+
+---
+
+## Contexte et dépendances
+
+### Prérequis validés (P5.1 et P5.2 — doivent être mergés avant cette spec)
+
+Cette spec ne répète pas les contrats établis en P5.1/P5.2. Elle s'y branche sans les modifier.
+
+| Élément existant | Localisation | Rôle pour P5.3 |
+|---|---|---|
+| `SleepSessionResponse` | `data/sleep/SleepSessionResponse.kt` | Modèle consommé par `TimelineViewModel` — champs utilisés : `id`, `sleep_start`, `sleep_end` |
+| `SleepStageResponse` | `data/sleep/SleepStageResponse.kt` | Non utilisé en V1 (timeline plage complète uniquement) |
+| `SleepRepository` / `SleepRepositoryImpl` | `data/sleep/` | Interface réutilisée telle quelle — `getSessions()` sans paramètre de filtre de date |
+| `NavDestination` | `ui/navigation/NavDestination.kt` | Modifier : remplacer `object Trends` par `object Timeline`, ajouter à `bottomNavItems()` |
+| `NavGraph` | `ui/navigation/NavGraph.kt` | Modifier : ajouter route `timeline`, câbler `TimelineViewModel` + `TimelineScreen` |
+| `NightfallApi.getSleepSessions()` | `data/http/NightfallApi.kt` | Endpoint existant `GET /api/sleep?include_stages=false` — pas de changement |
+| `SleepUiState` sealed class | `viewmodel/sleep/SleepUiState.kt` | **Non réutilisée** — `TimelineUiState` est une sealed class distincte co-localisée dans `TimelineViewModel.kt` |
+| Thème `NightfallTheme` | `ui/theme/` | Aucune modification — tokens `primary`, `surface`, `onSurface`, `onBackground` réutilisés |
+
+### Backend — pas de nouvel endpoint
+
+`GET /api/sleep` (sans `include_stages`) suffit. Les stages ne sont pas affichés en V1 de la timeline. Le backend filtre par `user_id` via `Depends(get_current_user)` — l'utilisateur ne voit que ses propres sessions.
+
+### Décision de remplacement de `Trends`
+
+`object Trends` dans `NavDestination` n'a aucun contenu associé (écran placeholder). `Timeline` prend sa place dans la `BottomNavBar` (4 onglets conservés : Sleep, Timeline, Activity, Profile). L'icône Material `Icons.Outlined.CalendarViewWeek` ou `Icons.Outlined.BarChart` sera utilisée — à confirmer à l'impl selon disponibilité dans la version Material Icons du projet.
+
+---
+
+## Architecture
+
+### Vue d'ensemble des fichiers
+
+```
+android-app/app/src/main/java/fr/datasaillance/nightfall/
+├── ui/navigation/
+│   ├── NavDestination.kt        [MODIFIER — remplacer Trends par Timeline, ajouter à bottomNavItems()]
+│   └── NavGraph.kt              [MODIFIER — ajouter route "timeline" + TimelineViewModel + TimelineScreen]
+└── viewmodel/sleep/
+    └── TimelineViewModel.kt     [CRÉER — TimelineUiState sealed + TimelineViewModel]
+
+android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/
+└── TimelineScreen.kt            [CRÉER — TimelineScreen + TimelineCanvas (composant interne privé)]
+
+android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/
+└── TimelineScreenTest.kt        [CRÉER — Paparazzi snapshots + Robolectric tests]
+```
+
+### Règle de placement des fichiers
+
+- `TimelineViewModel.kt` → `src/main/java/` : partagé entre les flavors (même pattern que `SleepViewModel`, `HypnogramViewModel`).
+- `TimelineScreen.kt` → `src/native/java/` : spécifique à la flavor native (même pattern que `SleepScreen`, `HypnogramScreen`).
+- `NavDestination.kt`, `NavGraph.kt` → `src/main/java/` : inchangé de position, déjà dans le bon répertoire.
+
+### Modifications des fichiers existants
+
+#### `NavDestination.kt` — remplacement de `Trends` par `Timeline`
+
+Supprimer `object Trends` et le remplacer par :
+
+```kotlin
+object Timeline : NavDestination("timeline", "Timeline")
+```
+
+Mettre à jour `bottomNavItems()` :
+
+```kotlin
+fun bottomNavItems(): List<NavDestination> = listOf(Sleep, Timeline, Activity, Profile)
+```
+
+`Timeline` est un onglet principal (pas un écran de détail) — il apparaît donc dans la `BottomNavBar`. Contrairement à `Hypnogram`, il ne porte pas de paramètre de route.
+
+#### `NavGraph.kt` — ajout de la route `timeline`
+
+```kotlin
+composable(route = NavDestination.Timeline.route) {
+    val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
+        if (api != null && tokenDataStore != null) {
+            SleepRepositoryImpl(api, tokenDataStore)
+        } else {
+            NoOpSleepRepository()
+        }
+    }
+    val timelineViewModel = remember(timelineRepository) {
+        TimelineViewModel(timelineRepository)
+    }
+    TimelineScreen(viewModel = timelineViewModel)
+}
+```
+
+Imports nécessaires : `TimelineViewModel`, `TimelineScreen`.
+
+---
+
+## ViewModel — `TimelineViewModel`
+
+### `TimelineUiState`
+
+Sealed class co-localisée dans `TimelineViewModel.kt`.
+
+```kotlin
+sealed class TimelineUiState {
+    object Idle    : TimelineUiState()
+    object Loading : TimelineUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : TimelineUiState()
+    data class Empty  : TimelineUiState()
+    data class Error(val message: String) : TimelineUiState()
+}
+```
+
+`Empty` est un état distinct de `Success(emptyList())` — cohérent avec `SleepUiState` en P5.1. `Success` transporte une liste déjà triée par `sleep_start` croissant (nuit la plus ancienne en premier, contrairement à `SleepViewModel` qui trie décroissant).
+
+### Signature et comportement
+
+```kotlin
+class TimelineViewModel(
+    private val repository: SleepRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
+    val uiState: StateFlow<TimelineUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSessions()
+    }
+
+    fun retry() = loadSessions()
+
+    private fun loadSessions() { ... }
+    private fun mapError(throwable: Throwable?): String { ... }
+}
+```
+
+**`loadSessions()` :**
+1. Émet `Loading`.
+2. Appelle `repository.getSessions()` (sans `include_stages` — les stages ne sont pas nécessaires en V1).
+3. Si `Result.isFailure` → émet `Error(mapError(...))`.
+4. Si la liste est vide → émet `Empty`.
+5. Sinon → trie par `sleep_start` croissant (via `OffsetDateTime.parse`) et émet `Success(sortedList)`.
+
+**`mapError()` :** identique aux ViewModels P5.1/P5.2 — 401 `"Session expirée, reconnectez-vous"`, 403 `"Accès refusé"`, `IOException` `"Vérifiez votre connexion réseau"`, autre `"Erreur serveur (code)"`.
+
+**Note sur le tri croissant :** contrairement à `SleepViewModel` (nuit la plus récente en haut de liste), `TimelineViewModel` trie croissant — la nuit la plus ancienne est à gauche sur l'axe temporel du canvas. Ce choix est cohérent avec la convention de lecture gauche-droite d'une timeline.
+
+---
+
+## UI Compose — `TimelineScreen`
+
+### Signature
+
+```kotlin
+@Composable
+fun TimelineScreen(
+    viewModel: TimelineViewModel
+)
+```
+
+Pas de paramètre `onBack` — c'est un écran racine de la `BottomNavBar`, pas un écran de détail.
+
+### Structure générale
+
+```
+Surface(color = MaterialTheme.colorScheme.background, modifier = fillMaxSize)
+└── Scaffold
+    ├── TopAppBar
+    │   ├── title: Text("Drift circadien", style = headlineMedium)
+    │   └── colors: TopAppBarDefaults.topAppBarColors(containerColor = background)
+    └── content (padding innerPadding)
+        ├── [Idle]    → rien (cohérent avec le pattern SleepScreen / HypnogramScreen)
+        ├── [Loading] → Box(fillMaxSize, centerAlign) { CircularProgressIndicator }
+        │               testTag = "tl_loading"
+        ├── [Error]   → Box(fillMaxSize, centerAlign) { Column { Text(message) + OutlinedButton("Réessayer") } }
+        │               testTag = "tl_error" / "tl_retry"
+        ├── [Empty]   → Box(fillMaxSize, centerAlign) { Text("Aucune nuit enregistrée") }
+        │               testTag = "tl_empty"
+        └── [Success] → Column(fillMaxSize, modifier.testTag("tl_screen"))
+                        ├── TimelineAxisHeader(sessions)     // en-tête heures fixes (00h→23h)
+                        └── VerticalScroll → TimelineCanvas(sessions)
+                                             testTag = "tl_canvas"
+```
+
+### `TimelineAxisHeader`
+
+Composant privé affiché en position sticky au-dessus du canvas scrollable. Affiche les graduations d'heures de la fenêtre temporelle calculée (voir section Algorithme). Hauteur fixe : 24.dp. Police `bodySmall`, couleur `onSurface.copy(alpha = 0.6f)`.
+
+---
+
+## Composant Canvas — `TimelineCanvas`
+
+### Décision de rendu : `Canvas { }` de Compose
+
+Identique au pattern `HypnogramCanvas` (P5.2). Un `Canvas` Compose (`androidx.compose.foundation.Canvas`) est utilisé pour dessiner toutes les nuits. Aucun autre composant de dessin n'est introduit.
+
+### Signature
+
+```kotlin
+@Composable
+private fun TimelineCanvas(
+    sessions: List<SleepSessionResponse>,
+    modifier: Modifier = Modifier
+)
+```
+
+Déclaré `private` dans `TimelineScreen.kt`.
+
+### Dimensions et layout
+
+```kotlin
+modifier = Modifier
+    .fillMaxWidth()
+    .height((sessions.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp)
+    .testTag("tl_canvas")
+```
+
+Constantes locales :
+
+```kotlin
+private const val ROW_HEIGHT_DP  = 40   // hauteur d'une ligne de nuit (dp)
+private const val BAR_HEIGHT_DP  = 24   // hauteur de la barre de sommeil dans la ligne (dp)
+private const val AXIS_BOTTOM_DP = 24   // zone axe X heures en bas du canvas
+private const val LABEL_WIDTH_DP = 48   // largeur réservée à gauche pour le label de date
+```
+
+Le canvas est rendu à l'intérieur d'un `verticalScroll(rememberScrollState())` — c'est le scroll Compose standard, pas de `LazyColumn` custom.
+
+---
+
+## Algorithme de dessin
+
+### 1. Calcul de la fenêtre temporelle (axe Y = 24h)
+
+La fenêtre Y n'est pas fixe 00h-24h. Elle est calculée dynamiquement à partir des sessions pour que le drift soit lisible sans espace mort excessif.
+
+```
+Algorithme fenêtre Y :
+1. Pour chaque session, extraire l'heure-minute de sleep_start et sleep_end
+   (ignorer la date, garder seulement le temps dans la journée)
+2. Calculer la médiane des heures de sleep_start → medianSleepHour (en minutes depuis minuit)
+3. windowStart = medianSleepHour - 120 minutes (marge 2h avant le coucher médian)
+4. windowEnd   = windowStart + 16 * 60 minutes (fenêtre de 16h)
+   Si windowEnd > 1440 → fenêtre wrap-around sur minuit (cas Non-24 extrême)
+5. Clamp : windowStart minimum = 0 (00:00), windowEnd maximum = 1440 (24:00)
+   → En V1, pas de wrap-around : si la fenêtre dépasse 24h, elle est tronquée à 24h.
+   Le wrap-around est noté comme évolution P5.3.1.
+```
+
+**Résultat :** `windowStartMinutes: Int` et `windowEndMinutes: Int` (exprimés en minutes depuis minuit).
+
+La **largeur effective du canvas** pour les barres est :
+
+```
+drawableWidth = canvasWidth - LABEL_WIDTH_DP.dp.toPx()
+```
+
+### 2. Calcul des coordonnées pixel pour chaque session
+
+Pour chaque session `i` (0-indexé, trié croissant) :
+
+```
+// Axe X (horizontal = axe des heures 24h)
+sleepStartMinutes = heure-minute de sleep_start en minutes depuis minuit
+sleepEndMinutes   = heure-minute de sleep_end en minutes depuis minuit
+// Si sleepEndMinutes < sleepStartMinutes → session à cheval sur minuit → sleepEndMinutes += 1440
+
+windowDurationMinutes = windowEndMinutes - windowStartMinutes
+
+barLeft  = LABEL_WIDTH_DP.dp.toPx() + ((sleepStartMinutes - windowStartMinutes).toFloat()
+           / windowDurationMinutes) * drawableWidth
+barRight = LABEL_WIDTH_DP.dp.toPx() + ((sleepEndMinutes   - windowStartMinutes).toFloat()
+           / windowDurationMinutes) * drawableWidth
+
+// Axe Y (vertical = lignes de nuits, haut = ancienne, bas = récente)
+rowTop    = i * ROW_HEIGHT_DP.dp.toPx()
+barTop    = rowTop + (ROW_HEIGHT_DP - BAR_HEIGHT_DP).dp.toPx() / 2f
+barBottom = barTop + BAR_HEIGHT_DP.dp.toPx()
+```
+
+**Edge case sessions à cheval sur minuit :** si `sleepEndMinutes < sleepStartMinutes` (ex : coucher 23h, réveil 06h), ajouter 1440 à `sleepEndMinutes` avant le calcul. Si la barre résultante dépasse `canvasWidth`, la tronquer à `canvasWidth` (clamp, pas de dessin hors canvas).
+
+**Edge case barre hors fenêtre :** si `sleepStartMinutes < windowStartMinutes` ou `sleepEndMinutes > windowEndMinutes`, la barre est tronquée aux limites de la fenêtre (clamp). La session reste représentée, même partiellement.
+
+### 3. Rendu de chaque barre
+
+```kotlin
+drawRect(
+    color   = ColorSleepBar,    // teal primary — voir tokens
+    topLeft = Offset(barLeft, barTop),
+    size    = Size(barRight - barLeft, BAR_HEIGHT_DP.dp.toPx())
+)
+```
+
+### 4. Labels de date (axe Y gauche)
+
+Pour chaque session `i`, dans la zone `LABEL_WIDTH_DP` à gauche :
+
+```kotlin
+val label = shortDateLabel(session.sleep_start)  // ex: "7 mai", "12 jun"
+drawContext.canvas.nativeCanvas.drawText(
+    label,
+    LABEL_PADDING_LEFT.dp.toPx(),   // LABEL_PADDING_LEFT = 4
+    rowTop + ROW_HEIGHT_DP.dp.toPx() / 2f + textSizeHalf,
+    paint  // textSize = 10.sp.toPx(), color = onSurface.copy(0.6f).toArgb()
+)
+```
+
+`shortDateLabel` : `OffsetDateTime.parse(sleep_start).format(DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH))`.
+
+### 5. Graduations horaires (axe X bas)
+
+Dans la zone `AXIS_BOTTOM_DP` en bas du canvas :
+
+- Calculer les heures pleines H entre `windowStartMinutes / 60` et `windowEndMinutes / 60`.
+- Pour chaque heure H :
+  - `x = LABEL_WIDTH_DP.dp.toPx() + ((H * 60 - windowStartMinutes).toFloat() / windowDurationMinutes) * drawableWidth`
+  - Trait vertical court : `drawLine(onSurface.copy(0.2f), Offset(x, canvasHeight - AXIS_BOTTOM_DP.dp.toPx()), Offset(x, canvasHeight - AXIS_BOTTOM_DP.dp.toPx() + 4.dp.toPx()))`
+  - Label : `"HH:00"` — `drawContext.canvas.nativeCanvas.drawText(...)` avec `textSize = 9.sp.toPx()`, `color = onSurface.copy(0.5f).toArgb()`
+- Afficher une graduation toutes les 2h si la fenêtre est >= 12h (éviter la surcharge visuelle).
+
+### 6. Ligne de référence médiane (optionnelle V1)
+
+Une ligne verticale fine pointillée à l'heure de la médiane des `sleep_start` peut être dessinée pour ancrer visuellement le "centre" du drift. En V1 : désactivé (non implémenté) pour garder le canvas simple. Noté comme évolution P5.3.2.
+
+---
+
+## Design tokens Compose
+
+Aucune modification du thème `NightfallTheme`. Tous les tokens sont réutilisés depuis P5.1/P5.2.
+
+| Rôle Material 3 | Dark mode | Light mode |
+|---|---|---|
+| `background` | `#191E22` | `#FAFAFA` |
+| `surface` | `#232E32` | `#FFFFFF` |
+| `primary` | `#0E9EB0` | `#0E9EB0` |
+| `onBackground` | `#FFFFFF` | `#1A1A1A` |
+| `onSurface` | `#E0E0E0` | `#1A1A1A` |
+
+### Couleurs canvas (constantes locales dans `TimelineScreen.kt`)
+
+| Constante | Valeur HEX | Usage |
+|---|---|---|
+| `ColorSleepBar` | `Color(0xFF0E9EB0)` | Barre de chaque nuit (teal = `primary`) |
+
+La couleur est unique pour toutes les nuits en V1. Le drift est lisible par la position des barres, pas par leur couleur. Une palette de dégradé temporel est notée comme évolution P5.3.3.
+
+### Typographie
+
+| Style Material 3 | Usage dans Timeline |
+|---|---|
+| `headlineMedium` | Titre TopAppBar "Drift circadien" |
+| `bodySmall` | Labels de date (axe Y), graduations horaires (axe X) |
+
+Police : système (Roboto), aucune police custom.
+
+---
+
+## Test IDs (testTag Compose)
+
+| Composant | testTag | Condition d'affichage |
+|---|---|---|
+| Écran racine (état Success) | `tl_screen` | état `Success` |
+| Canvas multi-nuits | `tl_canvas` | état `Success` |
+| Spinner chargement | `tl_loading` | état `Loading` |
+| Bloc erreur | `tl_error` | état `Error` |
+| Bouton "Réessayer" | `tl_retry` | état `Error` |
+| Message vide | `tl_empty` | état `Empty` |
+
+Application via `Modifier.testTag("...")` — pattern identique à `SleepScreen` et `HypnogramScreen`.
+
+---
+
+## Tests d'acceptation
+
+### TA-TL-01 — Canvas visible en état Success avec au moins 1 session
+
+**Given** `TimelineViewModel` est en état `Success` avec une liste de 3 sessions,  
+**when** `TimelineScreen` est composé,  
+**then** `testTag = "tl_canvas"` existe dans la hiérarchie de composants et `testTag = "tl_screen"` est visible.
+
+### TA-TL-02 — Loading spinner visible pendant le chargement
+
+**Given** `TimelineViewModel` est en état `Loading`,  
+**when** `TimelineScreen` est composé,  
+**then** `testTag = "tl_loading"` est visible, `testTag = "tl_canvas"` n'existe pas, `testTag = "tl_screen"` n'existe pas.
+
+### TA-TL-03 — État Error — message et retry
+
+**Given** `TimelineViewModel` est en état `Error("Vérifiez votre connexion réseau")`,  
+**when** `TimelineScreen` est composé,  
+**then** `testTag = "tl_error"` est visible avec le message d'erreur, `testTag = "tl_retry"` est visible. Un clic sur `tl_retry` déclenche `TimelineViewModel.retry()`, ce qui remet l'état à `Loading`.
+
+### TA-TL-04 — État Empty — message dédié
+
+**Given** `TimelineViewModel` est en état `Empty`,  
+**when** `TimelineScreen` est composé,  
+**then** `testTag = "tl_empty"` est visible avec le texte `"Aucune nuit enregistrée"`, `testTag = "tl_canvas"` n'existe pas.
+
+### TA-TL-05 — Ratio de position X d'une session sur le canvas
+
+**Given** une session avec `sleep_start` à 22h00 et `sleep_end` à 06h00 (lendemain), fenêtre calculée de 20h00 à 10h00 (fenêtre 14h),  
+**when** `TimelineCanvas` est composé avec cette session unique,  
+**then** la barre commence à environ `(120 / 840) * drawableWidth` pixels depuis le bord gauche (after `LABEL_WIDTH_DP`) et s'étend sur environ `(480 / 840) * drawableWidth` pixels de large. Tolérance : ±5% de la largeur du canvas.
+
+**Note implémentation :** ce test vérifie la logique algorithmique du ViewModel/calcul de coordonnées, pas le rendu pixel. Il peut être implémenté comme un test unitaire pur sur la fonction de calcul des coordonnées.
+
+### TA-TL-06 — Snapshot Paparazzi dark mode
+
+**Given** `TimelineScreen` composé sous `NightfallTheme(darkTheme = true)` avec `TimelineViewModel` en état `Success` (5 sessions fictives couvrant un drift visible de ~2h sur 5 nuits),  
+**when** Paparazzi génère un screenshot sur `DeviceConfig.PIXEL_5`,  
+**then** le screenshot correspond au golden de référence (fond `#191E22`, barres teal visibles sur le canvas, labels de date lisibles).
+
+### TA-TL-07 — Snapshot Paparazzi light mode
+
+**Given** même état `Success` que TA-TL-06,  
+**when** Paparazzi génère un screenshot sous `NightfallTheme(darkTheme = false)`,  
+**then** le screenshot correspond au golden de référence (fond `#FAFAFA`, barres teal inchangées, labels sombres lisibles).
+
+### TA-TL-VM-01 — ViewModel émet Success avec sessions triées croissant
+
+**Given** le repository retourne 3 sessions avec des `sleep_start` dans l'ordre aléatoire (2026-05-07, 2026-05-05, 2026-05-09),  
+**when** `TimelineViewModel` termine son `loadSessions()`,  
+**then** `uiState` est `Success` et `sessions` est triée par `sleep_start` croissant : [2026-05-05, 2026-05-07, 2026-05-09].
+
+### TA-TL-VM-02 — ViewModel émet Empty si liste vide
+
+**Given** le repository retourne `Result.success(emptyList())`,  
+**when** `TimelineViewModel` termine son `loadSessions()`,  
+**then** `uiState` est `Empty`.
+
+### TA-TL-VM-03 — ViewModel émet Error si repository failure
+
+**Given** le repository retourne `Result.failure(IOException())`,  
+**when** `TimelineViewModel` termine son `loadSessions()`,  
+**then** `uiState` est `Error("Vérifiez votre connexion réseau")`.
+
+### TA-TL-VM-04 — Edge case : session à cheval sur minuit
+
+**Given** une session avec `sleep_start = "2026-05-07T23:15:00+02:00"` et `sleep_end = "2026-05-08T06:38:00+02:00"`,  
+**when** le ViewModel calcule les données pour la timeline,  
+**then** aucune exception n'est levée et la session apparaît dans la liste `Success` (la date-clé de la nuit correspond au jour de `sleep_start`).
+
+### TA-TL-VM-05 — Edge case : une seule session
+
+**Given** le repository retourne 1 session unique,  
+**when** `TimelineViewModel` termine son `loadSessions()`,  
+**then** `uiState` est `Success` avec une liste de 1 élément (pas `Empty`, pas d'erreur). Le canvas doit s'afficher sans planter même avec une fenêtre calculée sur un seul point.
+
+---
+
+## Logging Android (Timber)
+
+Aucune valeur de santé brute dans les logs (conformité C2 : pas de `sleep_start`, pas de `sleep_end`, pas de durées en clair).
+
+| Événement | Niveau | Champs |
+|---|---|---|
+| Début chargement sessions timeline | `d` | `scope=timeline_vm` |
+| Chargement réussi | `d` | `scope=timeline_vm`, `count=N` |
+| Erreur HTTP | `w` | `scope=timeline_vm`, `http_code=N` |
+| Erreur réseau | `w` | `scope=timeline_vm`, `error=IOException` |
+| Fenêtre temporelle calculée | `d` | `scope=timeline_canvas`, `window_start_h=H`, `window_end_h=H` (heures entières, pas de timestamps) |
+
+---
+
+## RGPD
+
+- **Aucun cache local** des sessions côté Android — pas de Room, pas de SharedPreferences. Chaque ouverture de `TimelineScreen` effectue un appel réseau frais. Conforme contrainte C2.
+- Le tri et les calculs de fenêtre sont effectués entièrement côté Android, en mémoire, sans persistance.
+- La fenêtre temporelle calculée (heures entières, sans date) peut apparaître dans les logs — elle ne constitue pas une donnée de santé directe.
+- Les données sont filtrées côté backend par `user_id` via `Depends(get_current_user)`.
+- Le token JWT est lu depuis `EncryptedSharedPreferences` via `TokenDataStore` — chiffrement AES-256-GCM au repos, conforme C2.
+
+---
+
+## Décisions techniques
+
+| Décision | Choix retenu | Raison |
+|---|---|---|
+| Orientation de l'axe principal | Vertical scroll — une ligne par nuit, colonnes = heures | La VISION décrit "stacked timeline" avec nuits empilées. Le scroll vertical est naturel sur mobile (même pattern que les listes). L'axe X (heures) reste fixe en largeur d'écran. |
+| Fenêtre temporelle Y | Dynamique : médiane `sleep_start` ±2h + fenêtre de 16h | Une fenêtre fixe 00h-24h est inefficace (beaucoup d'espace mort). Le Non-24 casse toute fenêtre fixe calée sur le calendrier. La médiane center la vue sur la plage de sommeil effective. |
+| Granularité des barres | Plage coucher→réveil uniquement (1 rect par nuit, sans stages) | Suffisant pour visualiser le drift. Moins de complexité qu'un mini-hypnogramme. Les stages restent visibles dans `HypnogramScreen` (P5.2). |
+| Couleur des barres | Unique : teal `#0E9EB0` | Le drift est lisible par la position, pas la couleur. Une palette dégradée (évolution P5.3.3) serait un ajout esthétique, pas fonctionnel en V1. |
+| Onglet BottomNavBar | Remplace `Trends` (placeholder sans contenu) | Conserver 4 onglets. `Trends` n'a aucun écran associé — le remplacer par `Timeline` est non-destructif et apporte immédiatement de la valeur. |
+| Chargement des données | Même `SleepRepository.getSessions()` que P5.1/P5.2, `include_stages=false` | Pas de nouvel endpoint. Les stages ne sont pas utilisés en V1. Réduire le payload réseau. |
+| `TimelineUiState` séparée | Sealed class distincte de `SleepUiState`, co-localisée dans `TimelineViewModel.kt` | Évite le couplage entre les deux ViewModels. `TimelineUiState.Success` trie croissant — l'opposé de `SleepUiState.Success`. Co-localiser évite un fichier supplémentaire pour une complexité non justifiée. |
+| Canvas Compose | `androidx.compose.foundation.Canvas` | Même bibliothèque que `HypnogramCanvas` (P5.2). Positionnement pixel-parfait par calcul flottant. Pas de dépendance supplémentaire. |
+| Scroll du canvas | `verticalScroll(rememberScrollState())` wrappant le Canvas | Pattern standard Compose pour un canvas de taille dynamique. `LazyColumn` ne s'applique pas à un Canvas monolithique. |
+| Wrap-around minuit | Différé (P5.3.1) | En V1, clamp à [00h, 24h]. Le cas Non-24 extrême (coucher à 23h30, réveil à 08h) est géré par clamp — la barre est visible mais potentiellement tronquée. Le wrap-around est une évolution documentée. |
+
+---
+
+## Évolutions différées
+
+| ID | Description | Priorité |
+|---|---|---|
+| P5.3.1 | Wrap-around minuit sur le canvas (sessions à cheval sur deux jours affichées sans troncature) | Moyenne |
+| P5.3.2 | Ligne de référence médiane pointillée sur le canvas (ancre visuelle du drift) | Basse |
+| P5.3.3 | Dégradé temporel des couleurs de barres (heatmap chronologique) | Basse |
+| P5.3.4 | Colorisation weekend (samedi/dimanche) pour repérer les patterns hebdomadaires (mentionné dans VISION.md) | Moyenne |
+| P5.3.5 | Sticky header des graduations horaires au scroll (actuellement fixe en bas du canvas) | Haute |
+
+---
+
+## Livrables
+
+- [ ] `NavDestination.kt` — remplacement `object Trends` par `object Timeline`, mise à jour `bottomNavItems()`
+- [ ] `NavGraph.kt` — ajout route `"timeline"`, câblage `TimelineViewModel` + `TimelineScreen`
+- [ ] `TimelineViewModel.kt` — `TimelineUiState` (sealed, co-localisé) + `TimelineViewModel` (init, loadSessions, retry, mapError)
+- [ ] `TimelineScreen.kt` — `TimelineScreen` + `TimelineAxisHeader` (privé) + `TimelineCanvas` (privé) + constantes de layout
+- [ ] `TimelineScreenTest.kt` — classes `TimelineSnapshotTest` (Paparazzi TA-TL-06/07) + `TimelineInteractionTest` (Robolectric TA-TL-01 à TA-TL-05) + `TimelineViewModelTest` (JUnit TA-TL-VM-01 à TA-TL-VM-05)
+
+---
+
+## Suite naturelle
+
+**P5.4 — Radial Clock** : vue polaire 24h, un arc par nuit représentant la plage heure coucher → heure réveil. Le drift se lit comme une rotation progressive de l'arc sur le cadran. Les données sont les mêmes (`SleepSessionResponse.sleep_start` + `sleep_end`). L'algorithme de dessin passe de coordonnées cartésiennes (timeline) à des coordonnées polaires (radial). Le pattern `Canvas { }`, `ViewModel`, et la route de navigation suivent exactement la même structure que P5.3.


### PR DESCRIPTION
## Summary

- `TimelineViewModel` : sealed `TimelineUiState` (Idle/Loading/Success/Empty/Error), tri croissant `sleep_start`, Loading synchrone avant `viewModelScope.launch`
- `TimelineScreen` : Scaffold + TopAppBar "Drift circadien", Canvas multi-nuits avec fenêtre Y dynamique (médiane ±2h, 16h, clamp V1), `TimelineAxisHeader`, graduations X horaires, labels date
- `NavDestination.Trends` → `NavDestination.Timeline` ; BottomNavBar + `bottomNavItems()` mis à jour
- `NavGraph` : route `timeline` câblée ; `authViewModel` fallback non-null via `LocalContext` + `NoOpNightfallApi` (suppression des guards `if(authViewModel != null)` sur les écrans auth)
- 15 nouveaux tests GREEN (Paparazzi ×4, Robolectric ×6, ViewModel pur ×5) ; total 150/0

## Test plan

- [ ] `./gradlew :app:testNativeDebugUnitTest` → 150 tests / 0 failures
- [ ] `TimelineViewModelTest` — Success tri croissant, Empty, Error IOException, Loading synchrone, ordre sessions
- [ ] `TimelineScreenInteractionTest` — tl_canvas (Success), tl_loading+no canvas (Loading), tl_error+tl_retry (Error), retry click → Loading, tl_empty (Empty), tl_screen (Success)
- [ ] `TimelineScreenSnapshotTest` — golden dark Success, light Success, dark Loading, dark Error
- [ ] Vérifier onglet "Timeline" dans BottomNavBar remplace "Tendances"
- [ ] Vérifier `navGraph_login_screen_shows_real_loginscreen` GREEN (authViewModel fallback)