### PR TITLE
fix(ci): pull web < /dev/null — prevent stdin consumption in SSH heredoc

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Build & push GHCR (no :latest mutable tag — HIGH 2)
         uses: docker/build-push-action@v5
         with:
+          context: .
           push: true
+          no-cache: true
           tags: ghcr.io/lyonmoncef/samsunghealth:${{ steps.meta.outputs.tag }}
 
   deploy:
@@ -94,9 +96,11 @@ jobs:
           ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << EOF
           set -euo pipefail
           cd /srv/samsunghealth-dev
-          # Write IMAGE_TAG first — --env-file .env.prod overrides shell env in compose interpolation
           sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
-          docker compose -f docker-compose.prod.yml --env-file .env.prod pull web
+          echo "IMAGE_TAG: \$(grep '^IMAGE_TAG=' .env.prod)"
+          # < /dev/null — docker compose pull consomme le stdin SSH sans ça,
+          # bash voit EOF et stoppe l'exécution du heredoc après le pull
+          docker compose -f docker-compose.prod.yml --env-file .env.prod pull web < /dev/null
           # Use run --rm (not exec) — works even if web container not yet started
           CURRENT=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print \$1}')
           EXPECTED=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic heads 2>/dev/null | awk 'NR==1{print \$1}')
@@ -104,7 +108,6 @@ jobs:
             echo "::error::Failed to read alembic heads"
             exit 1
           fi
-          # CURRENT empty = fresh DB, treat as (none)
           CURRENT=\${CURRENT:-(none)}
           echo "alembic current=\$CURRENT expected=\$EXPECTED"
           if [ "\$CURRENT" != "\$EXPECTED" ] && [ "\$CURRENT" != "(none)" ]; then
@@ -112,7 +115,9 @@ jobs:
             exit 1
           fi
           docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
+          docker compose -f docker-compose.prod.yml --env-file .env.prod rm --stop --force web 2>/dev/null || true
           docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
+          echo "container: \$(docker ps --filter 'publish=8001' --format '{{.Names}} {{.Image}}')"
           EOF
 
       - name: Smoke test (loop, 60s max)


### PR DESCRIPTION
## Summary

- Root cause of all silent deploy failures since #71: `docker compose pull web` reads from SSH stdin in the heredoc context, consuming the remaining commands — bash sees EOF after the pull and exits cleanly (exit 0), leaving the old container running
- Evidence: "Image Pulled" → Smoke test start was only 4-5 seconds across every deploy (#72–#77), impossible if alembic + container restart were actually running
- Fixes: `pull web < /dev/null` (stdin isolation), `context: .` + `no-cache: true` on build step, explicit `rm --stop --force web` before `up -d`, echo of IMAGE_TAG and running container for observability

## Test plan

- [ ] Merge → CI build+deploy runs
- [ ] Smoke test passes at `https://sh-dev.datasaillance.fr/healthz`
- [ ] `docker ps` on VPS shows new image tag (dev-<sha>)
- [ ] `/api/sleep/import-stages` responds (not 404) — confirms endpoint deployed
- [ ] CI log shows "alembic current=..." and "container: ..." lines (commands after pull now execute)