### PR TITLE
fix(ci): context: . + explicit container rm before deploy

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Build & push GHCR (no :latest mutable tag — HIGH 2)
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
+          no-cache: true
           tags: ghcr.io/lyonmoncef/samsunghealth:${{ steps.meta.outputs.tag }}
 
   deploy:
@@ -94,8 +96,13 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << EOF
           set -euo pipefail
           cd /srv/samsunghealth-dev
-          # Write IMAGE_TAG first — --env-file .env.prod overrides shell env in compose interpolation
+          # Verify IMAGE_TAG line exists before sed (silent mismatch = old image deployed)
+          if ! grep -qE "^IMAGE_TAG=" .env.prod; then
+            echo "::error::IMAGE_TAG not found in .env.prod — check file format"
+            exit 1
+          fi
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
+          echo "IMAGE_TAG updated: \$(grep '^IMAGE_TAG=' .env.prod)"
           docker compose -f docker-compose.prod.yml --env-file .env.prod pull web
           # Use run --rm (not exec) — works even if web container not yet started
           CURRENT=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print \$1}')
@@ -112,7 +119,11 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
+          # Stop and remove web explicitly — handles any v1/v2 naming drift
+          docker compose -f docker-compose.prod.yml --env-file .env.prod rm --stop --force web 2>/dev/null || true
           docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
+          echo "=== Running container ==="
+          docker ps --filter "publish=8001" --format "{{.Names}} {{.Image}}"
           EOF
 
       - name: Smoke test (loop, 60s max)


### PR DESCRIPTION
## Root cause

`docker compose up -d web` silently redéployait l'**ancienne image** à cause de deux problèmes combinés :

1. **Build context erroné** : sans `context: .`, BuildKit construisait depuis `github.com/repo.git#SHA` — le clone git était mis en cache par URL → layers byte-identiques à chaque build → VPS recevait la vieille image
2. **Sed silencieux** : si la ligne `IMAGE_TAG=` dans `.env.prod` ne matchait pas exactement `^IMAGE_TAG=`, le sed ne modifiait rien → `docker compose up -d` redémarrait le container avec l'ancien tag

## Fixes

- `context: .` + `no-cache: true` : build depuis le checkout CI, layers toujours frais
- Vérification que `IMAGE_TAG=` existe dans `.env.prod` avant le `sed` (fail-fast si format incorrect)
- Echo du tag après mise à jour pour diagnostic CI
- `docker compose rm --stop --force web` avant `up -d` : supprime le container existant quel que soit son nom (gère le drift v1/v2 Docker Compose)
- `docker ps` post-deploy pour confirmer quel container tourne avec quelle image

## Test plan

- [ ] Merge → deploy automatique sur sh-dev
- [ ] CI log montre `IMAGE_TAG updated: IMAGE_TAG=dev-<sha>` (sed a matchés)
- [ ] CI log montre le container et l'image après deploy
- [ ] `curl https://sh-dev.datasaillance.fr/openapi.json` inclut `/api/sleep/import-stages`
- [ ] Import sleep stage Android fonctionne

## Note

Checkpoint tag créé avant force push : `checkpoint-before-history-clean-2026-05-09`