### PR TITLE
fix(ci): no-cache Docker build — endpoint deployed since Phase 5

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: true
+          no-cache: true
           tags: ghcr.io/lyonmoncef/samsunghealth:${{ steps.meta.outputs.tag }}
 
   deploy:


### PR DESCRIPTION
## Summary

- All previous deploys were serving stale Docker images (all layers "Pull complete 0B" on VPS)
- `build-push-action@v5` uses implicit BuildKit cache: layers with same digest as a prior build are reused even when source code changed
- `no-cache: true` forces a full rebuild on every deploy — guarantees the VPS gets the actual current code
- This unblocks `/api/sleep/import-stages` which has been in the codebase since PR #71 but never reached the VPS

## Test plan

- [ ] After merge: verify `/api/sleep/import-stages` appears in `https://sh-dev.datasaillance.fr/openapi.json`
- [ ] Import "Phases de sommeil" from Android → Timeline shows colored phase blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)