### PR TITLE
fix(ci): scp+ssh script file instead of heredoc — fix silent deploy failure

### DIFF
--- a/.github/scripts/deploy-vps.sh
+++ b/.github/scripts/deploy-vps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# VPS deploy script — runs on the VPS, not on the runner.
+# Argument: $1 = IMAGE_TAG (ex: dev-abc123...).
+#
+# Pourquoi un script séparé plutôt qu'un heredoc dans le workflow :
+# `ssh ... bash << EOF ... EOF` envoie le heredoc sur stdin du bash distant.
+# `docker compose pull` peut consommer ce stdin (ou la connexion SSH se ferme
+# pendant le pull), bash voit EOF et sort proprement (exit 0), laissant
+# l'ancien container tourner. Symptôme : déploiement "success" mais image
+# inchangée. Un script-fichier exécuté via `bash /tmp/deploy.sh` n'a pas ce
+# problème — bash lit le fichier, pas stdin.
+set -euo pipefail
+
+IMAGE_TAG="${1:-}"
+if [ -z "$IMAGE_TAG" ]; then
+  echo "::error::IMAGE_TAG arg required"
+  exit 1
+fi
+
+cd /srv/samsunghealth-dev
+
+if ! grep -qE "^IMAGE_TAG=" .env.prod; then
+  echo "::error::IMAGE_TAG not found in .env.prod"
+  exit 1
+fi
+sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
+echo "IMAGE_TAG updated: $(grep '^IMAGE_TAG=' .env.prod)"
+
+docker compose -f docker-compose.prod.yml --env-file .env.prod pull web
+
+CURRENT=$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print $1}')
+EXPECTED=$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic heads 2>/dev/null | awk 'NR==1{print $1}')
+if [ -z "$EXPECTED" ]; then
+  echo "::error::Failed to read alembic heads"
+  exit 1
+fi
+CURRENT=${CURRENT:-(none)}
+echo "alembic current=$CURRENT expected=$EXPECTED"
+if [ "$CURRENT" != "$EXPECTED" ] && [ "$CURRENT" != "(none)" ]; then
+  echo "::error::Alembic drift — current=$CURRENT expected=$EXPECTED"
+  exit 1
+fi
+
+docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
+docker compose -f docker-compose.prod.yml --env-file .env.prod rm --stop --force web 2>/dev/null || true
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
+
+echo "=== Running container ==="
+docker ps --filter "publish=8001" --format "{{.Names}} {{.Image}}"

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -93,39 +93,12 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE_TAG="${{ needs.build.outputs.image_tag }}"
-          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" bash << EOF
-          set -euo pipefail
-          cd /srv/samsunghealth-dev
-          # Verify IMAGE_TAG line exists before sed (silent mismatch = old image deployed)
-          if ! grep -qE "^IMAGE_TAG=" .env.prod; then
-            echo "::error::IMAGE_TAG not found in .env.prod — check file format"
-            exit 1
-          fi
-          sed -i "s/^IMAGE_TAG=.*/IMAGE_TAG=$IMAGE_TAG/" .env.prod
-          echo "IMAGE_TAG updated: \$(grep '^IMAGE_TAG=' .env.prod)"
-          # < /dev/null — docker compose pull consomme le stdin SSH sans ça,
-          # bash voit EOF et stoppe l'exécution du heredoc après le pull
-          docker compose -f docker-compose.prod.yml --env-file .env.prod pull web < /dev/null
-          # Use run --rm (not exec) — works even if web container not yet started
-          CURRENT=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic current 2>/dev/null | awk 'NR==1{print \$1}')
-          EXPECTED=\$(docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic heads 2>/dev/null | awk 'NR==1{print \$1}')
-          if [ -z "\$EXPECTED" ]; then
-            echo "::error::Failed to read alembic heads"
-            exit 1
-          fi
-          CURRENT=\${CURRENT:-(none)}
-          echo "alembic current=\$CURRENT expected=\$EXPECTED"
-          if [ "\$CURRENT" != "\$EXPECTED" ] && [ "\$CURRENT" != "(none)" ]; then
-            echo "::error::Alembic drift — current=\$CURRENT expected=\$EXPECTED"
-            exit 1
-          fi
-          docker compose -f docker-compose.prod.yml --env-file .env.prod run --rm web alembic upgrade head
-          # Stop and remove web explicitly — handles any v1/v2 naming drift
-          docker compose -f docker-compose.prod.yml --env-file .env.prod rm --stop --force web 2>/dev/null || true
-          docker compose -f docker-compose.prod.yml --env-file .env.prod up -d web
-          echo "=== Running container ==="
-          docker ps --filter "publish=8001" --format "{{.Names}} {{.Image}}"
-          EOF
+          # Script-file approach (pas de heredoc-over-SSH) — voir commentaire dans
+          # .github/scripts/deploy-vps.sh pour le pourquoi.
+          scp -o StrictHostKeyChecking=yes .github/scripts/deploy-vps.sh \
+            "${{ secrets.VPS_DEV_HOST }}:/tmp/deploy-vps.sh"
+          ssh -o StrictHostKeyChecking=yes "${{ secrets.VPS_DEV_HOST }}" \
+            "bash /tmp/deploy-vps.sh '$IMAGE_TAG' && rm /tmp/deploy-vps.sh"
 
       - name: Smoke test (loop, 60s max)
         id: smoke


### PR DESCRIPTION
## Root cause

PR #78 (`< /dev/null`) n'a **pas** résolu le problème. Run de prod #25601268262 prouve :
- 12:36:18.95 — Image Pulled
- 12:36:23.55 — Smoke test démarre

5 secondes entre les deux, **rien d'autre dans le log** : pas de `alembic current=`, pas de `=== Running container ===`. Les commandes après le pull ne s'exécutent toujours pas, et `/api/sleep/import-stages` reste en 404.

Le pattern `ssh ... bash << EOF ... EOF` est intrinsèquement fragile : `docker compose pull` (ou la connexion SSH pendant le pull lourd) interfère avec le stdin du bash distant et bash sort proprement (exit 0). Le `< /dev/null` ciblé sur la commande pull ne suffit pas — d'autres mécanismes (re-ouverture de tty, fork de processus) bypass la redirection.

## Fix

Remplacer le heredoc par un **fichier de script** :
1. `.github/scripts/deploy-vps.sh` — script bash autonome avec toute la logique de déploiement
2. `deploy-dev.yml` : `scp` le script sur le VPS, puis `ssh ... bash /tmp/deploy-vps.sh "$IMAGE_TAG"`

Bash distant lit le **fichier**, pas son stdin → plus aucune interférence possible avec `docker compose pull`.

## Pourquoi ça commence à planter "depuis PR #71"

Le workflow était déjà cassé depuis le commit initial `6067a94`. Mais pré-#71, les pulls avaient surtout des couches en cache (deploys peu espacés) → pull rapide, peu d'I/O sur stdin → bash terminait l'heredoc avant que la corruption stdin se manifeste. PR #71 = release massive (90 fichiers, nouvelle image complète) → pull lent → premier déploiement où le bug se révèle systématiquement.

## Test plan

- [ ] Merge → CI passe et logs montrent `IMAGE_TAG updated:` + `alembic current=...` + `=== Running container ===`
- [ ] `curl https://sh-dev.datasaillance.fr/api/sleep/import-stages` → 405 (méthode) ou 401 (auth), **pas 404**
- [ ] Image VPS = `dev-<sha-de-cette-PR>`
- [ ] Note : `deploy-prod.yml` a le même heredoc — à refactorer dans un PR séparé après validation dev