### PR TITLE
fix(ci): context: . — build from checkout, not git URL

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build & push GHCR (no :latest mutable tag — HIGH 2)
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
           tags: ghcr.io/lyonmoncef/samsunghealth:${{ steps.meta.outputs.tag }}
 


### PR DESCRIPTION
## Summary

- `build-push-action@v5` without `context:` defaults to building from the GitHub remote URL (`https://github.com/repo.git#SHA`), whose git clone is cached by BuildKit
- Every build reused the same cached clone → identical layer digests → VPS pulled 0B and kept running old code
- `context: .` uses the locally checked-out filesystem, bypassing the git URL cache entirely

## Test plan

- [ ] Build log shows `COPY server/` without "CACHED" prefix
- [ ] VPS pull shows at least one layer with real bytes (not all 0B)
- [ ] `https://sh-dev.datasaillance.fr/openapi.json` includes `/api/sleep/import-stages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)