### PR TITLE
fix(ci): --force-recreate web on deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -114,7 +114,7 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
-          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
+          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --force-recreate web
           EOF
 
       - name: Smoke test (loop, 60s max)


### PR DESCRIPTION
## Summary

- `docker compose up -d web` without `--force-recreate` silently skips container recreation if Docker Compose thinks config hasn't changed (e.g. if the `sed` updating IMAGE_TAG in `.env.prod` found no match, or the image digest appeared identical)
- The endpoint `/api/sleep/import-stages` was in the built image but the old container kept running
- `--force-recreate` guarantees the container is always replaced with the newly pulled image on every deploy

## Test plan

- [ ] Merge triggers deploy to sh-dev
- [ ] `curl https://sh-dev.datasaillance.fr/openapi.json` includes `/api/sleep/import-stages`
- [ ] Android sleep stage import succeeds