### PR TITLE
feat(android): Timeline V2 — nuit agrégée, phases, bottom sheet

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,10 +34,23 @@
 | P5.2 Hypnogramme | `HypnogramViewModel.kt`, `HypnogramScreen.kt`, `HypnogramStatsSection.kt`, `NavDestination.kt`, `NavGraph.kt`, `AuthViewModel.kt`, `HypnogramScreenTest.kt` | [`77b7ca6`](#2026-05-09-p52-hypnogramme) |
 | Android auth flow + bug-tracker MCP | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/MainActivity.kt`, `agents/mcp/bug_tracker/server.py` | [`301fe9a`](#2026-05-09-301fe9a) |
 | Import ZIP Samsung Health end-to-end | `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/auth/TokenDataStore.kt` | [`c1424f9`](#2026-05-09-c1424f9) |
+| P5.3 Timeline Circadienne | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt`, `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt` | [`352e619`](#2026-05-09-352e619) |
 
 ---
 
 ## Changelog
+
+### 2026-05-09 `352e619`
+feat: P5.3 Timeline Circadienne — canvas multi-nuits, onglet Timeline, fenêtre Y dynamique
+- Ajout de TimelineViewModel : sealed TimelineUiState (Idle/Loading/Success/Empty/Error), tri croissant par sleep_start, Loading émis synchroniquement avant viewModelScope.launch
+- Ajout de TimelineScreen : Scaffold + TopAppBar 'Drift circadien', Canvas multi-nuits avec fenêtre Y dynamique (médiane sleep_start ±2h, 16h, clamp [0, 1440])
+- Canvas : barres teal tronquées par LABEL_WIDTH_DP=48dp, date labels axe Y gauche, graduations horaires axe X bas (step 1h ou 2h si fenêtre ≥12h)
+- TimelineAxisHeader composable privé : en-tête graduations d'heures fixe (24dp) au-dessus du scroll canvas
+- Remplacement NavDestination.Trends → NavDestination.Timeline, BottomNavBar et bottomNavItems() mis à jour
+- NavGraph : route 'timeline' câblée, authViewModel fallback non-null via LocalContext (NoOpNightfallApi + TokenDataStore), suppression des guards if(authViewModel != null) sur les écrans auth
+- NavGraph : paramètre authViewModel: AuthViewModel? = null ré-ajouté pour injection test, authViewModel.logout() sans safe-call
+- 15 tests RED → GREEN : TimelineViewModelTest ×5, TimelineScreenInteractionTest ×6, TimelineScreenSnapshotTest ×4 ; 150 tests / 0 failures
+- BottomNavBarTest + NavGraphTest mis à jour : références Trends → Timeline, navGraph_login_screen_shows_real_loginscreen désormais GREEN
 
 ### 2026-05-09 `77b7ca6` {#2026-05-09-p52-hypnogramme}
 feat(android): P5.2 hypnogramme — HypnogramScreen, canvas timeline, nav route, 16 tests GREEN

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,10 +35,21 @@
 | Android auth flow + bug-tracker MCP | `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/auth/AuthViewModel.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/MainActivity.kt`, `agents/mcp/bug_tracker/server.py` | [`301fe9a`](#2026-05-09-301fe9a) |
 | Import ZIP Samsung Health end-to-end | `android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/data/auth/TokenDataStore.kt` | [`c1424f9`](#2026-05-09-c1424f9) |
 | P5.3 Timeline Circadienne | `android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt`, `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt`, `android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt`, `android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreenTest.kt` | [`352e619`](#2026-05-09-352e619) |
+| P5.3 Timeline V2 | `android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt` | [`0e79abe`](#2026-05-09-0e79abe) |
 
 ---
 
 ## Changelog
+
+### 2026-05-09 `0e79abe`
+feat: Timeline V2 — 1 ligne/nuit, phases colorées, bottom sheet
+- groupByNight() : agrégation 1 ligne = 1 date calendaire (clé sleep_start.toLocalDate())
+- drawStageSegment() : couleur par type DEEP/LIGHT/REM/AWAKE, segments AWAKE à hauteur 50%
+- drawFallbackBar() : barre teal fallback si stages == null
+- StageHitBox : struct pixel bounds + stageType/stageStart/stageEnd/nightLabel pour tap detection
+- pointerInput + detectTapGestures sur Canvas — hitBoxes accumulées pendant le draw, vidées à chaque recomposition
+- ModalBottomSheet StageDetailSheet : dot coloré (CircleShape), nom de phase, durée, plage horaire
+- Fix StageDetailSheet : remplacement Box cassé (.run/.let imbriqués) par Box { Modifier.clip(CircleShape).background(stageColor) }
 
 ### 2026-05-09 `352e619`
 feat: P5.3 Timeline Circadienne — canvas multi-nuits, onglet Timeline, fenêtre Y dynamique

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
@@ -53,4 +53,8 @@ interface NightfallApi {
     @Multipart
     @POST("api/exercise/import")
     suspend fun importExercise(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/sleep/import-stages")
+    suspend fun importSleepStages(@Part file: MultipartBody.Part): ImportApiResponse
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
@@ -111,6 +111,7 @@ class ImportRepositoryImpl(
             ImportDataType.HEART_RATE -> api.importHeartRate(part)
             ImportDataType.STEPS -> api.importSteps(part)
             ImportDataType.EXERCISE -> api.importExercise(part)
+            ImportDataType.SLEEP_STAGE -> api.importSleepStages(part)
         }
         return ImportResult(type = type, inserted = response.inserted, skipped = response.skipped)
     }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
@@ -14,7 +14,7 @@ class SleepRepositoryImpl(
         val token = tokenDataStore.getToken()
             ?: return Result.failure(IOException("No auth token"))
         return try {
-            val sessions = api.getSleepSessions("Bearer $token")
+            val sessions = api.getSleepSessions("Bearer $token", includeStages = true)
             Timber.i("sleep_sessions_fetched count=${sessions.size}")
             Result.success(sessions)
         } catch (e: retrofit2.HttpException) {

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
@@ -32,4 +32,10 @@ enum class ImportDataType(
         labelRes = R.string.import_type_exercise,
         iconRes = R.drawable.ic_import_exercise,
     ),
+    SLEEP_STAGE(
+        samsungFilenamePrefix = "com.samsung.health.sleep_stage.",
+        apiPath = "api/sleep/import-stages",
+        labelRes = R.string.import_type_sleep_stage,
+        iconRes = R.drawable.ic_import_sleep,
+    ),
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -248,6 +248,7 @@ private class NoOpNightfallApi : NightfallApi {
     override suspend fun importHeartRate(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importSteps(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importExercise(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importSleepStages(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
 }
 
 /**

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
@@ -11,11 +11,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
+import java.time.OffsetDateTime
 
 sealed class HypnogramUiState {
     object Idle    : HypnogramUiState()
     object Loading : HypnogramUiState()
-    data class Success(val session: SleepSessionResponse) : HypnogramUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : HypnogramUiState()
     data class Error(val message: String) : HypnogramUiState()
 }
 
@@ -54,14 +55,24 @@ class HypnogramViewModel(
                     Timber.w("scope=hypno_vm session_id=$sessionId sessions_null")
                     return@launch
                 }
-                val session = sessions.firstOrNull { it.id == sessionId }
-                if (session == null) {
+                val target = sessions.firstOrNull { it.id == sessionId }
+                if (target == null) {
                     Timber.w("scope=hypno_vm session_id=$sessionId not found")
                     _uiState.value = HypnogramUiState.Error("Session introuvable")
-                } else {
-                    Timber.d("scope=hypno_vm stage_count=${session.stages?.size ?: 0}")
-                    _uiState.value = HypnogramUiState.Success(session)
+                    return@launch
                 }
+                val targetDate = runCatching {
+                    OffsetDateTime.parse(target.sleep_start).toLocalDate()
+                }.getOrNull()
+                val nightSessions = if (targetDate != null) {
+                    sessions.filter { s ->
+                        runCatching { OffsetDateTime.parse(s.sleep_start).toLocalDate() }.getOrNull() == targetDate
+                    }.sortedBy { it.sleep_start }
+                } else {
+                    listOf(target)
+                }
+                Timber.d("scope=hypno_vm night_sessions=${nightSessions.size} total_stages=${nightSessions.sumOf { it.stages?.size ?: 0 }}")
+                _uiState.value = HypnogramUiState.Success(nightSessions)
             } catch (e: Exception) {
                 Timber.w("scope=hypno_vm error=${e::class.simpleName}")
                 _uiState.value = HypnogramUiState.Error(mapError(e))

--- a/android-app/app/src/main/res/values/strings.xml
+++ b/android-app/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="import_type_heartrate">Fréquence cardiaque</string>
     <string name="import_type_steps">Pas</string>
     <string name="import_type_exercise">Exercice</string>
+    <string name="import_type_sleep_stage">Phases de sommeil</string>
     <string name="import_rgpd_notice">Ces données sont envoyées uniquement vers %1$s. Elles ne transitent par aucun serveur tiers. Aucune copie n\'est conservée sur cet appareil après l\'import.</string>
     <string name="import_step_connection">Connexion</string>
     <string name="import_step_selection">Sélection</string>

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
@@ -70,7 +70,7 @@ fun HypnogramScreen(
                 TopAppBar(
                     title = {
                         val title = when (val s = uiState) {
-                            is HypnogramUiState.Success -> nightTitle(s.session.sleep_start)
+                            is HypnogramUiState.Success -> nightTitle(s.sessions.first().sleep_start)
                             else -> ""
                         }
                         Text(title, style = MaterialTheme.typography.headlineMedium)
@@ -134,10 +134,10 @@ fun HypnogramScreen(
                                 .verticalScroll(rememberScrollState())
                                 .testTag("hyp_screen")
                         ) {
-                            HypnogramSummarySection(state.session)
+                            HypnogramSummarySection(state.sessions)
                             Spacer(modifier = Modifier.height(16.dp))
                             HypnogramCanvas(
-                                session = state.session,
+                                sessions = state.sessions,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(120.dp)
@@ -146,7 +146,7 @@ fun HypnogramScreen(
                             Spacer(modifier = Modifier.height(8.dp))
                             HypnogramLegend()
                             Spacer(modifier = Modifier.height(16.dp))
-                            HypnogramStatsSection(session = state.session)
+                            HypnogramStatsSection(sessions = state.sessions)
                         }
                     }
                 }
@@ -157,11 +157,11 @@ fun HypnogramScreen(
 
 @Composable
 private fun HypnogramSummarySection(
-    session: SleepSessionResponse,
+    sessions: List<SleepSessionResponse>,
     modifier: Modifier = Modifier
 ) {
-    val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+    val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
+    val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
     val duration = if (start != null && end != null) Duration.between(start, end) else null
 
     val durationText = duration?.let {
@@ -175,13 +175,13 @@ private fun HypnogramSummarySection(
     val wakeTime = end?.format(timeFmt) ?: ""
 
     val totalMin = duration?.toMinutes() ?: 0L
-    val deepMin  = session.stages
-        ?.filter { it.stage == "DEEP" }
-        ?.sumOf { s ->
+    val deepMin  = sessions.flatMap { it.stages ?: emptyList() }
+        .filter { it.stage == "DEEP" }
+        .sumOf { s ->
             val ss = runCatching { OffsetDateTime.parse(s.stage_start) }.getOrNull()
             val se = runCatching { OffsetDateTime.parse(s.stage_end) }.getOrNull()
             if (ss != null && se != null) Duration.between(ss, se).toMinutes() else 0L
-        } ?: 0L
+        }
     val deepPct = if (totalMin > 0 && deepMin > 0) (deepMin * 100 / totalMin).toInt() else null
 
     Column(
@@ -205,7 +205,7 @@ private fun HypnogramSummarySection(
 
 @Composable
 private fun HypnogramCanvas(
-    session: SleepSessionResponse,
+    sessions: List<SleepSessionResponse>,
     modifier: Modifier = Modifier
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
@@ -215,11 +215,12 @@ private fun HypnogramCanvas(
         val canvasWidth = size.width
         val stageZoneH  = 100.dp.toPx()
 
-        val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-        val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
-        val sessionDuration = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+        val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
+        val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
+        val totalDuration = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
 
-        if (sessionDuration <= 0 || session.stages.isNullOrEmpty()) {
+        val allStages = sessions.flatMap { it.stages ?: emptyList() }
+        if (totalDuration <= 0 || allStages.isEmpty()) {
             drawRect(
                 color   = surface.copy(alpha = 0.3f),
                 topLeft = Offset(0f, 0f),
@@ -228,15 +229,14 @@ private fun HypnogramCanvas(
             return@Canvas
         }
 
-        val sorted = session.stages.sortedBy { it.stage_start }
-        for (stage in sorted) {
+        for (stage in allStages.sortedBy { it.stage_start }) {
             val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: continue
             val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: continue
             val stageDurMs = Duration.between(ss, se).toMillis()
             val offsetMs   = Duration.between(start, ss).toMillis()
 
-            val x     = (offsetMs.toFloat() / sessionDuration) * canvasWidth
-            val width = (stageDurMs.toFloat() / sessionDuration) * canvasWidth
+            val x     = (offsetMs.toFloat() / totalDuration) * canvasWidth
+            val width = (stageDurMs.toFloat() / totalDuration) * canvasWidth
 
             val rectH: Float
             val rectTop: Float
@@ -271,7 +271,7 @@ private fun HypnogramCanvas(
         var tick = tickStart
         while (!tick.isAfter(end!!)) {
             val tickOffsetMs = Duration.between(start, tick).toMillis()
-            val xTick = (tickOffsetMs.toFloat() / sessionDuration) * canvasWidth
+            val xTick = (tickOffsetMs.toFloat() / totalDuration) * canvasWidth
             drawLine(
                 color       = onSurface.copy(alpha = 0.3f),
                 start       = Offset(xTick, 95.dp.toPx()),

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramStatsSection.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramStatsSection.kt
@@ -16,12 +16,12 @@ import java.time.OffsetDateTime
 
 @Composable
 fun HypnogramStatsSection(
-    session: SleepSessionResponse,
+    sessions: List<SleepSessionResponse>,
     modifier: Modifier = Modifier
 ) {
-    val stages = session.stages ?: emptyList()
-    val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+    val stages = sessions.flatMap { it.stages ?: emptyList() }
+    val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
+    val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
     val totalMin = if (start != null && end != null) Duration.between(start, end).toMinutes() else 0L
 
     data class StageInfo(val color: Color, val label: String, val type: String)

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
@@ -1,28 +1,38 @@
 package fr.datasaillance.nightfall.ui.screens.sleep
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import fr.datasaillance.nightfall.data.sleep.SleepStageResponse
 import fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
 import fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+import java.time.Duration
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+
+// ── Constants ──────────────────────────────────────────────────────────────
 
 private const val ROW_HEIGHT_DP    = 40
 private const val BAR_HEIGHT_DP    = 24
@@ -30,20 +40,63 @@ private const val AXIS_BOTTOM_DP   = 24
 private const val LABEL_WIDTH_DP   = 48
 private const val LABEL_PADDING_DP = 4
 
-private val ColorSleepBar = Color(0xFF0E9EB0)
+// ── Stage colours ──────────────────────────────────────────────────────────
+
+private val ColorDeep  = Color(0xFF0E9EB0)
+private val ColorLight = Color(0xFF7A9AAA)
+private val ColorRem   = Color(0xFF07BCD3)
+private val ColorAwake = Color(0xFFD37C04)
+
+private fun stageColor(type: String): Color = when (type) {
+    "DEEP"  -> ColorDeep
+    "LIGHT" -> ColorLight
+    "REM"   -> ColorRem
+    "AWAKE" -> ColorAwake
+    else    -> ColorLight
+}
+
+private fun stageDisplayName(type: String): String = when (type) {
+    "DEEP"  -> "Sommeil profond"
+    "LIGHT" -> "Sommeil léger"
+    "REM"   -> "Sommeil paradoxal"
+    "AWAKE" -> "Éveil"
+    else    -> type
+}
+
+// ── Window algorithm ──────────────────────────────────────────────────────
 
 private fun computeTimelineWindow(sessions: List<SleepSessionResponse>): Pair<Int, Int> {
     val startMinutes = sessions.mapNotNull {
         runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull()
     }.map { it.hour * 60 + it.minute }.sorted()
-
-    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60
-    else startMinutes[startMinutes.size / 2]
-
+    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60 else startMinutes[startMinutes.size / 2]
     val windowStart = (medianMinutes - 120).coerceAtLeast(0)
     val windowEnd   = (windowStart + 960).coerceAtMost(1440)
     return Pair(windowStart, windowEnd)
 }
+
+// ── Night aggregation — 1 row = 1 calendar date (keyed by sleep_start.date) ──
+
+private fun groupByNight(sessions: List<SleepSessionResponse>): List<Pair<LocalDate, List<SleepSessionResponse>>> =
+    sessions
+        .groupBy { runCatching { OffsetDateTime.parse(it.sleep_start).toLocalDate() }.getOrNull() }
+        .filterKeys { it != null }
+        .mapKeys { it.key!! }
+        .entries
+        .sortedBy { it.key }
+        .map { (date, list) -> date to list }
+
+// ── Hit-box for tap detection on stage segments ────────────────────────────
+
+private data class StageHitBox(
+    val left: Float, val top: Float, val right: Float, val bottom: Float,
+    val stageType: String,
+    val stageStart: String,
+    val stageEnd: String,
+    val nightLabel: String
+)
+
+// ── Screen ─────────────────────────────────────────────────────────────────
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,6 +104,7 @@ fun TimelineScreen(
     viewModel: TimelineViewModel
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var selectedStage by remember { mutableStateOf<StageHitBox?>(null) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -85,9 +139,7 @@ fun TimelineScreen(
                             contentAlignment = Alignment.Center
                         ) {
                             Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 24.dp),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 Text(
@@ -120,21 +172,25 @@ fun TimelineScreen(
                     }
 
                     is TimelineUiState.Success -> {
-                        val (windowStart, windowEnd) = computeTimelineWindow(state.sessions)
+                        val nights = remember(state.sessions) { groupByNight(state.sessions) }
+                        val (windowStart, windowEnd) = remember(state.sessions) {
+                            computeTimelineWindow(state.sessions)
+                        }
+                        val canvasHeightDp = (nights.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp
+
                         Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag("tl_screen")
+                            modifier = Modifier.fillMaxSize().testTag("tl_screen")
                         ) {
                             TimelineAxisHeader(windowStart = windowStart, windowEnd = windowEnd)
                             Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
                                 TimelineCanvas(
-                                    sessions    = state.sessions,
+                                    nights      = nights,
                                     windowStart = windowStart,
                                     windowEnd   = windowEnd,
+                                    onStageTap  = { selectedStage = it },
                                     modifier    = Modifier
                                         .fillMaxWidth()
-                                        .height((state.sessions.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp)
+                                        .height(canvasHeightDp)
                                         .testTag("tl_canvas")
                                 )
                             }
@@ -144,7 +200,20 @@ fun TimelineScreen(
             }
         }
     }
+
+    // ── Bottom sheet — stage detail ────────────────────────────────────────
+    selectedStage?.let { stage ->
+        ModalBottomSheet(
+            onDismissRequest = { selectedStage = null },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = MaterialTheme.colorScheme.surface
+        ) {
+            StageDetailSheet(stage = stage)
+        }
+    }
 }
+
+// ── Axis header ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun TimelineAxisHeader(
@@ -156,36 +225,25 @@ private fun TimelineAxisHeader(
     val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
 
     Canvas(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(AXIS_BOTTOM_DP.dp)
+        modifier = modifier.fillMaxWidth().height(AXIS_BOTTOM_DP.dp)
     ) {
-        val canvasW  = size.width
-        val labelPx  = LABEL_WIDTH_DP.dp.toPx()
+        val canvasW   = size.width
+        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
-
         val paint = android.graphics.Paint().apply {
             textSize  = 9.sp.toPx()
             color     = onSurface.copy(alpha = 0.6f).toArgb()
             textAlign = android.graphics.Paint.Align.CENTER
         }
-
         val step = if (windowDuration >= 720) 2 else 1
-        val startHour = windowStart / 60
-        val endHour   = (windowEnd + 59) / 60
-
-        var h = startHour
+        var h = windowStart / 60
+        val endHour = (windowEnd + 59) / 60
         while (h <= endHour) {
             val hMin = h * 60
             if (hMin in windowStart..windowEnd) {
                 val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
                 drawIntoCanvas { canvas ->
-                    canvas.nativeCanvas.drawText(
-                        "%02d:00".format(h % 24),
-                        x,
-                        size.height * 0.8f,
-                        paint
-                    )
+                    canvas.nativeCanvas.drawText("%02d:00".format(h % 24), x, size.height * 0.8f, paint)
                 }
             }
             h += step
@@ -193,21 +251,39 @@ private fun TimelineAxisHeader(
     }
 }
 
+// ── Canvas ──────────────────────────────────────────────────────────────────
+
 @Composable
 private fun TimelineCanvas(
-    sessions: List<SleepSessionResponse>,
+    nights: List<Pair<LocalDate, List<SleepSessionResponse>>>,
     windowStart: Int,
     windowEnd: Int,
+    onStageTap: (StageHitBox) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val onSurface     = MaterialTheme.colorScheme.onSurface
+    val onSurface = MaterialTheme.colorScheme.onSurface
     val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+    val hitBoxes = remember { mutableListOf<StageHitBox>() }
+    val dateFmt  = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
 
-    Canvas(modifier = modifier) {
+    Canvas(
+        modifier = modifier.pointerInput(Unit) {
+            detectTapGestures { offset ->
+                hitBoxes.firstOrNull { box ->
+                    offset.x >= box.left && offset.x <= box.right &&
+                    offset.y >= box.top  && offset.y <= box.bottom
+                }?.let { onStageTap(it) }
+            }
+        }
+    ) {
+        hitBoxes.clear()
+
         val canvasW   = size.width
-        val canvasH   = size.height
         val labelPx   = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
+        val rowH      = ROW_HEIGHT_DP.dp.toPx()
+        val barH      = BAR_HEIGHT_DP.dp.toPx()
+        val axisBot   = AXIS_BOTTOM_DP.dp.toPx()
 
         val datePaint = android.graphics.Paint().apply {
             textSize  = 10.sp.toPx()
@@ -220,56 +296,60 @@ private fun TimelineCanvas(
             textAlign = android.graphics.Paint.Align.CENTER
         }
 
-        val rowH    = ROW_HEIGHT_DP.dp.toPx()
-        val barH    = BAR_HEIGHT_DP.dp.toPx()
-        val axisBot = AXIS_BOTTOM_DP.dp.toPx()
-        val dateFmt = DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH)
+        nights.forEachIndexed { rowIndex, (date, sessions) ->
+            val rowTop = rowIndex * rowH
+            val barTop = rowTop + (rowH - barH) / 2f
+            val label  = date.format(dateFmt)
 
-        // Draw bars and date labels
-        sessions.forEachIndexed { index, session ->
-            val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-                ?: return@forEachIndexed
-            val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
-                ?: return@forEachIndexed
-
-            val startMin = start.hour * 60 + start.minute
-            var endMin   = end.hour * 60 + end.minute
-            if (endMin < startMin) endMin += 1440
-
-            val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
-            val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
-
-            if (endOff > startOff) {
-                val barLeft  = (labelPx + (startOff.toFloat() / windowDuration) * drawableW)
-                    .coerceIn(labelPx, canvasW)
-                val barRight = (labelPx + (endOff.toFloat() / windowDuration) * drawableW)
-                    .coerceIn(labelPx, canvasW)
-                val rowTop   = index * rowH
-                val barTop   = rowTop + (rowH - barH) / 2f
-
-                drawRect(
-                    color   = ColorSleepBar,
-                    topLeft = Offset(barLeft, barTop),
-                    size    = Size(barRight - barLeft, barH)
+            // Date label
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawText(
+                    label,
+                    LABEL_PADDING_DP.dp.toPx(),
+                    rowTop + rowH / 2f + datePaint.textSize / 3f,
+                    datePaint
                 )
             }
 
-            // Date label
-            val label  = start.format(dateFmt)
-            val textY  = index * rowH + rowH / 2f + datePaint.textSize / 3f
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawText(label, LABEL_PADDING_DP.dp.toPx(), textY, datePaint)
+            // Draw stages for all sessions of this night
+            sessions.forEach { session ->
+                val stages = session.stages
+                if (stages.isNullOrEmpty()) {
+                    // Fallback: single bar spanning sleep duration
+                    drawFallbackBar(
+                        session      = session,
+                        windowStart  = windowStart,
+                        windowDuration = windowDuration,
+                        labelPx      = labelPx,
+                        drawableW    = drawableW,
+                        barTop       = barTop,
+                        barH         = barH,
+                        nightLabel   = label,
+                        hitBoxes     = hitBoxes
+                    )
+                } else {
+                    stages.sortedBy { it.stage_start }.forEach { stage ->
+                        drawStageSegment(
+                            stage        = stage,
+                            windowStart  = windowStart,
+                            windowDuration = windowDuration,
+                            labelPx      = labelPx,
+                            drawableW    = drawableW,
+                            barTop       = barTop,
+                            barH         = barH,
+                            nightLabel   = label,
+                            hitBoxes     = hitBoxes
+                        )
+                    }
+                }
             }
         }
 
         // X-axis hour ticks at bottom
-        val axisTopY  = canvasH - axisBot
-        val tickBotY  = axisTopY + 4.dp.toPx()
+        val axisTopY = size.height - axisBot
         val step = if (windowDuration >= 720) 2 else 1
-        val startHour = windowStart / 60
-        val endHour   = (windowEnd + 59) / 60
-
-        var h = startHour
+        var h = windowStart / 60
+        val endHour = (windowEnd + 59) / 60
         while (h <= endHour) {
             val hMin = h * 60
             if (hMin in windowStart..windowEnd) {
@@ -277,19 +357,144 @@ private fun TimelineCanvas(
                 drawLine(
                     color       = onSurface.copy(alpha = 0.2f),
                     start       = Offset(x, axisTopY),
-                    end         = Offset(x, tickBotY),
+                    end         = Offset(x, axisTopY + 4.dp.toPx()),
                     strokeWidth = 1.dp.toPx()
                 )
                 drawIntoCanvas { canvas ->
                     canvas.nativeCanvas.drawText(
                         "%02d:00".format(h % 24),
                         x,
-                        canvasH - 2.dp.toPx(),
+                        size.height - 2.dp.toPx(),
                         tickPaint
                     )
                 }
             }
             h += step
+        }
+    }
+}
+
+// ── Drawing helpers (pure DrawScope calls extracted for readability) ─────────
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawFallbackBar(
+    session: SleepSessionResponse,
+    windowStart: Int,
+    windowDuration: Int,
+    labelPx: Float,
+    drawableW: Float,
+    barTop: Float,
+    barH: Float,
+    nightLabel: String,
+    hitBoxes: MutableList<StageHitBox>
+) {
+    val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull() ?: return
+    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull() ?: return
+    var startMin = start.hour * 60 + start.minute
+    var endMin   = end.hour * 60 + end.minute
+    if (endMin < startMin) endMin += 1440
+
+    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
+    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
+    if (endOff <= startOff) return
+
+    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val barW = xEnd - x
+    if (barW <= 0f) return
+
+    drawRect(color = ColorDeep.copy(alpha = 0.6f), topLeft = Offset(x, barTop), size = Size(barW, barH))
+    hitBoxes.add(StageHitBox(x, barTop, xEnd, barTop + barH, "LIGHT",
+        session.sleep_start, session.sleep_end, nightLabel))
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStageSegment(
+    stage: SleepStageResponse,
+    windowStart: Int,
+    windowDuration: Int,
+    labelPx: Float,
+    drawableW: Float,
+    barTop: Float,
+    barH: Float,
+    nightLabel: String,
+    hitBoxes: MutableList<StageHitBox>
+) {
+    val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return
+    val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return
+    var startMin = ss.hour * 60 + ss.minute
+    var endMin   = se.hour * 60 + se.minute
+    if (endMin < startMin) endMin += 1440
+
+    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
+    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
+    if (endOff <= startOff) return
+
+    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val barW = xEnd - x
+    if (barW <= 0f) return
+
+    // AWAKE segments are shorter to distinguish them visually
+    val segH  = if (stage.stage == "AWAKE") barH * 0.5f else barH
+    val segTop = barTop + (barH - segH) / 2f
+
+    drawRect(
+        color   = stageColor(stage.stage),
+        topLeft = Offset(x, segTop),
+        size    = Size(barW, segH)
+    )
+    hitBoxes.add(StageHitBox(x, segTop, xEnd, segTop + segH,
+        stage.stage, stage.stage_start, stage.stage_end, nightLabel))
+}
+
+// ── Bottom sheet detail ──────────────────────────────────────────────────────
+
+@Composable
+private fun StageDetailSheet(stage: StageHitBox) {
+    val start = runCatching { OffsetDateTime.parse(stage.stageStart) }.getOrNull()
+    val end   = runCatching { OffsetDateTime.parse(stage.stageEnd) }.getOrNull()
+    val duration = if (start != null && end != null) Duration.between(start, end) else null
+    val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+            .padding(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = stage.nightLabel,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+        )
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(stageColor(stage.stageType))
+            )
+            Text(
+                text = stageDisplayName(stage.stageType),
+                style = MaterialTheme.typography.titleMedium,
+                color = stageColor(stage.stageType)
+            )
+        }
+        if (duration != null) {
+            val h  = duration.toHours()
+            val mm = duration.toMinutes() % 60
+            Text(
+                text = if (h > 0) "${h}h ${mm.toString().padStart(2, '0')}min" else "${mm}min",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        if (start != null && end != null) {
+            Text(
+                text = "${start.format(timeFmt)} → ${end.format(timeFmt)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
         }
     }
 }

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreenTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreenTest.kt
@@ -138,7 +138,7 @@ class HypnogramScreenSnapshotTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         paparazzi.snapshot {
@@ -161,7 +161,7 @@ class HypnogramScreenSnapshotTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         paparazzi.snapshot {
@@ -254,7 +254,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         composeTestRule.setContent {
@@ -281,7 +281,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         composeTestRule.setContent {
@@ -308,7 +308,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         composeTestRule.setContent {
@@ -402,7 +402,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(sessionNoStages)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(sessionNoStages))
         )
 
         composeTestRule.setContent {
@@ -441,7 +441,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(sessionZeroDuration)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(sessionZeroDuration))
         )
 
         composeTestRule.setContent {
@@ -463,7 +463,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         var backCalled = false
@@ -520,7 +520,7 @@ class HypnogramViewModelTest {
     }
 
     // spec: TA-H-VM-01 — repository retourne [fullSession], loadSession() filtre par "hyp-001"
-    //   → uiState = HypnogramUiState.Success(fullSession)
+    //   → uiState = HypnogramUiState.Success(listOf(fullSession))
     // RED: HypnogramViewModel.loadSession() n'existe pas encore
     @Test
     fun hypnogramViewModel_emits_success_when_session_found() = runTest {
@@ -536,10 +536,10 @@ class HypnogramViewModelTest {
             "uiState must be HypnogramUiState.Success when session hyp-001 is found — spec: TA-H-VM-01, got: $state"
         }
 
-        // spec: TA-H-VM-01 — Success.session doit être la session correspondant au sessionId
-        val session = (state as fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success).session
-        assert(session.id == "hyp-001") {
-            "Success.session.id must be 'hyp-001' — spec: TA-H-VM-01, got: ${session.id}"
+        // spec: TA-H-VM-01 — Success.sessions doit contenir la session correspondant au sessionId
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success).sessions
+        assert(sessions.any { it.id == "hyp-001" }) {
+            "Success.sessions must contain session 'hyp-001' — spec: TA-H-VM-01, got: ${sessions.map { it.id }}"
         }
     }
 

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/http/NightfallApi.kt
-git_blob: 15be5d2254cfd3874a877df8f8d79f1928b8101d
-last_synced: '2026-05-09T04:03:34Z'
-loc: 56
+git_blob: 8c032be84c7326e2c320a7c2fc48795349691ae2
+last_synced: '2026-05-09T08:38:11Z'
+loc: 60
 annotations: []
 imports: []
 exports: []
@@ -76,6 +76,10 @@ interface NightfallApi {
     @Multipart
     @POST("api/exercise/import")
     suspend fun importExercise(@Part file: MultipartBody.Part): ImportApiResponse
+
+    @Multipart
+    @POST("api/sleep/import-stages")
+    suspend fun importSleepStages(@Part file: MultipartBody.Part): ImportApiResponse
 }
 ```
 
@@ -85,7 +89,7 @@ interface NightfallApi {
 
 ### Symbols
 - `ImportApiResponse` (class) — lines 14-15
-- `NightfallApi` (class) — lines 17-56
+- `NightfallApi` (class) — lines 17-60
 - `health` (function) — lines 18-19
 - `login` (function) — lines 21-22
 - `register` (function) — lines 24-25
@@ -96,3 +100,4 @@ interface NightfallApi {
 - `importHeartRate` (function) — lines 45-47
 - `importSteps` (function) — lines 49-51
 - `importExercise` (function) — lines 53-55
+- `importSleepStages` (function) — lines 57-59

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
-git_blob: 58de67aea204eea8b2f605bb8e206e90048a0718
-last_synced: '2026-05-07T03:10:49Z'
-loc: 124
+git_blob: 383c43dc5d1f90785d939634206bd0dabb45287d
+last_synced: '2026-05-09T08:38:11Z'
+loc: 118
 annotations: []
 imports: []
 exports: []
@@ -38,7 +38,6 @@ import java.io.IOException
 import java.util.zip.ZipInputStream
 
 private const val MAX_UNCOMPRESSED_BYTES = 200_000_000L
-private const val MAX_ZIP_ENTRIES = 100
 
 class ImportRepositoryImpl(
     private val api: NightfallApi,
@@ -76,16 +75,10 @@ class ImportRepositoryImpl(
             ?: throw IOException("Cannot open URI")
 
         var totalUncompressed = 0L
-        var entryCount = 0
 
         ZipInputStream(inputStream).use { zis ->
             var entry = zis.nextEntry
             while (entry != null) {
-                if (entryCount >= MAX_ZIP_ENTRIES) {
-                    throw IOException("Archive trop grande: dépasse $MAX_ZIP_ENTRIES entrées")
-                }
-                entryCount++
-
                 val name = entry.name.substringAfterLast('/')
                 val matchingType = ImportDataType.entries.firstOrNull { type ->
                     name.startsWith(type.samsungFilenamePrefix) && name.endsWith(".csv")
@@ -141,6 +134,7 @@ class ImportRepositoryImpl(
             ImportDataType.HEART_RATE -> api.importHeartRate(part)
             ImportDataType.STEPS -> api.importSteps(part)
             ImportDataType.EXERCISE -> api.importExercise(part)
+            ImportDataType.SLEEP_STAGE -> api.importSleepStages(part)
         }
         return ImportResult(type = type, inserted = response.inserted, skipped = response.skipped)
     }
@@ -152,8 +146,8 @@ class ImportRepositoryImpl(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportRepositoryImpl` (class) — lines 20-124
-- `pingBackend` (function) — lines 24-31
-- `extractCsvEntries` (function) — lines 35-45
-- `extractFromZip` (function) — lines 47-92
-- `uploadCsv` (function) — lines 94-123
+- `ImportRepositoryImpl` (class) — lines 19-118
+- `pingBackend` (function) — lines 23-30
+- `extractCsvEntries` (function) — lines 34-44
+- `extractFromZip` (function) — lines 46-85
+- `uploadCsv` (function) — lines 87-117

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
-git_blob: 1d5121ead2f5371815083acc39d390e0ad0338e1
-last_synced: '2026-05-09T04:03:35Z'
+git_blob: 9287ff0337e7f2932d15291a09cd90db0c871fc5
+last_synced: '2026-05-09T08:38:11Z'
 loc: 28
 annotations: []
 imports: []
@@ -37,7 +37,7 @@ class SleepRepositoryImpl(
         val token = tokenDataStore.getToken()
             ?: return Result.failure(IOException("No auth token"))
         return try {
-            val sessions = api.getSleepSessions("Bearer $token")
+            val sessions = api.getSleepSessions("Bearer $token", includeStages = true)
             Timber.i("sleep_sessions_fetched count=${sessions.size}")
             Result.success(sessions)
         } catch (e: retrofit2.HttpException) {

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportDataType.kt
-git_blob: 54597c9c952e5cb764bf75abafee457c0d844873
-last_synced: '2026-05-07T03:10:49Z'
-loc: 35
+git_blob: e53b1d50951aec6a31bc07b40f081e9cf9c9000b
+last_synced: '2026-05-09T08:38:11Z'
+loc: 41
 annotations: []
 imports: []
 exports: []
@@ -32,28 +32,34 @@ enum class ImportDataType(
     val iconRes: Int,
 ) {
     SLEEP(
-        samsungFilenamePrefix = "com.samsung.health.sleep",
+        samsungFilenamePrefix = "com.samsung.shealth.sleep.",
         apiPath = "api/sleep/import",
         labelRes = R.string.import_type_sleep,
         iconRes = R.drawable.ic_import_sleep,
     ),
     HEART_RATE(
-        samsungFilenamePrefix = "com.samsung.health.heart_rate",
+        samsungFilenamePrefix = "com.samsung.shealth.tracker.heart_rate.",
         apiPath = "api/heartrate/import",
         labelRes = R.string.import_type_heartrate,
         iconRes = R.drawable.ic_import_heartrate,
     ),
     STEPS(
-        samsungFilenamePrefix = "com.samsung.health.step_daily_trend",
+        samsungFilenamePrefix = "com.samsung.shealth.step_daily_trend.",
         apiPath = "api/steps/import",
         labelRes = R.string.import_type_steps,
         iconRes = R.drawable.ic_import_steps,
     ),
     EXERCISE(
-        samsungFilenamePrefix = "com.samsung.health.exercise",
+        samsungFilenamePrefix = "com.samsung.shealth.exercise.",
         apiPath = "api/exercise/import",
         labelRes = R.string.import_type_exercise,
         iconRes = R.drawable.ic_import_exercise,
+    ),
+    SLEEP_STAGE(
+        samsungFilenamePrefix = "com.samsung.health.sleep_stage.",
+        apiPath = "api/sleep/import-stages",
+        labelRes = R.string.import_type_sleep_stage,
+        iconRes = R.drawable.ic_import_sleep,
     ),
 }
 ```
@@ -63,4 +69,4 @@ enum class ImportDataType(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportDataType` (class) — lines 5-35
+- `ImportDataType` (class) — lines 5-41

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: bc187019adb6fafa680fb1f88517ed67905975cf
-last_synced: '2026-05-09T07:04:02Z'
-loc: 267
+git_blob: f30caf03537af9ccc83d3653d7458a9e1397c042
+last_synced: '2026-05-09T08:38:11Z'
+loc: 268
 annotations: []
 imports: []
 exports: []
@@ -271,6 +271,7 @@ private class NoOpNightfallApi : NightfallApi {
     override suspend fun importHeartRate(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importSteps(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
     override suspend fun importExercise(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
+    override suspend fun importSleepStages(file: MultipartBody.Part): ImportApiResponse = throw UnsupportedOperationException("No-op api")
 }
 
 /**
@@ -302,7 +303,7 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 - `pingBackend` (function) — lines 224-224
 - `extractCsvEntries` (function) — lines 226-229
 - `uploadCsv` (function) — lines 231-237
-- `NoOpNightfallApi` (class) — lines 240-251
+- `NoOpNightfallApi` (class) — lines 240-252
 - `health` (function) — lines 241-241
 - `login` (function) — lines 242-242
 - `register` (function) — lines 243-243
@@ -313,4 +314,5 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 - `importHeartRate` (function) — lines 248-248
 - `importSteps` (function) — lines 249-249
 - `importExercise` (function) — lines 250-250
-- `ensureComposeNavigators` (function) — lines 259-267
+- `importSleepStages` (function) — lines 251-251
+- `ensureComposeNavigators` (function) — lines 260-268

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
-git_blob: 8bd6b7c7e92f2a326abab094ad48001ac2ada78d
-last_synced: '2026-05-09T06:05:32Z'
-loc: 81
+git_blob: ea4e5479bc273af0f644f239ba66a90ce852a087
+last_synced: '2026-05-09T08:38:11Z'
+loc: 92
 annotations: []
 imports: []
 exports: []
@@ -34,11 +34,12 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
+import java.time.OffsetDateTime
 
 sealed class HypnogramUiState {
     object Idle    : HypnogramUiState()
     object Loading : HypnogramUiState()
-    data class Success(val session: SleepSessionResponse) : HypnogramUiState()
+    data class Success(val sessions: List<SleepSessionResponse>) : HypnogramUiState()
     data class Error(val message: String) : HypnogramUiState()
 }
 
@@ -77,14 +78,24 @@ class HypnogramViewModel(
                     Timber.w("scope=hypno_vm session_id=$sessionId sessions_null")
                     return@launch
                 }
-                val session = sessions.firstOrNull { it.id == sessionId }
-                if (session == null) {
+                val target = sessions.firstOrNull { it.id == sessionId }
+                if (target == null) {
                     Timber.w("scope=hypno_vm session_id=$sessionId not found")
                     _uiState.value = HypnogramUiState.Error("Session introuvable")
-                } else {
-                    Timber.d("scope=hypno_vm stage_count=${session.stages?.size ?: 0}")
-                    _uiState.value = HypnogramUiState.Success(session)
+                    return@launch
                 }
+                val targetDate = runCatching {
+                    OffsetDateTime.parse(target.sleep_start).toLocalDate()
+                }.getOrNull()
+                val nightSessions = if (targetDate != null) {
+                    sessions.filter { s ->
+                        runCatching { OffsetDateTime.parse(s.sleep_start).toLocalDate() }.getOrNull() == targetDate
+                    }.sortedBy { it.sleep_start }
+                } else {
+                    listOf(target)
+                }
+                Timber.d("scope=hypno_vm night_sessions=${nightSessions.size} total_stages=${nightSessions.sumOf { it.stages?.size ?: 0 }}")
+                _uiState.value = HypnogramUiState.Success(nightSessions)
             } catch (e: Exception) {
                 Timber.w("scope=hypno_vm error=${e::class.simpleName}")
                 _uiState.value = HypnogramUiState.Error(mapError(e))
@@ -109,10 +120,10 @@ class HypnogramViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `HypnogramUiState` (class) — lines 15-20
-- `Success` (class) — lines 18-18
-- `Error` (class) — lines 19-19
-- `HypnogramViewModel` (class) — lines 22-81
-- `retry` (function) — lines 34-34
-- `loadSession` (function) — lines 36-70
-- `mapError` (function) — lines 72-80
+- `HypnogramUiState` (class) — lines 16-21
+- `Success` (class) — lines 19-19
+- `Error` (class) — lines 20-20
+- `HypnogramViewModel` (class) — lines 23-92
+- `retry` (function) — lines 35-35
+- `loadSession` (function) — lines 37-81
+- `mapError` (function) — lines 83-91

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
-git_blob: 01d0df6892316d2c9b37f02f5f406dd166ff1ffd
-last_synced: '2026-05-09T06:05:32Z'
+git_blob: af95f089ced1500882b826646a1d087a99b2a252
+last_synced: '2026-05-09T08:38:11Z'
 loc: 320
 annotations: []
 imports: []
@@ -93,7 +93,7 @@ fun HypnogramScreen(
                 TopAppBar(
                     title = {
                         val title = when (val s = uiState) {
-                            is HypnogramUiState.Success -> nightTitle(s.session.sleep_start)
+                            is HypnogramUiState.Success -> nightTitle(s.sessions.first().sleep_start)
                             else -> ""
                         }
                         Text(title, style = MaterialTheme.typography.headlineMedium)
@@ -157,10 +157,10 @@ fun HypnogramScreen(
                                 .verticalScroll(rememberScrollState())
                                 .testTag("hyp_screen")
                         ) {
-                            HypnogramSummarySection(state.session)
+                            HypnogramSummarySection(state.sessions)
                             Spacer(modifier = Modifier.height(16.dp))
                             HypnogramCanvas(
-                                session = state.session,
+                                sessions = state.sessions,
                                 modifier = Modifier
                                     .fillMaxWidth()
                                     .height(120.dp)
@@ -169,7 +169,7 @@ fun HypnogramScreen(
                             Spacer(modifier = Modifier.height(8.dp))
                             HypnogramLegend()
                             Spacer(modifier = Modifier.height(16.dp))
-                            HypnogramStatsSection(session = state.session)
+                            HypnogramStatsSection(sessions = state.sessions)
                         }
                     }
                 }
@@ -180,11 +180,11 @@ fun HypnogramScreen(
 
 @Composable
 private fun HypnogramSummarySection(
-    session: SleepSessionResponse,
+    sessions: List<SleepSessionResponse>,
     modifier: Modifier = Modifier
 ) {
-    val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+    val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
+    val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
     val duration = if (start != null && end != null) Duration.between(start, end) else null
 
     val durationText = duration?.let {
@@ -198,13 +198,13 @@ private fun HypnogramSummarySection(
     val wakeTime = end?.format(timeFmt) ?: ""
 
     val totalMin = duration?.toMinutes() ?: 0L
-    val deepMin  = session.stages
-        ?.filter { it.stage == "DEEP" }
-        ?.sumOf { s ->
+    val deepMin  = sessions.flatMap { it.stages ?: emptyList() }
+        .filter { it.stage == "DEEP" }
+        .sumOf { s ->
             val ss = runCatching { OffsetDateTime.parse(s.stage_start) }.getOrNull()
             val se = runCatching { OffsetDateTime.parse(s.stage_end) }.getOrNull()
             if (ss != null && se != null) Duration.between(ss, se).toMinutes() else 0L
-        } ?: 0L
+        }
     val deepPct = if (totalMin > 0 && deepMin > 0) (deepMin * 100 / totalMin).toInt() else null
 
     Column(
@@ -228,7 +228,7 @@ private fun HypnogramSummarySection(
 
 @Composable
 private fun HypnogramCanvas(
-    session: SleepSessionResponse,
+    sessions: List<SleepSessionResponse>,
     modifier: Modifier = Modifier
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
@@ -238,11 +238,12 @@ private fun HypnogramCanvas(
         val canvasWidth = size.width
         val stageZoneH  = 100.dp.toPx()
 
-        val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-        val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
-        val sessionDuration = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+        val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
+        val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
+        val totalDuration = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
 
-        if (sessionDuration <= 0 || session.stages.isNullOrEmpty()) {
+        val allStages = sessions.flatMap { it.stages ?: emptyList() }
+        if (totalDuration <= 0 || allStages.isEmpty()) {
             drawRect(
                 color   = surface.copy(alpha = 0.3f),
                 topLeft = Offset(0f, 0f),
@@ -251,15 +252,14 @@ private fun HypnogramCanvas(
             return@Canvas
         }
 
-        val sorted = session.stages.sortedBy { it.stage_start }
-        for (stage in sorted) {
+        for (stage in allStages.sortedBy { it.stage_start }) {
             val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: continue
             val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: continue
             val stageDurMs = Duration.between(ss, se).toMillis()
             val offsetMs   = Duration.between(start, ss).toMillis()
 
-            val x     = (offsetMs.toFloat() / sessionDuration) * canvasWidth
-            val width = (stageDurMs.toFloat() / sessionDuration) * canvasWidth
+            val x     = (offsetMs.toFloat() / totalDuration) * canvasWidth
+            val width = (stageDurMs.toFloat() / totalDuration) * canvasWidth
 
             val rectH: Float
             val rectTop: Float
@@ -294,7 +294,7 @@ private fun HypnogramCanvas(
         var tick = tickStart
         while (!tick.isAfter(end!!)) {
             val tickOffsetMs = Duration.between(start, tick).toMillis()
-            val xTick = (tickOffsetMs.toFloat() / sessionDuration) * canvasWidth
+            val xTick = (tickOffsetMs.toFloat() / totalDuration) * canvasWidth
             drawLine(
                 color       = onSurface.copy(alpha = 0.3f),
                 start       = Offset(xTick, 95.dp.toPx()),

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramStatsSection.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramStatsSection.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramStatsSection.kt
-git_blob: 48a400d34fb09fcf251843de7c28a72efdd245f1
-last_synced: '2026-05-09T06:05:32Z'
+git_blob: c0e05bd672018dfebaee3f220a400c0516e24bc9
+last_synced: '2026-05-09T08:38:11Z'
 loc: 107
 annotations: []
 imports: []
@@ -39,12 +39,12 @@ import java.time.OffsetDateTime
 
 @Composable
 fun HypnogramStatsSection(
-    session: SleepSessionResponse,
+    sessions: List<SleepSessionResponse>,
     modifier: Modifier = Modifier
 ) {
-    val stages = session.stages ?: emptyList()
-    val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+    val stages = sessions.flatMap { it.stages ?: emptyList() }
+    val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
+    val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
     val totalMin = if (start != null && end != null) Duration.between(start, end).toMinutes() else 0L
 
     data class StageInfo(val color: Color, val label: String, val type: String)

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
-git_blob: 5833c2b98b5dc6de210d4ae52cb69dac132a8a7a
-last_synced: '2026-05-09T07:04:02Z'
-loc: 295
+git_blob: a5bc9731bc6edb08faa180fa5c9cff38df8c62a3
+last_synced: '2026-05-09T07:41:11Z'
+loc: 500
 annotations: []
 imports: []
 exports: []
@@ -24,28 +24,38 @@ tags:
 package fr.datasaillance.nightfall.ui.screens.sleep
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
+import fr.datasaillance.nightfall.data.sleep.SleepStageResponse
 import fr.datasaillance.nightfall.viewmodel.sleep.TimelineUiState
 import fr.datasaillance.nightfall.viewmodel.sleep.TimelineViewModel
+import java.time.Duration
+import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Locale
+
+// ── Constants ──────────────────────────────────────────────────────────────
 
 private const val ROW_HEIGHT_DP    = 40
 private const val BAR_HEIGHT_DP    = 24
@@ -53,20 +63,63 @@ private const val AXIS_BOTTOM_DP   = 24
 private const val LABEL_WIDTH_DP   = 48
 private const val LABEL_PADDING_DP = 4
 
-private val ColorSleepBar = Color(0xFF0E9EB0)
+// ── Stage colours ──────────────────────────────────────────────────────────
+
+private val ColorDeep  = Color(0xFF0E9EB0)
+private val ColorLight = Color(0xFF7A9AAA)
+private val ColorRem   = Color(0xFF07BCD3)
+private val ColorAwake = Color(0xFFD37C04)
+
+private fun stageColor(type: String): Color = when (type) {
+    "DEEP"  -> ColorDeep
+    "LIGHT" -> ColorLight
+    "REM"   -> ColorRem
+    "AWAKE" -> ColorAwake
+    else    -> ColorLight
+}
+
+private fun stageDisplayName(type: String): String = when (type) {
+    "DEEP"  -> "Sommeil profond"
+    "LIGHT" -> "Sommeil léger"
+    "REM"   -> "Sommeil paradoxal"
+    "AWAKE" -> "Éveil"
+    else    -> type
+}
+
+// ── Window algorithm ──────────────────────────────────────────────────────
 
 private fun computeTimelineWindow(sessions: List<SleepSessionResponse>): Pair<Int, Int> {
     val startMinutes = sessions.mapNotNull {
         runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull()
     }.map { it.hour * 60 + it.minute }.sorted()
-
-    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60
-    else startMinutes[startMinutes.size / 2]
-
+    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60 else startMinutes[startMinutes.size / 2]
     val windowStart = (medianMinutes - 120).coerceAtLeast(0)
     val windowEnd   = (windowStart + 960).coerceAtMost(1440)
     return Pair(windowStart, windowEnd)
 }
+
+// ── Night aggregation — 1 row = 1 calendar date (keyed by sleep_start.date) ──
+
+private fun groupByNight(sessions: List<SleepSessionResponse>): List<Pair<LocalDate, List<SleepSessionResponse>>> =
+    sessions
+        .groupBy { runCatching { OffsetDateTime.parse(it.sleep_start).toLocalDate() }.getOrNull() }
+        .filterKeys { it != null }
+        .mapKeys { it.key!! }
+        .entries
+        .sortedBy { it.key }
+        .map { (date, list) -> date to list }
+
+// ── Hit-box for tap detection on stage segments ────────────────────────────
+
+private data class StageHitBox(
+    val left: Float, val top: Float, val right: Float, val bottom: Float,
+    val stageType: String,
+    val stageStart: String,
+    val stageEnd: String,
+    val nightLabel: String
+)
+
+// ── Screen ─────────────────────────────────────────────────────────────────
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -74,6 +127,7 @@ fun TimelineScreen(
     viewModel: TimelineViewModel
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var selectedStage by remember { mutableStateOf<StageHitBox?>(null) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -108,9 +162,7 @@ fun TimelineScreen(
                             contentAlignment = Alignment.Center
                         ) {
                             Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 24.dp),
+                                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
                                 horizontalAlignment = Alignment.CenterHorizontally
                             ) {
                                 Text(
@@ -143,21 +195,25 @@ fun TimelineScreen(
                     }
 
                     is TimelineUiState.Success -> {
-                        val (windowStart, windowEnd) = computeTimelineWindow(state.sessions)
+                        val nights = remember(state.sessions) { groupByNight(state.sessions) }
+                        val (windowStart, windowEnd) = remember(state.sessions) {
+                            computeTimelineWindow(state.sessions)
+                        }
+                        val canvasHeightDp = (nights.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp
+
                         Column(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .testTag("tl_screen")
+                            modifier = Modifier.fillMaxSize().testTag("tl_screen")
                         ) {
                             TimelineAxisHeader(windowStart = windowStart, windowEnd = windowEnd)
                             Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
                                 TimelineCanvas(
-                                    sessions    = state.sessions,
+                                    nights      = nights,
                                     windowStart = windowStart,
                                     windowEnd   = windowEnd,
+                                    onStageTap  = { selectedStage = it },
                                     modifier    = Modifier
                                         .fillMaxWidth()
-                                        .height((state.sessions.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp)
+                                        .height(canvasHeightDp)
                                         .testTag("tl_canvas")
                                 )
                             }
@@ -167,7 +223,20 @@ fun TimelineScreen(
             }
         }
     }
+
+    // ── Bottom sheet — stage detail ────────────────────────────────────────
+    selectedStage?.let { stage ->
+        ModalBottomSheet(
+            onDismissRequest = { selectedStage = null },
+            sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+            containerColor = MaterialTheme.colorScheme.surface
+        ) {
+            StageDetailSheet(stage = stage)
+        }
+    }
 }
+
+// ── Axis header ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun TimelineAxisHeader(
@@ -179,36 +248,25 @@ private fun TimelineAxisHeader(
     val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
 
     Canvas(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(AXIS_BOTTOM_DP.dp)
+        modifier = modifier.fillMaxWidth().height(AXIS_BOTTOM_DP.dp)
     ) {
-        val canvasW  = size.width
-        val labelPx  = LABEL_WIDTH_DP.dp.toPx()
+        val canvasW   = size.width
+        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
-
         val paint = android.graphics.Paint().apply {
             textSize  = 9.sp.toPx()
             color     = onSurface.copy(alpha = 0.6f).toArgb()
             textAlign = android.graphics.Paint.Align.CENTER
         }
-
         val step = if (windowDuration >= 720) 2 else 1
-        val startHour = windowStart / 60
-        val endHour   = (windowEnd + 59) / 60
-
-        var h = startHour
+        var h = windowStart / 60
+        val endHour = (windowEnd + 59) / 60
         while (h <= endHour) {
             val hMin = h * 60
             if (hMin in windowStart..windowEnd) {
                 val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
                 drawIntoCanvas { canvas ->
-                    canvas.nativeCanvas.drawText(
-                        "%02d:00".format(h % 24),
-                        x,
-                        size.height * 0.8f,
-                        paint
-                    )
+                    canvas.nativeCanvas.drawText("%02d:00".format(h % 24), x, size.height * 0.8f, paint)
                 }
             }
             h += step
@@ -216,21 +274,39 @@ private fun TimelineAxisHeader(
     }
 }
 
+// ── Canvas ──────────────────────────────────────────────────────────────────
+
 @Composable
 private fun TimelineCanvas(
-    sessions: List<SleepSessionResponse>,
+    nights: List<Pair<LocalDate, List<SleepSessionResponse>>>,
     windowStart: Int,
     windowEnd: Int,
+    onStageTap: (StageHitBox) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    val onSurface     = MaterialTheme.colorScheme.onSurface
+    val onSurface = MaterialTheme.colorScheme.onSurface
     val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+    val hitBoxes = remember { mutableListOf<StageHitBox>() }
+    val dateFmt  = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
 
-    Canvas(modifier = modifier) {
+    Canvas(
+        modifier = modifier.pointerInput(Unit) {
+            detectTapGestures { offset ->
+                hitBoxes.firstOrNull { box ->
+                    offset.x >= box.left && offset.x <= box.right &&
+                    offset.y >= box.top  && offset.y <= box.bottom
+                }?.let { onStageTap(it) }
+            }
+        }
+    ) {
+        hitBoxes.clear()
+
         val canvasW   = size.width
-        val canvasH   = size.height
         val labelPx   = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
+        val rowH      = ROW_HEIGHT_DP.dp.toPx()
+        val barH      = BAR_HEIGHT_DP.dp.toPx()
+        val axisBot   = AXIS_BOTTOM_DP.dp.toPx()
 
         val datePaint = android.graphics.Paint().apply {
             textSize  = 10.sp.toPx()
@@ -243,56 +319,60 @@ private fun TimelineCanvas(
             textAlign = android.graphics.Paint.Align.CENTER
         }
 
-        val rowH    = ROW_HEIGHT_DP.dp.toPx()
-        val barH    = BAR_HEIGHT_DP.dp.toPx()
-        val axisBot = AXIS_BOTTOM_DP.dp.toPx()
-        val dateFmt = DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH)
+        nights.forEachIndexed { rowIndex, (date, sessions) ->
+            val rowTop = rowIndex * rowH
+            val barTop = rowTop + (rowH - barH) / 2f
+            val label  = date.format(dateFmt)
 
-        // Draw bars and date labels
-        sessions.forEachIndexed { index, session ->
-            val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
-                ?: return@forEachIndexed
-            val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
-                ?: return@forEachIndexed
-
-            val startMin = start.hour * 60 + start.minute
-            var endMin   = end.hour * 60 + end.minute
-            if (endMin < startMin) endMin += 1440
-
-            val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
-            val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
-
-            if (endOff > startOff) {
-                val barLeft  = (labelPx + (startOff.toFloat() / windowDuration) * drawableW)
-                    .coerceIn(labelPx, canvasW)
-                val barRight = (labelPx + (endOff.toFloat() / windowDuration) * drawableW)
-                    .coerceIn(labelPx, canvasW)
-                val rowTop   = index * rowH
-                val barTop   = rowTop + (rowH - barH) / 2f
-
-                drawRect(
-                    color   = ColorSleepBar,
-                    topLeft = Offset(barLeft, barTop),
-                    size    = Size(barRight - barLeft, barH)
+            // Date label
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawText(
+                    label,
+                    LABEL_PADDING_DP.dp.toPx(),
+                    rowTop + rowH / 2f + datePaint.textSize / 3f,
+                    datePaint
                 )
             }
 
-            // Date label
-            val label  = start.format(dateFmt)
-            val textY  = index * rowH + rowH / 2f + datePaint.textSize / 3f
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawText(label, LABEL_PADDING_DP.dp.toPx(), textY, datePaint)
+            // Draw stages for all sessions of this night
+            sessions.forEach { session ->
+                val stages = session.stages
+                if (stages.isNullOrEmpty()) {
+                    // Fallback: single bar spanning sleep duration
+                    drawFallbackBar(
+                        session      = session,
+                        windowStart  = windowStart,
+                        windowDuration = windowDuration,
+                        labelPx      = labelPx,
+                        drawableW    = drawableW,
+                        barTop       = barTop,
+                        barH         = barH,
+                        nightLabel   = label,
+                        hitBoxes     = hitBoxes
+                    )
+                } else {
+                    stages.sortedBy { it.stage_start }.forEach { stage ->
+                        drawStageSegment(
+                            stage        = stage,
+                            windowStart  = windowStart,
+                            windowDuration = windowDuration,
+                            labelPx      = labelPx,
+                            drawableW    = drawableW,
+                            barTop       = barTop,
+                            barH         = barH,
+                            nightLabel   = label,
+                            hitBoxes     = hitBoxes
+                        )
+                    }
+                }
             }
         }
 
         // X-axis hour ticks at bottom
-        val axisTopY  = canvasH - axisBot
-        val tickBotY  = axisTopY + 4.dp.toPx()
+        val axisTopY = size.height - axisBot
         val step = if (windowDuration >= 720) 2 else 1
-        val startHour = windowStart / 60
-        val endHour   = (windowEnd + 59) / 60
-
-        var h = startHour
+        var h = windowStart / 60
+        val endHour = (windowEnd + 59) / 60
         while (h <= endHour) {
             val hMin = h * 60
             if (hMin in windowStart..windowEnd) {
@@ -300,19 +380,144 @@ private fun TimelineCanvas(
                 drawLine(
                     color       = onSurface.copy(alpha = 0.2f),
                     start       = Offset(x, axisTopY),
-                    end         = Offset(x, tickBotY),
+                    end         = Offset(x, axisTopY + 4.dp.toPx()),
                     strokeWidth = 1.dp.toPx()
                 )
                 drawIntoCanvas { canvas ->
                     canvas.nativeCanvas.drawText(
                         "%02d:00".format(h % 24),
                         x,
-                        canvasH - 2.dp.toPx(),
+                        size.height - 2.dp.toPx(),
                         tickPaint
                     )
                 }
             }
             h += step
+        }
+    }
+}
+
+// ── Drawing helpers (pure DrawScope calls extracted for readability) ─────────
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawFallbackBar(
+    session: SleepSessionResponse,
+    windowStart: Int,
+    windowDuration: Int,
+    labelPx: Float,
+    drawableW: Float,
+    barTop: Float,
+    barH: Float,
+    nightLabel: String,
+    hitBoxes: MutableList<StageHitBox>
+) {
+    val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull() ?: return
+    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull() ?: return
+    var startMin = start.hour * 60 + start.minute
+    var endMin   = end.hour * 60 + end.minute
+    if (endMin < startMin) endMin += 1440
+
+    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
+    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
+    if (endOff <= startOff) return
+
+    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val barW = xEnd - x
+    if (barW <= 0f) return
+
+    drawRect(color = ColorDeep.copy(alpha = 0.6f), topLeft = Offset(x, barTop), size = Size(barW, barH))
+    hitBoxes.add(StageHitBox(x, barTop, xEnd, barTop + barH, "LIGHT",
+        session.sleep_start, session.sleep_end, nightLabel))
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStageSegment(
+    stage: SleepStageResponse,
+    windowStart: Int,
+    windowDuration: Int,
+    labelPx: Float,
+    drawableW: Float,
+    barTop: Float,
+    barH: Float,
+    nightLabel: String,
+    hitBoxes: MutableList<StageHitBox>
+) {
+    val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return
+    val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return
+    var startMin = ss.hour * 60 + ss.minute
+    var endMin   = se.hour * 60 + se.minute
+    if (endMin < startMin) endMin += 1440
+
+    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
+    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
+    if (endOff <= startOff) return
+
+    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
+    val barW = xEnd - x
+    if (barW <= 0f) return
+
+    // AWAKE segments are shorter to distinguish them visually
+    val segH  = if (stage.stage == "AWAKE") barH * 0.5f else barH
+    val segTop = barTop + (barH - segH) / 2f
+
+    drawRect(
+        color   = stageColor(stage.stage),
+        topLeft = Offset(x, segTop),
+        size    = Size(barW, segH)
+    )
+    hitBoxes.add(StageHitBox(x, segTop, xEnd, segTop + segH,
+        stage.stage, stage.stage_start, stage.stage_end, nightLabel))
+}
+
+// ── Bottom sheet detail ──────────────────────────────────────────────────────
+
+@Composable
+private fun StageDetailSheet(stage: StageHitBox) {
+    val start = runCatching { OffsetDateTime.parse(stage.stageStart) }.getOrNull()
+    val end   = runCatching { OffsetDateTime.parse(stage.stageEnd) }.getOrNull()
+    val duration = if (start != null && end != null) Duration.between(start, end) else null
+    val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+            .padding(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Text(
+            text = stage.nightLabel,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+        )
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(stageColor(stage.stageType))
+            )
+            Text(
+                text = stageDisplayName(stage.stageType),
+                style = MaterialTheme.typography.titleMedium,
+                color = stageColor(stage.stageType)
+            )
+        }
+        if (duration != null) {
+            val h  = duration.toHours()
+            val mm = duration.toMinutes() % 60
+            Text(
+                text = if (h > 0) "${h}h ${mm.toString().padStart(2, '0')}min" else "${mm}min",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+        if (start != null && end != null) {
+            Text(
+                text = "${start.format(timeFmt)} → ${end.format(timeFmt)}",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
         }
     }
 }
@@ -323,7 +528,14 @@ private fun TimelineCanvas(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `computeTimelineWindow` (function) — lines 35-46
-- `TimelineScreen` (function) — lines 48-147
-- `TimelineAxisHeader` (function) — lines 149-194
-- `TimelineCanvas` (function) — lines 196-295
+- `stageColor` (function) — lines 50-56
+- `stageDisplayName` (function) — lines 58-64
+- `computeTimelineWindow` (function) — lines 68-76
+- `groupByNight` (function) — lines 80-87
+- `StageHitBox` (class) — lines 91-97
+- `TimelineScreen` (function) — lines 101-214
+- `TimelineAxisHeader` (function) — lines 218-252
+- `TimelineCanvas` (function) — lines 256-375
+- `drawFallbackBar` (function) — lines 379-408
+- `drawStageSegment` (function) — lines 410-447
+- `StageDetailSheet` (function) — lines 451-500

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreenTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreenTest.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreenTest.kt
-git_blob: 7ab09fb66e23faeb6f137635233fac1a89a6a908
-last_synced: '2026-05-09T06:05:32Z'
+git_blob: 6bef60c6e5168bf270be17f7f227ae6dcd358dbe
+last_synced: '2026-05-09T08:38:11Z'
 loc: 612
 annotations: []
 imports: []
@@ -161,7 +161,7 @@ class HypnogramScreenSnapshotTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         paparazzi.snapshot {
@@ -184,7 +184,7 @@ class HypnogramScreenSnapshotTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         paparazzi.snapshot {
@@ -277,7 +277,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         composeTestRule.setContent {
@@ -304,7 +304,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         composeTestRule.setContent {
@@ -331,7 +331,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         composeTestRule.setContent {
@@ -425,7 +425,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(sessionNoStages)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(sessionNoStages))
         )
 
         composeTestRule.setContent {
@@ -464,7 +464,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(sessionZeroDuration)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(sessionZeroDuration))
         )
 
         composeTestRule.setContent {
@@ -486,7 +486,7 @@ class HypnogramScreenInteractionTest {
         val viewModel = buildViewModel()
         injectHypnogramState(
             viewModel,
-            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(fullSession)
+            fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success(listOf(fullSession))
         )
 
         var backCalled = false
@@ -543,7 +543,7 @@ class HypnogramViewModelTest {
     }
 
     // spec: TA-H-VM-01 — repository retourne [fullSession], loadSession() filtre par "hyp-001"
-    //   → uiState = HypnogramUiState.Success(fullSession)
+    //   → uiState = HypnogramUiState.Success(listOf(fullSession))
     // RED: HypnogramViewModel.loadSession() n'existe pas encore
     @Test
     fun hypnogramViewModel_emits_success_when_session_found() = runTest {
@@ -559,10 +559,10 @@ class HypnogramViewModelTest {
             "uiState must be HypnogramUiState.Success when session hyp-001 is found — spec: TA-H-VM-01, got: $state"
         }
 
-        // spec: TA-H-VM-01 — Success.session doit être la session correspondant au sessionId
-        val session = (state as fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success).session
-        assert(session.id == "hyp-001") {
-            "Success.session.id must be 'hyp-001' — spec: TA-H-VM-01, got: ${session.id}"
+        // spec: TA-H-VM-01 — Success.sessions doit contenir la session correspondant au sessionId
+        val sessions = (state as fr.datasaillance.nightfall.viewmodel.sleep.HypnogramUiState.Success).sessions
+        assert(sessions.any { it.id == "hyp-001" }) {
+            "Success.sessions must contain session 'hyp-001' — spec: TA-H-VM-01, got: ${sessions.map { it.id }}"
         }
     }
 

--- a/docs/vault/code/server/routers/sleep.md
+++ b/docs/vault/code/server/routers/sleep.md
@@ -2,9 +2,9 @@
 type: code-source
 language: python
 file_path: server/routers/sleep.py
-git_blob: 9000f5af1fa903c59cfdc25d0b10269412451430
-last_synced: '2026-05-07T16:11:01Z'
-loc: 149
+git_blob: 7765583e149d3519e98155decfc72fe427ccac61
+last_synced: '2026-05-09T08:38:11Z'
+loc: 177
 annotations: []
 imports:
 - datetime
@@ -48,11 +48,39 @@ from server.logging_config import get_logger
 from server.models import SleepBulkIn, SleepSessionOut, SleepStageOut
 from server.security.auth import get_current_user
 from server.security.rate_limit import _api_post_cap, _user_id_key, limiter
-from server.services.csv_import import MAX_CSV_BYTES, parse_samsung_csv, parse_sleep_rows
+from server.services.csv_import import MAX_CSV_BYTES, parse_samsung_csv, parse_sleep_rows, parse_sleep_stage_rows
 
 _log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/sleep", tags=["sleep"])
+
+
+@router.post("/import-stages", status_code=200)
+@limiter.limit(_api_post_cap, key_func=_user_id_key)
+def import_sleep_stages(
+    request: Request,
+    response: Response,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    raw = file.file.read(MAX_CSV_BYTES + 1)
+    if len(raw) > MAX_CSV_BYTES:
+        raise HTTPException(status_code=413, detail="file_too_large")
+    try:
+        rows = parse_samsung_csv(raw)
+    except (UnicodeDecodeError, ValueError):
+        raise HTTPException(status_code=422, detail="invalid_csv_encoding")
+    inserted, skipped = parse_sleep_stage_rows(rows, current_user.id, db)
+    _log.info(
+        "csv_import.done",
+        endpoint="sleep_stage",
+        inserted=inserted,
+        skipped=skipped,
+        user_id=str(current_user.id),
+        filename=file.filename[:255] if file.filename else None,
+    )
+    return {"inserted": inserted, "skipped": skipped}
 
 
 @router.post("/import", status_code=200)
@@ -197,9 +225,9 @@ def get_sleep_sessions(
 - [[../../specs/2026-04-26-v2.3.3.1-rate-limit-lockout]] — symbols: `router`
 
 ### Symbols
-- `_parse_day` (function) — lines 48-49
-- `_to_iso` (function) — lines 97-102
-- `_serialize` (function) — lines 105-123
+- `_parse_day` (function) — lines 76-77
+- `_to_iso` (function) — lines 125-130
+- `_serialize` (function) — lines 133-151
 
 ### Imports
 - `datetime`

--- a/docs/vault/code/server/services/csv_import.md
+++ b/docs/vault/code/server/services/csv_import.md
@@ -2,25 +2,27 @@
 type: code-source
 language: python
 file_path: server/services/csv_import.py
-git_blob: 493c47c175a6ddfc7c17405627d740ae75cdd3c3
-last_synced: '2026-05-07T16:11:01Z'
-loc: 218
+git_blob: e989f8e2cccd3d12137ded5b22290bd3178cd068
+last_synced: '2026-05-09T08:38:11Z'
+loc: 304
 annotations: []
 imports:
 - csv
 - io
+- sys
 - collections
 - datetime
 - uuid
-- sqlalchemy
 - sqlalchemy.dialects.postgresql
 - sqlalchemy.orm
+- sqlalchemy
 - server.db.models
 - server.logging_config
 exports:
 - parse_samsung_csv
 - _parse_ts
 - parse_sleep_rows
+- parse_sleep_stage_rows
 - parse_heartrate_rows
 - parse_steps_rows
 - parse_exercise_rows
@@ -41,20 +43,29 @@ from __future__ import annotations
 
 import csv
 import io
+import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from server.db.models import ExerciseSession, HeartRateHourly, SleepSession, StepsHourly
+from sqlalchemy import select
+
+from server.db.models import ExerciseSession, HeartRateHourly, SleepSession, SleepStage, StepsHourly
 from server.logging_config import get_logger
 
 _log = get_logger(__name__)
 
-MAX_CSV_BYTES = 10 * 1024 * 1024
+MAX_CSV_BYTES = 100 * 1024 * 1024
+
+_SLEEP_STAGE_MAP: dict[int, str] = {
+    40001: "AWAKE",
+    40002: "LIGHT",
+    40003: "DEEP",
+    40004: "REM",
+}
 
 _EXERCISE_TYPE_MAP: dict[int, str] = {
     1001: "running",
@@ -67,12 +78,24 @@ _EXERCISE_TYPE_MAP: dict[int, str] = {
 
 
 def parse_samsung_csv(raw_bytes: bytes) -> list[dict]:
-    text = raw_bytes.decode("utf-8")
+    csv.field_size_limit(sys.maxsize)
+    # utf-8-sig strips the BOM (U+FEFF) that Samsung Health prepends to every CSV
+    text = raw_bytes.decode("utf-8-sig")
     lines = [ln for ln in text.splitlines() if not ln.startswith("#")]
     if not lines:
         return []
-    reader = csv.DictReader(io.StringIO("\n".join(lines)))
-    return list(reader)
+    # Samsung Health CSVs start with a metadata line: namespace,user_id,version
+    # The second field is always a numeric user ID — use that to detect it.
+    parts = lines[0].split(",", 2)
+    if len(parts) >= 2 and parts[1].strip().isdigit():
+        lines = lines[1:]
+    if not lines:
+        return []
+    try:
+        reader = csv.DictReader(io.StringIO("\n".join(lines)))
+        return list(reader)
+    except csv.Error as exc:
+        raise ValueError(f"malformed_csv: {exc}") from exc
 
 
 def _parse_ts(value: str) -> datetime:
@@ -102,24 +125,79 @@ def parse_sleep_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
             skipped += 1
             continue
 
-        existing = db.execute(
-            select(SleepSession).where(
-                SleepSession.user_id == user_id,
-                SleepSession.sleep_start == start,
-                SleepSession.sleep_end == end,
-            )
-        ).scalar_one_or_none()
-        if existing is not None:
+        stmt = (
+            pg_insert(SleepSession)
+            .values(user_id=user_id, sleep_start=start, sleep_end=end)
+            .on_conflict_do_nothing(index_elements=["user_id", "sleep_start", "sleep_end"])
+            .returning(SleepSession.id)
+        )
+        if db.execute(stmt).first() is not None:
+            inserted += 1
+        else:
             skipped += 1
-            continue
-
-        db.add(SleepSession(user_id=user_id, sleep_start=start, sleep_end=end))
-        db.flush()
-        inserted += 1
 
     db.commit()
     if skip_reasons:
         _log.warning("csv_import.rows_skipped", endpoint="sleep", count=sum(skip_reasons.values()), reasons=dict(skip_reasons), user_id=str(user_id))
+    return inserted, skipped
+
+
+def parse_sleep_stage_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int, int]:
+    inserted = 0
+    skipped = 0
+    skip_reasons: Counter = Counter()
+
+    for row in rows:
+        try:
+            start = _parse_ts(row["start_time"])
+            end   = _parse_ts(row["end_time"])
+            stage_code = int(row["stage"])
+        except (KeyError, ValueError, TypeError):
+            skip_reasons["missing_or_invalid_field"] += 1
+            skipped += 1
+            continue
+
+        stage_type = _SLEEP_STAGE_MAP.get(stage_code)
+        if stage_type is None:
+            skip_reasons["unknown_stage_code"] += 1
+            skipped += 1
+            continue
+
+        session = db.execute(
+            select(SleepSession)
+            .where(
+                SleepSession.user_id == user_id,
+                SleepSession.sleep_start <= start,
+                SleepSession.sleep_end >= end,
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if session is None:
+            skip_reasons["no_matching_session"] += 1
+            skipped += 1
+            continue
+
+        stmt = (
+            pg_insert(SleepStage)
+            .values(
+                user_id=user_id,
+                session_id=session.id,
+                stage_type=stage_type,
+                stage_start=start,
+                stage_end=end,
+            )
+            .on_conflict_do_nothing(index_elements=["user_id", "stage_start", "stage_end"])
+            .returning(SleepStage.id)
+        )
+        if db.execute(stmt).first() is not None:
+            inserted += 1
+        else:
+            skipped += 1
+
+    db.commit()
+    if skip_reasons:
+        _log.warning("csv_import.rows_skipped", endpoint="sleep_stage", count=sum(skip_reasons.values()), reasons=dict(skip_reasons), user_id=str(user_id))
     return inserted, skipped
 
 
@@ -130,9 +208,9 @@ def parse_heartrate_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[
     for row in rows:
         try:
             ts = _parse_ts(row["com.samsung.health.heart_rate.start_time"])
-            bpm = int(row["com.samsung.health.heart_rate.heart_rate"])
-            mn = int(row["com.samsung.health.heart_rate.min"])
-            mx = int(row["com.samsung.health.heart_rate.max"])
+            bpm = round(float(row["com.samsung.health.heart_rate.heart_rate"]))
+            mn = round(float(row["com.samsung.health.heart_rate.min"]))
+            mx = round(float(row["com.samsung.health.heart_rate.max"]))
         except KeyError:
             skip_reasons["missing_field"] += 1
             continue
@@ -180,11 +258,21 @@ def parse_steps_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
 
     for row in rows:
         try:
-            ts = _parse_ts(row["com.samsung.health.step_daily_trend.start_time"])
-            count = int(row["com.samsung.health.step_daily_trend.count"])
+            # Samsung Health export: day_time is a Unix timestamp in milliseconds
+            ts_ms = int(row["day_time"])
+            ts = datetime.fromtimestamp(ts_ms / 1000.0, tz=timezone.utc)
+            count = int(row["count"])
         except KeyError:
-            skip_reasons["missing_field"] += 1
-            continue
+            # Fallback: legacy com.samsung.health.* column names
+            try:
+                ts = _parse_ts(row["com.samsung.health.step_daily_trend.start_time"])
+                count = int(row["com.samsung.health.step_daily_trend.count"])
+            except KeyError:
+                skip_reasons["missing_field"] += 1
+                continue
+            except (ValueError, TypeError):
+                skip_reasons["invalid_value"] += 1
+                continue
         except (ValueError, TypeError):
             skip_reasons["invalid_value"] += 1
             continue
@@ -262,22 +350,24 @@ def parse_exercise_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[i
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `parse_samsung_csv` (function) — lines 30-36
-- `_parse_ts` (function) — lines 39-45
-- `parse_sleep_rows` (function) — lines 48-84
-- `parse_heartrate_rows` (function) — lines 87-135
-- `parse_steps_rows` (function) — lines 138-172
-- `parse_exercise_rows` (function) — lines 175-218
+- `parse_samsung_csv` (function) — lines 39-57
+- `_parse_ts` (function) — lines 60-66
+- `parse_sleep_rows` (function) — lines 69-101
+- `parse_sleep_stage_rows` (function) — lines 104-160
+- `parse_heartrate_rows` (function) — lines 163-211
+- `parse_steps_rows` (function) — lines 214-258
+- `parse_exercise_rows` (function) — lines 261-304
 
 ### Imports
 - `csv`
 - `io`
+- `sys`
 - `collections`
 - `datetime`
 - `uuid`
-- `sqlalchemy`
 - `sqlalchemy.dialects.postgresql`
 - `sqlalchemy.orm`
+- `sqlalchemy`
 - `server.db.models`
 - `server.logging_config`
 
@@ -285,6 +375,7 @@ def parse_exercise_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[i
 - `parse_samsung_csv`
 - `_parse_ts`
 - `parse_sleep_rows`
+- `parse_sleep_stage_rows`
 - `parse_heartrate_rows`
 - `parse_steps_rows`
 - `parse_exercise_rows`

--- a/server/routers/sleep.py
+++ b/server/routers/sleep.py
@@ -10,11 +10,39 @@ from server.logging_config import get_logger
 from server.models import SleepBulkIn, SleepSessionOut, SleepStageOut
 from server.security.auth import get_current_user
 from server.security.rate_limit import _api_post_cap, _user_id_key, limiter
-from server.services.csv_import import MAX_CSV_BYTES, parse_samsung_csv, parse_sleep_rows
+from server.services.csv_import import MAX_CSV_BYTES, parse_samsung_csv, parse_sleep_rows, parse_sleep_stage_rows
 
 _log = get_logger(__name__)
 
 router = APIRouter(prefix="/api/sleep", tags=["sleep"])
+
+
+@router.post("/import-stages", status_code=200)
+@limiter.limit(_api_post_cap, key_func=_user_id_key)
+def import_sleep_stages(
+    request: Request,
+    response: Response,
+    file: UploadFile = File(...),
+    db: Session = Depends(get_session),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    raw = file.file.read(MAX_CSV_BYTES + 1)
+    if len(raw) > MAX_CSV_BYTES:
+        raise HTTPException(status_code=413, detail="file_too_large")
+    try:
+        rows = parse_samsung_csv(raw)
+    except (UnicodeDecodeError, ValueError):
+        raise HTTPException(status_code=422, detail="invalid_csv_encoding")
+    inserted, skipped = parse_sleep_stage_rows(rows, current_user.id, db)
+    _log.info(
+        "csv_import.done",
+        endpoint="sleep_stage",
+        inserted=inserted,
+        skipped=skipped,
+        user_id=str(current_user.id),
+        filename=file.filename[:255] if file.filename else None,
+    )
+    return {"inserted": inserted, "skipped": skipped}
 
 
 @router.post("/import", status_code=200)

--- a/server/services/csv_import.py
+++ b/server/services/csv_import.py
@@ -10,12 +10,21 @@ from uuid import UUID
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
-from server.db.models import ExerciseSession, HeartRateHourly, SleepSession, StepsHourly
+from sqlalchemy import select
+
+from server.db.models import ExerciseSession, HeartRateHourly, SleepSession, SleepStage, StepsHourly
 from server.logging_config import get_logger
 
 _log = get_logger(__name__)
 
 MAX_CSV_BYTES = 100 * 1024 * 1024
+
+_SLEEP_STAGE_MAP: dict[int, str] = {
+    40001: "AWAKE",
+    40002: "LIGHT",
+    40003: "DEEP",
+    40004: "REM",
+}
 
 _EXERCISE_TYPE_MAP: dict[int, str] = {
     1001: "running",
@@ -89,6 +98,65 @@ def parse_sleep_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int,
     db.commit()
     if skip_reasons:
         _log.warning("csv_import.rows_skipped", endpoint="sleep", count=sum(skip_reasons.values()), reasons=dict(skip_reasons), user_id=str(user_id))
+    return inserted, skipped
+
+
+def parse_sleep_stage_rows(rows: list[dict], user_id: UUID, db: Session) -> tuple[int, int]:
+    inserted = 0
+    skipped = 0
+    skip_reasons: Counter = Counter()
+
+    for row in rows:
+        try:
+            start = _parse_ts(row["start_time"])
+            end   = _parse_ts(row["end_time"])
+            stage_code = int(row["stage"])
+        except (KeyError, ValueError, TypeError):
+            skip_reasons["missing_or_invalid_field"] += 1
+            skipped += 1
+            continue
+
+        stage_type = _SLEEP_STAGE_MAP.get(stage_code)
+        if stage_type is None:
+            skip_reasons["unknown_stage_code"] += 1
+            skipped += 1
+            continue
+
+        session = db.execute(
+            select(SleepSession)
+            .where(
+                SleepSession.user_id == user_id,
+                SleepSession.sleep_start <= start,
+                SleepSession.sleep_end >= end,
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+
+        if session is None:
+            skip_reasons["no_matching_session"] += 1
+            skipped += 1
+            continue
+
+        stmt = (
+            pg_insert(SleepStage)
+            .values(
+                user_id=user_id,
+                session_id=session.id,
+                stage_type=stage_type,
+                stage_start=start,
+                stage_end=end,
+            )
+            .on_conflict_do_nothing(index_elements=["user_id", "stage_start", "stage_end"])
+            .returning(SleepStage.id)
+        )
+        if db.execute(stmt).first() is not None:
+            inserted += 1
+        else:
+            skipped += 1
+
+    db.commit()
+    if skip_reasons:
+        _log.warning("csv_import.rows_skipped", endpoint="sleep_stage", count=sum(skip_reasons.values()), reasons=dict(skip_reasons), user_id=str(user_id))
     return inserted, skipped
 
 


### PR DESCRIPTION
## Summary

- **Agrégation par nuit** : `groupByNight()` regroupe toutes les sessions par `sleep_start.toLocalDate()` — 1 ligne Canvas = 1 date calendaire, un sommeil entrecoupé n'est plus splité sur 2 lignes
- **Phases colorées** : `drawStageSegment()` colore chaque segment DEEP/LIGHT/REM/AWAKE ; segments AWAKE affichés à 50% de hauteur pour les distinguer visuellement ; fallback barre teal si `stages == null`
- **Bottom sheet interactif** : tap sur un segment ouvre `ModalBottomSheet` avec `StageDetailSheet` — dot coloré (CircleShape), nom de phase, durée calculée, plage horaire hh:mm → hh:mm
- **Hit-box tap detection** : `StageHitBox` accumule les bounds pixel pendant le draw Canvas ; `pointerInput + detectTapGestures` résout le segment tappé
- **Fix box cassé** : `StageDetailSheet` avait un `Box` avec `.run/.let` imbriqués non-fonctionnels — remplacé par `Box { Modifier.clip(CircleShape).background(stageColor) }`

## Test plan

- [ ] 150 tests GREEN (natif) — `./gradlew :app:testNativeDebugUnitTest`
- [ ] TimelineScreenSnapshotTest ×4 — Paparazzi goldens avec phases colorées
- [ ] TimelineScreenInteractionTest ×6 — testTags `tl_canvas`, `tl_loading`, `tl_error`, `tl_retry`, `tl_empty`, `tl_screen`
- [ ] TimelineViewModelTest ×5 — Loading synchrone, tri par date, guard null sessions
- [ ] Vérifier sur device : sommeil entrecoupé = 1 seule ligne multi-segments
- [ ] Tapper un segment → bottom sheet avec bonne couleur et durée