### PR TITLE
feat(timeline): lazy loading, mountain view, scrub tooltip + perf fix hypnogram

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
@@ -1,5 +1,10 @@
 package fr.datasaillance.nightfall.data.sleep
 
+import java.time.LocalDate
+
 interface SleepRepository {
-    suspend fun getSessions(): Result<List<SleepSessionResponse>>
+    suspend fun getSessions(
+        from: LocalDate? = null,
+        to: LocalDate? = null,
+    ): Result<List<SleepSessionResponse>>
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
@@ -4,18 +4,27 @@ import fr.datasaillance.nightfall.data.auth.TokenDataStore
 import fr.datasaillance.nightfall.data.http.NightfallApi
 import timber.log.Timber
 import java.io.IOException
+import java.time.LocalDate
 
 class SleepRepositoryImpl(
     private val api: NightfallApi,
     private val tokenDataStore: TokenDataStore
 ) : SleepRepository {
 
-    override suspend fun getSessions(): Result<List<SleepSessionResponse>> {
+    override suspend fun getSessions(
+        from: LocalDate?,
+        to: LocalDate?,
+    ): Result<List<SleepSessionResponse>> {
         val token = tokenDataStore.getToken()
             ?: return Result.failure(IOException("No auth token"))
         return try {
-            val sessions = api.getSleepSessions("Bearer $token", includeStages = true)
-            Timber.i("sleep_sessions_fetched count=${sessions.size}")
+            val sessions = api.getSleepSessions(
+                token = "Bearer $token",
+                from = from?.toString(),
+                to = to?.toString(),
+                includeStages = true,
+            )
+            Timber.i("sleep_sessions_fetched count=${sessions.size} from=$from to=$to")
             Result.success(sessions)
         } catch (e: retrofit2.HttpException) {
             Timber.w("sleep_fetch_http_error code=${e.code()}")

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
@@ -13,8 +13,11 @@ sealed class NavDestination(
     object Profile  : NavDestination("profile",  "Profil")
     object Import   : NavDestination("import",   "Importer")
     object Settings : NavDestination("settings", "Paramètres")
-    object Hypnogram : NavDestination("hypnogram/{sessionId}", "Hypnogramme") {
-        fun route(id: String): String = "hypnogram/$id"
+    object Hypnogram : NavDestination("hypnogram/{sessionId}?date={date}", "Hypnogramme") {
+        // date facultative (ISO yyyy-MM-dd) — quand fournie, on fetch uniquement cette nuit
+        // au lieu de télécharger tout l'historique sleep_sessions du user.
+        fun route(id: String, date: String? = null): String =
+            if (date != null) "hypnogram/$id?date=$date" else "hypnogram/$id"
     }
 
     companion object {

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -149,9 +149,17 @@ fun NavGraph(
             }
             composable(
                 route = NavDestination.Hypnogram.route,
-                arguments = listOf(navArgument("sessionId") { type = NavType.StringType })
+                arguments = listOf(
+                    navArgument("sessionId") { type = NavType.StringType },
+                    navArgument("date") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                )
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
+                val dateArg = backStackEntry.arguments?.getString("date")
                 val hypnogramRepository: SleepRepository = remember(api, tokenDataStore) {
                     if (api != null && tokenDataStore != null) {
                         SleepRepositoryImpl(api, tokenDataStore)
@@ -159,8 +167,8 @@ fun NavGraph(
                         NoOpSleepRepository()
                     }
                 }
-                val hypnogramViewModel = remember(sessionId, hypnogramRepository) {
-                    HypnogramViewModel(sessionId, hypnogramRepository)
+                val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
+                    HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
                 }
                 HypnogramScreen(
                     viewModel = hypnogramViewModel,
@@ -176,7 +184,12 @@ fun NavGraph(
                     }
                 }
                 val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
-                TimelineScreen(viewModel = timelineViewModel)
+                TimelineScreen(
+                    viewModel = timelineViewModel,
+                    onOpenHypnogram = { sessionId, isoDate ->
+                        navController.navigate(NavDestination.Hypnogram.route(sessionId, isoDate))
+                    },
+                )
             }
             composable(NavDestination.Activity.route) { ActivityScreen() }
             composable(NavDestination.Profile.route) {
@@ -216,8 +229,10 @@ fun NavGraph(
 }
 
 private class NoOpSleepRepository : SleepRepository {
-    override suspend fun getSessions(): Result<List<SleepSessionResponse>> =
-        Result.success(emptyList())
+    override suspend fun getSessions(
+        from: java.time.LocalDate?,
+        to: java.time.LocalDate?,
+    ): Result<List<SleepSessionResponse>> = Result.success(emptyList())
 }
 
 private class NoOpImportRepository : ImportRepository {

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 sealed class HypnogramUiState {
@@ -22,7 +23,8 @@ sealed class HypnogramUiState {
 
 class HypnogramViewModel(
     private val sessionId: String,
-    private val repository: SleepRepository
+    private val repository: SleepRepository,
+    private val hintDate: String? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HypnogramUiState>(HypnogramUiState.Idle)
@@ -39,8 +41,16 @@ class HypnogramViewModel(
         viewModelScope.launch {
             yield()
             try {
-                Timber.d("scope=hypno_vm session_id=$sessionId loading")
-                val result = repository.getSessions()
+                Timber.d("scope=hypno_vm session_id=$sessionId hint_date=$hintDate loading")
+                // Si une hint date est fournie (via nav arg) on cadre la requête sur cette nuit
+                // au lieu de fetcher tout l'historique. Fenêtre [date-1, date+1] pour couvrir
+                // les sessions à cheval sur minuit.
+                val parsedHint = hintDate?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+                val result = if (parsedHint != null) {
+                    repository.getSessions(from = parsedHint.minusDays(1), to = parsedHint.plusDays(1))
+                } else {
+                    repository.getSessions()
+                }
                 if (result.isFailure) {
                     val code = (result.exceptionOrNull() as? retrofit2.HttpException)?.code()
                     if (code != null) Timber.w("scope=hypno_vm http_code=$code")

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
@@ -11,55 +11,78 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import timber.log.Timber
 import java.io.IOException
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
+private const val PAGE_DAYS = 30L
+// Pour le 1er chargement : on n'a pas de borne d'historique, donc on étend la
+// fenêtre vers le passé jusqu'à trouver des données ou abandonner.
+private const val INITIAL_MAX_BACKOFF_PAGES = 24  // ~2 ans
+
 sealed class TimelineUiState {
-    object Idle    : TimelineUiState()
+    object Idle : TimelineUiState()
     object Loading : TimelineUiState()
-    data class Success(val sessions: List<SleepSessionResponse>) : TimelineUiState()
-    object Empty   : TimelineUiState()
+    data class Success(
+        val sessions: List<SleepSessionResponse>,
+        val loadingMore: Boolean = false,
+        val hasMore: Boolean = true,
+    ) : TimelineUiState()
+    object Empty : TimelineUiState()
     data class Error(val message: String) : TimelineUiState()
 }
 
 class TimelineViewModel(
-    private val repository: SleepRepository
+    private val repository: SleepRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
     val uiState: StateFlow<TimelineUiState> = _uiState.asStateFlow()
 
+    // Borne basse de la fenêtre actuellement chargée (= sleep_start le plus ancien).
+    // null tant que rien n'a été chargé.
+    private var oldestLoaded: LocalDate? = null
+
     init {
-        loadSessions()
+        loadInitial()
     }
 
-    fun retry() = loadSessions()
+    fun retry() = loadInitial()
 
-    private fun loadSessions() {
+    private fun loadInitial() {
         _uiState.value = TimelineUiState.Loading
+        oldestLoaded = null
         viewModelScope.launch {
             yield()
             try {
-                val result = repository.getSessions()
-                if (result.isFailure) {
-                    _uiState.value = TimelineUiState.Error(mapError(result.exceptionOrNull()))
-                    return@launch
+                val today = LocalDate.now()
+                var from = today.minusDays(PAGE_DAYS)
+                var to = today
+                var sessions: List<SleepSessionResponse>? = null
+                var attempts = 0
+                while (attempts < INITIAL_MAX_BACKOFF_PAGES) {
+                    val result = repository.getSessions(from = from, to = to)
+                    if (result.isFailure) {
+                        _uiState.value = TimelineUiState.Error(mapError(result.exceptionOrNull()))
+                        return@launch
+                    }
+                    val batch = result.getOrNull() ?: emptyList()
+                    if (batch.isNotEmpty()) {
+                        sessions = batch
+                        oldestLoaded = from
+                        break
+                    }
+                    // Pas de données : on étend la fenêtre vers le passé.
+                    to = from.minusDays(1)
+                    from = to.minusDays(PAGE_DAYS)
+                    attempts++
                 }
-                val sessions = result.getOrNull()
-                // sessions can only be null from an unstubbed mock (SleepRepositoryImpl always
-                // returns a non-null List). Silent return preserves injected test state.
                 if (sessions == null) {
-                    Timber.w("scope=timeline_vm sessions_null")
-                    return@launch
-                }
-                if (sessions.isEmpty()) {
                     _uiState.value = TimelineUiState.Empty
                     return@launch
                 }
                 _uiState.value = TimelineUiState.Success(
-                    sessions.sortedBy { session ->
-                        runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }
-                            .getOrNull()
-                    }
+                    sessions = sortSessions(sessions),
+                    hasMore = true,
                 )
             } catch (e: Exception) {
                 Timber.w("scope=timeline_vm error=${e::class.simpleName}")
@@ -67,6 +90,54 @@ class TimelineViewModel(
             }
         }
     }
+
+    fun loadOlder() {
+        val current = _uiState.value as? TimelineUiState.Success ?: return
+        if (current.loadingMore || !current.hasMore) return
+        val anchor = oldestLoaded ?: return
+
+        _uiState.value = current.copy(loadingMore = true)
+        viewModelScope.launch {
+            try {
+                val to = anchor.minusDays(1)
+                val from = to.minusDays(PAGE_DAYS)
+                val result = repository.getSessions(from = from, to = to)
+                if (result.isFailure) {
+                    Timber.w("scope=timeline_vm load_older_failed")
+                    _uiState.value = current.copy(loadingMore = false)
+                    return@launch
+                }
+                val batch = result.getOrNull() ?: emptyList()
+                oldestLoaded = from
+                if (batch.isEmpty()) {
+                    // Une seule page vide ne signifie pas fin d'historique : on continue
+                    // plus loin via un prochain trigger. Pour éviter une boucle, on
+                    // marque hasMore=false seulement après plusieurs pages vides
+                    // consécutives — ici on garde simple et on laisse l'utilisateur
+                    // re-trigger manuellement (futur scroll). Marquage conservateur :
+                    _uiState.value = current.copy(
+                        loadingMore = false,
+                        hasMore = false,
+                    )
+                    return@launch
+                }
+                val merged = sortSessions(current.sessions + batch)
+                _uiState.value = current.copy(
+                    sessions = merged,
+                    loadingMore = false,
+                    hasMore = true,
+                )
+            } catch (e: Exception) {
+                Timber.w("scope=timeline_vm load_older_error error=${e::class.simpleName}")
+                _uiState.value = current.copy(loadingMore = false)
+            }
+        }
+    }
+
+    private fun sortSessions(list: List<SleepSessionResponse>): List<SleepSessionResponse> =
+        list.sortedBy { session ->
+            runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }.getOrNull()
+        }
 
     private fun mapError(throwable: Throwable?): String = when (throwable) {
         is IOException -> "Vérifiez votre connexion réseau"

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
@@ -2,9 +2,11 @@ package fr.datasaillance.nightfall.ui.screens.sleep
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -12,13 +14,17 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
@@ -36,11 +42,44 @@ private val ColorLight = Color(0xFF7A9AAA)
 private val ColorRem   = Color(0xFF07BCD3)
 private val ColorAwake = Color(0xFFD37C04)
 
+private const val HYPNO_MICRO_AWAKE_THRESHOLD_MIN = 5
+
+enum class HypnogramViewMode { BARS, MOUNTAIN }
+
 private fun stageColor(stageType: String): Color = when (stageType) {
     "DEEP"  -> ColorDeep
     "REM"   -> ColorRem
     "AWAKE" -> ColorAwake
     else    -> ColorLight
+}
+
+private fun hypnoMountainLevel(stage: String): Int = when (stage) {
+    "REM"   -> 4
+    "LIGHT" -> 3
+    "DEEP"  -> 2
+    "AWAKE" -> 1
+    else    -> 0
+}
+
+private fun hypnoStageDisplayName(type: String): String = when (type) {
+    "DEEP"  -> "Sommeil profond"
+    "LIGHT" -> "Sommeil léger"
+    "REM"   -> "Sommeil paradoxal"
+    "AWAKE" -> "Éveil"
+    else    -> type
+}
+
+/**
+ * Cherche le stage qui couvre un instant `t` (offset depuis le début).
+ * Retourne null si aucun stage ne le couvre (gap entre 2 sessions).
+ */
+private fun stageAtTime(
+    t: OffsetDateTime,
+    sortedStages: List<SleepStageResponse>,
+): SleepStageResponse? = sortedStages.firstOrNull { stage ->
+    val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return@firstOrNull false
+    val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return@firstOrNull false
+    !t.isBefore(ss) && t.isBefore(se)
 }
 
 private fun nightTitle(sleepStart: String): String {
@@ -60,6 +99,7 @@ fun HypnogramScreen(
     onBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var viewMode by remember { mutableStateOf(HypnogramViewMode.BARS) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -81,6 +121,19 @@ fun HypnogramScreen(
                             onBack()
                         }) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Retour")
+                        }
+                    },
+                    actions = {
+                        TextButton(
+                            onClick = {
+                                viewMode = if (viewMode == HypnogramViewMode.BARS) HypnogramViewMode.MOUNTAIN else HypnogramViewMode.BARS
+                            },
+                            modifier = Modifier.testTag("hyp_view_toggle"),
+                        ) {
+                            Text(
+                                text = if (viewMode == HypnogramViewMode.BARS) "Mountain" else "Barres",
+                                color = MaterialTheme.colorScheme.primary,
+                            )
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
@@ -136,13 +189,24 @@ fun HypnogramScreen(
                         ) {
                             HypnogramSummarySection(state.sessions)
                             Spacer(modifier = Modifier.height(16.dp))
-                            HypnogramCanvas(
-                                sessions = state.sessions,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(120.dp)
-                                    .testTag("hyp_canvas")
-                            )
+                            when (viewMode) {
+                                HypnogramViewMode.BARS -> HypnogramCanvas(
+                                    sessions = state.sessions,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                        .height(140.dp)
+                                        .testTag("hyp_canvas")
+                                )
+                                HypnogramViewMode.MOUNTAIN -> HypnogramMountainCanvas(
+                                    sessions = state.sessions,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                        .height(180.dp)
+                                        .testTag("hyp_canvas_mountain")
+                                )
+                            }
                             Spacer(modifier = Modifier.height(8.dp))
                             HypnogramLegend()
                             Spacer(modifier = Modifier.height(16.dp))
@@ -211,82 +275,419 @@ private fun HypnogramCanvas(
     val onSurface = MaterialTheme.colorScheme.onSurface
     val surface   = MaterialTheme.colorScheme.surface
 
-    Canvas(modifier = modifier) {
-        val canvasWidth = size.width
-        val stageZoneH  = 100.dp.toPx()
+    val sortedStarts = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }
+    val sortedEnds = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }
+    val start = sortedStarts.minOrNull()
+    val end = sortedEnds.maxOrNull()
+    val totalMs = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+    val allStages = sessions.flatMap { it.stages ?: emptyList() }.sortedBy { it.stage_start }
 
-        val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
-        val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
-        val totalDuration = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+    var scrubX by remember { mutableStateOf<Float?>(null) }
+    var canvasW by remember { mutableStateOf(0f) }
 
-        val allStages = sessions.flatMap { it.stages ?: emptyList() }
-        if (totalDuration <= 0 || allStages.isEmpty()) {
-            drawRect(
-                color   = surface.copy(alpha = 0.3f),
-                topLeft = Offset(0f, 0f),
-                size    = Size(canvasWidth, stageZoneH)
-            )
-            return@Canvas
-        }
+    Box(modifier = modifier) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(start, end, allStages.size) {
+                    detectDragGesturesAfterLongPress(
+                        onDragStart = { offset -> scrubX = offset.x.coerceIn(0f, canvasW) },
+                        onDrag = { change, _ -> scrubX = change.position.x.coerceIn(0f, canvasW) },
+                        onDragEnd = { scrubX = null },
+                        onDragCancel = { scrubX = null },
+                    )
+                }
+        ) {
+            canvasW = size.width
+            val canvasWidth = size.width
+            val stageZoneH = 110.dp.toPx()
+            val cornerR = 4.dp.toPx()
 
-        for (stage in allStages.sortedBy { it.stage_start }) {
-            val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: continue
-            val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: continue
-            val stageDurMs = Duration.between(ss, se).toMillis()
-            val offsetMs   = Duration.between(start, ss).toMillis()
-
-            val x     = (offsetMs.toFloat() / totalDuration) * canvasWidth
-            val width = (stageDurMs.toFloat() / totalDuration) * canvasWidth
-
-            val rectH: Float
-            val rectTop: Float
-            if (stage.stage == "AWAKE") {
-                rectH   = 60.dp.toPx()
-                rectTop = (stageZoneH - rectH) / 2f
-            } else {
-                rectH   = stageZoneH
-                rectTop = 0f
+            if (totalMs <= 0 || allStages.isEmpty() || start == null || end == null) {
+                drawRect(
+                    color = surface.copy(alpha = 0.3f),
+                    topLeft = Offset(0f, 0f),
+                    size = Size(canvasWidth, stageZoneH),
+                )
+                return@Canvas
             }
 
-            drawRect(
-                color   = stageColor(stage.stage),
-                topLeft = Offset(x, rectTop),
-                size    = Size(width, rectH)
-            )
-        }
-
-        val tickStart = start!!.toLocalDateTime().let { ldt ->
-            val h = ldt.hour
-            val nextH = if (ldt.minute > 0 || ldt.second > 0) h + 1 else h
-            start.withHour(nextH % 24).withMinute(0).withSecond(0).withNano(0)
-                .let { if (nextH >= 24) it.plusDays(1) else it }
-        }
-
-        val paint = android.graphics.Paint().apply {
-            textSize  = 10.sp.toPx()
-            color     = onSurface.copy(alpha = 0.5f).toArgb()
-            textAlign = android.graphics.Paint.Align.CENTER
-        }
-
-        var tick = tickStart
-        while (!tick.isAfter(end!!)) {
-            val tickOffsetMs = Duration.between(start, tick).toMillis()
-            val xTick = (tickOffsetMs.toFloat() / totalDuration) * canvasWidth
-            drawLine(
-                color       = onSurface.copy(alpha = 0.3f),
-                start       = Offset(xTick, 95.dp.toPx()),
-                end         = Offset(xTick, stageZoneH),
-                strokeWidth = 1.dp.toPx()
-            )
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawText(
-                    tick.format(DateTimeFormatter.ofPattern("HH:mm")),
-                    xTick,
-                    118.dp.toPx(),
-                    paint
+            val firstStageStart = allStages.first().stage_start
+            val lastStageEnd = allStages.last().stage_end
+            for (stage in allStages) {
+                val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: continue
+                val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: continue
+                val stageDurMs = Duration.between(ss, se).toMillis()
+                val offsetMs = Duration.between(start, ss).toMillis()
+                val x = (offsetMs.toFloat() / totalMs) * canvasWidth
+                val width = (stageDurMs.toFloat() / totalMs) * canvasWidth
+                drawRoundedSegment(
+                    color = stageColor(stage.stage),
+                    left = x,
+                    top = 0f,
+                    width = width,
+                    height = stageZoneH,
+                    cornerRadius = cornerR,
+                    roundLeft = stage.stage_start == firstStageStart,
+                    roundRight = stage.stage_end == lastStageEnd,
                 )
             }
-            tick = tick.plusHours(1)
+
+            // Axe : 4 ticks fixes — coucher (0%), 33%, 66%, réveil (100%)
+            drawAxisFourTicks(start, totalMs, canvasWidth, stageZoneH, onSurface)
+
+            // Curseur de scrub
+            scrubX?.let { x ->
+                drawLine(
+                    color = onSurface.copy(alpha = 0.7f),
+                    start = Offset(x, 0f),
+                    end = Offset(x, stageZoneH),
+                    strokeWidth = 1.5.dp.toPx(),
+                )
+            }
+        }
+
+        // Tooltip flottant pendant le scrub
+        scrubX?.let { x ->
+            if (canvasW > 0 && totalMs > 0 && start != null) {
+                val ratio = (x / canvasW).coerceIn(0f, 1f)
+                val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+                val stage = stageAtTime(t, allStages)
+                ScrubTooltip(
+                    timeText = t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                    stageText = stage?.let { hypnoStageDisplayName(it.stage) } ?: "—",
+                    stageDotColor = stage?.let { stageColor(it.stage) } ?: ColorLight,
+                    xPx = x,
+                    canvasWidthPx = canvasW,
+                )
+            }
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawAxisFourTicks(
+    start: OffsetDateTime,
+    totalMs: Long,
+    canvasWidth: Float,
+    stageZoneH: Float,
+    onSurface: Color,
+) {
+    val paint = android.graphics.Paint().apply {
+        textSize = 13.sp.toPx()
+        color = onSurface.copy(alpha = 0.7f).toArgb()
+        textAlign = android.graphics.Paint.Align.CENTER
+    }
+    val ratios = listOf(0f, 1 / 3f, 2 / 3f, 1f)
+    ratios.forEachIndexed { i, ratio ->
+        val xTick = ratio * canvasWidth
+        val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+        drawLine(
+            color = onSurface.copy(alpha = 0.3f),
+            start = Offset(xTick, stageZoneH - 5.dp.toPx()),
+            end = Offset(xTick, stageZoneH),
+            strokeWidth = 1.dp.toPx(),
+        )
+        // Aligne les labels aux extrémités pour éviter qu'ils dépassent l'écran
+        paint.textAlign = when (i) {
+            0 -> android.graphics.Paint.Align.LEFT
+            ratios.lastIndex -> android.graphics.Paint.Align.RIGHT
+            else -> android.graphics.Paint.Align.CENTER
+        }
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                xTick,
+                stageZoneH + 22.dp.toPx(),
+                paint,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.ScrubTooltip(
+    timeText: String,
+    stageText: String,
+    stageDotColor: Color,
+    xPx: Float,
+    canvasWidthPx: Float,
+) {
+    val density = LocalDensity.current
+    val approxTooltipWidthPx = with(density) { 160.dp.toPx() }
+    val centeredX = (xPx - approxTooltipWidthPx / 2f).coerceIn(0f, canvasWidthPx - approxTooltipWidthPx)
+
+    Surface(
+        modifier = Modifier
+            .offset { IntOffset(centeredX.toInt(), 0) }
+            .align(Alignment.TopStart)
+            .clip(RoundedCornerShape(8.dp)),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 4.dp,
+        tonalElevation = 2.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(stageDotColor),
+            )
+            Text(
+                text = timeText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stageText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+            )
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRoundedSegment(
+    color: Color,
+    left: Float,
+    top: Float,
+    width: Float,
+    height: Float,
+    cornerRadius: Float,
+    roundLeft: Boolean,
+    roundRight: Boolean,
+) {
+    if (width <= 0f) return
+    val rect = androidx.compose.ui.geometry.Rect(left, top, left + width, top + height)
+    if (!roundLeft && !roundRight) {
+        drawRect(color, rect.topLeft, rect.size)
+        return
+    }
+    val radius = cornerRadius.coerceAtMost(width / 2f).coerceAtMost(height / 2f)
+    val path = androidx.compose.ui.graphics.Path().apply {
+        if (roundLeft && roundRight) {
+            addRoundRect(
+                androidx.compose.ui.geometry.RoundRect(rect, androidx.compose.ui.geometry.CornerRadius(radius))
+            )
+        } else if (roundLeft) {
+            // Coins arrondis seulement à gauche, droits à droite
+            moveTo(rect.left + radius, rect.top)
+            lineTo(rect.right, rect.top)
+            lineTo(rect.right, rect.bottom)
+            lineTo(rect.left + radius, rect.bottom)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.left, rect.bottom - 2 * radius, rect.left + 2 * radius, rect.bottom),
+                startAngleDegrees = 90f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            lineTo(rect.left, rect.top + radius)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.left, rect.top, rect.left + 2 * radius, rect.top + 2 * radius),
+                startAngleDegrees = 180f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            close()
+        } else {
+            // Coins arrondis seulement à droite
+            moveTo(rect.left, rect.top)
+            lineTo(rect.right - radius, rect.top)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.right - 2 * radius, rect.top, rect.right, rect.top + 2 * radius),
+                startAngleDegrees = 270f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            lineTo(rect.right, rect.bottom - radius)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.right - 2 * radius, rect.bottom - 2 * radius, rect.right, rect.bottom),
+                startAngleDegrees = 0f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            lineTo(rect.left, rect.bottom)
+            close()
+        }
+    }
+    drawPath(path, color)
+}
+
+// ── Mountain canvas — graph 5 niveaux pour 1 hypnogramme zoomé ─────────────
+
+private data class HypnoMountainSegment(
+    val startMs: Long,
+    val endMs: Long,
+    val level: Int,
+    val color: Color,
+)
+
+private data class HypnoMicroAwake(val tMs: Long)
+
+private fun buildHypnoMountain(
+    sessions: List<SleepSessionResponse>,
+    sessionStart: OffsetDateTime,
+): Pair<List<HypnoMountainSegment>, List<HypnoMicroAwake>> {
+    val segments = mutableListOf<HypnoMountainSegment>()
+    val ticks = mutableListOf<HypnoMicroAwake>()
+    sessions.flatMap { it.stages ?: emptyList() }
+        .sortedBy { it.stage_start }
+        .forEach { stage ->
+            val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return@forEach
+            val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return@forEach
+            val durMin = Duration.between(ss, se).toMinutes()
+            val startMs = Duration.between(sessionStart, ss).toMillis()
+            val endMs = Duration.between(sessionStart, se).toMillis()
+            if (stage.stage == "AWAKE" && durMin < HYPNO_MICRO_AWAKE_THRESHOLD_MIN) {
+                ticks.add(HypnoMicroAwake(startMs))
+            } else {
+                segments.add(
+                    HypnoMountainSegment(
+                        startMs = startMs,
+                        endMs = endMs,
+                        level = hypnoMountainLevel(stage.stage),
+                        color = stageColor(stage.stage),
+                    )
+                )
+            }
+        }
+    return Pair(segments, ticks)
+}
+
+@Composable
+private fun HypnogramMountainCanvas(
+    sessions: List<SleepSessionResponse>,
+    modifier: Modifier = Modifier,
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val gridColor = onSurface.copy(alpha = 0.1f)
+    val lineColor = onSurface.copy(alpha = 0.85f)
+    val tickColor = ColorAwake.copy(alpha = 0.9f)
+
+    val sortedStarts = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }
+    val sortedEnds = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }
+    val start = sortedStarts.minOrNull()
+    val end = sortedEnds.maxOrNull()
+    val totalMs = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+    val allStages = sessions.flatMap { it.stages ?: emptyList() }.sortedBy { it.stage_start }
+
+    var scrubX by remember { mutableStateOf<Float?>(null) }
+    var canvasW by remember { mutableStateOf(0f) }
+
+    Box(modifier = modifier) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(start, end, allStages.size) {
+                    detectDragGesturesAfterLongPress(
+                        onDragStart = { offset -> scrubX = offset.x.coerceIn(0f, canvasW) },
+                        onDrag = { change, _ -> scrubX = change.position.x.coerceIn(0f, canvasW) },
+                        onDragEnd = { scrubX = null },
+                        onDragCancel = { scrubX = null },
+                    )
+                }
+        ) {
+            canvasW = size.width
+            val plotTop = 8.dp.toPx()
+            val plotBot = size.height - 28.dp.toPx()
+            val plotH = plotBot - plotTop
+
+            if (start == null || end == null || totalMs <= 0L) return@Canvas
+
+            fun yForLevel(level: Int): Float = plotBot - (level / 4f) * plotH
+            fun xForMs(ms: Long): Float = (ms.toFloat() / totalMs) * canvasW
+
+            val (segments, ticks) = buildHypnoMountain(sessions, start)
+            val l0y = yForLevel(0)
+
+            for (lvl in 0..4) {
+                val y = yForLevel(lvl)
+                drawLine(gridColor, Offset(0f, y), Offset(canvasW, y), strokeWidth = 1f)
+            }
+
+            segments.forEach { seg ->
+                val x = xForMs(seg.startMs)
+                val xEnd = xForMs(seg.endMs)
+                val w = (xEnd - x).coerceAtLeast(1f)
+                val y = yForLevel(seg.level)
+                drawRect(seg.color.copy(alpha = 0.55f), Offset(x, y), Size(w, l0y - y))
+            }
+
+            if (segments.isNotEmpty()) {
+                val path = androidx.compose.ui.graphics.Path()
+                val first = segments.first()
+                path.moveTo(xForMs(first.startMs), l0y)
+                path.lineTo(xForMs(first.startMs), yForLevel(first.level))
+                segments.forEachIndexed { idx, seg ->
+                    val xEnd = xForMs(seg.endMs)
+                    path.lineTo(xEnd, yForLevel(seg.level))
+                    if (idx < segments.size - 1) {
+                        val next = segments[idx + 1]
+                        val xNextStart = xForMs(next.startMs)
+                        if (xNextStart > xEnd) {
+                            path.lineTo(xEnd, l0y)
+                            path.lineTo(xNextStart, l0y)
+                            path.lineTo(xNextStart, yForLevel(next.level))
+                        } else {
+                            path.lineTo(xEnd, yForLevel(next.level))
+                        }
+                    }
+                }
+                val last = segments.last()
+                path.lineTo(xForMs(last.endMs), l0y)
+                drawPath(path, lineColor, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.5.dp.toPx()))
+            }
+
+            ticks.forEach { tick ->
+                val x = xForMs(tick.tMs)
+                drawLine(tickColor, Offset(x, plotTop), Offset(x, l0y), strokeWidth = 1.4.dp.toPx())
+            }
+
+            // Axe X 4 ticks (coucher / 33% / 66% / réveil)
+            val paint = android.graphics.Paint().apply {
+                textSize = 13.sp.toPx()
+                color = onSurface.copy(alpha = 0.7f).toArgb()
+                textAlign = android.graphics.Paint.Align.CENTER
+            }
+            val ratios = listOf(0f, 1 / 3f, 2 / 3f, 1f)
+            ratios.forEachIndexed { i, ratio ->
+                val xTick = ratio * canvasW
+                val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+                drawLine(onSurface.copy(alpha = 0.3f), Offset(xTick, plotBot - 4.dp.toPx()), Offset(xTick, plotBot), strokeWidth = 1.dp.toPx())
+                paint.textAlign = when (i) {
+                    0 -> android.graphics.Paint.Align.LEFT
+                    ratios.lastIndex -> android.graphics.Paint.Align.RIGHT
+                    else -> android.graphics.Paint.Align.CENTER
+                }
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawText(
+                        t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                        xTick,
+                        plotBot + 18.dp.toPx(),
+                        paint,
+                    )
+                }
+            }
+
+            // Curseur scrub
+            scrubX?.let { x ->
+                drawLine(
+                    color = onSurface.copy(alpha = 0.7f),
+                    start = Offset(x, plotTop),
+                    end = Offset(x, plotBot),
+                    strokeWidth = 1.5.dp.toPx(),
+                )
+            }
+        }
+
+        scrubX?.let { x ->
+            if (canvasW > 0 && totalMs > 0 && start != null) {
+                val ratio = (x / canvasW).coerceIn(0f, 1f)
+                val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+                val stage = stageAtTime(t, allStages)
+                ScrubTooltip(
+                    timeText = t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                    stageText = stage?.let { hypnoStageDisplayName(it.stage) } ?: "—",
+                    stageDotColor = stage?.let { stageColor(it.stage) } ?: ColorLight,
+                    xPx = x,
+                    canvasWidthPx = canvasW,
+                )
+            }
         }
     }
 }

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
@@ -4,11 +4,14 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,9 +39,28 @@ import java.util.Locale
 
 private const val ROW_HEIGHT_DP    = 40
 private const val BAR_HEIGHT_DP    = 24
+private const val MOUNTAIN_ROW_HEIGHT_DP = 64
 private const val AXIS_BOTTOM_DP   = 24
 private const val LABEL_WIDTH_DP   = 48
 private const val LABEL_PADDING_DP = 4
+// Fenêtre fixe 24h pour Non-24 — les heures de sommeil glissent partout.
+private const val WINDOW_START_MIN = 0
+private const val WINDOW_END_MIN   = 1440
+// Grille verticale toutes les 3h pour rester lisible sur un écran portrait.
+private const val GRID_STEP_HOURS  = 3
+// Micro-réveil < ce seuil = trait vertical, pas de creux dans la mountain.
+private const val MICRO_AWAKE_THRESHOLD_MIN = 5
+
+enum class TimelineViewMode { BARS, MOUNTAIN }
+
+// Mountain : 5 niveaux (0 = éveil session, 1 = AWAKE intra, 2 = DEEP, 3 = LIGHT, 4 = REM)
+private fun mountainLevel(stage: String): Int = when (stage) {
+    "REM"   -> 4
+    "LIGHT" -> 3
+    "DEEP"  -> 2
+    "AWAKE" -> 1
+    else    -> 0
+}
 
 // ── Stage colours ──────────────────────────────────────────────────────────
 
@@ -63,18 +85,6 @@ private fun stageDisplayName(type: String): String = when (type) {
     else    -> type
 }
 
-// ── Window algorithm ──────────────────────────────────────────────────────
-
-private fun computeTimelineWindow(sessions: List<SleepSessionResponse>): Pair<Int, Int> {
-    val startMinutes = sessions.mapNotNull {
-        runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull()
-    }.map { it.hour * 60 + it.minute }.sorted()
-    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60 else startMinutes[startMinutes.size / 2]
-    val windowStart = (medianMinutes - 120).coerceAtLeast(0)
-    val windowEnd   = (windowStart + 960).coerceAtMost(1440)
-    return Pair(windowStart, windowEnd)
-}
-
 // ── Night aggregation — 1 row = 1 calendar date (keyed by sleep_start.date) ──
 
 private fun groupByNight(sessions: List<SleepSessionResponse>): List<Pair<LocalDate, List<SleepSessionResponse>>> =
@@ -86,14 +96,11 @@ private fun groupByNight(sessions: List<SleepSessionResponse>): List<Pair<LocalD
         .sortedBy { it.key }
         .map { (date, list) -> date to list }
 
-// ── Hit-box for tap detection on stage segments ────────────────────────────
+// ── Selection model — un click ouvre le détail d'UNE nuit complète ─────────
 
-private data class StageHitBox(
-    val left: Float, val top: Float, val right: Float, val bottom: Float,
-    val stageType: String,
-    val stageStart: String,
-    val stageEnd: String,
-    val nightLabel: String
+private data class NightSelection(
+    val date: LocalDate,
+    val sessions: List<SleepSessionResponse>,
 )
 
 // ── Screen ─────────────────────────────────────────────────────────────────
@@ -101,10 +108,12 @@ private data class StageHitBox(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TimelineScreen(
-    viewModel: TimelineViewModel
+    viewModel: TimelineViewModel,
+    onOpenHypnogram: (sessionId: String, isoDate: String?) -> Unit = { _, _ -> },
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var selectedStage by remember { mutableStateOf<StageHitBox?>(null) }
+    var selectedNight by remember { mutableStateOf<NightSelection?>(null) }
+    var viewMode by remember { mutableStateOf(TimelineViewMode.BARS) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -114,6 +123,19 @@ fun TimelineScreen(
             topBar = {
                 TopAppBar(
                     title = { Text("Drift circadien", style = MaterialTheme.typography.headlineMedium) },
+                    actions = {
+                        TextButton(
+                            onClick = {
+                                viewMode = if (viewMode == TimelineViewMode.BARS) TimelineViewMode.MOUNTAIN else TimelineViewMode.BARS
+                            },
+                            modifier = Modifier.testTag("tl_view_toggle"),
+                        ) {
+                            Text(
+                                text = if (viewMode == TimelineViewMode.BARS) "Mountain" else "Barres",
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.background
                     )
@@ -173,26 +195,55 @@ fun TimelineScreen(
 
                     is TimelineUiState.Success -> {
                         val nights = remember(state.sessions) { groupByNight(state.sessions) }
-                        val (windowStart, windowEnd) = remember(state.sessions) {
-                            computeTimelineWindow(state.sessions)
+                        val listState = rememberLazyListState()
+                        var initialScrollDone by remember { mutableStateOf(false) }
+
+                        // 1er rendu : scroll au bas de la liste pour afficher la nuit la plus récente.
+                        LaunchedEffect(nights.size, initialScrollDone) {
+                            if (!initialScrollDone && nights.isNotEmpty()) {
+                                listState.scrollToItem(nights.size) // +1 sentinel offset → last index
+                                initialScrollDone = true
+                            }
                         }
-                        val canvasHeightDp = (nights.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp
+
+                        // Sentinel : quand l'utilisateur scrolle jusqu'en haut de la liste, on charge
+                        // 30 jours plus anciens. distinctUntilChanged évite les triggers répétés
+                        // pendant que la pagination est déjà en cours.
+                        LaunchedEffect(listState, state.hasMore, state.loadingMore) {
+                            snapshotFlow { listState.firstVisibleItemIndex }
+                                .distinctUntilChanged()
+                                .filter { it == 0 && state.hasMore && !state.loadingMore && initialScrollDone }
+                                .collect { viewModel.loadOlder() }
+                        }
 
                         Column(
                             modifier = Modifier.fillMaxSize().testTag("tl_screen")
                         ) {
-                            TimelineAxisHeader(windowStart = windowStart, windowEnd = windowEnd)
-                            Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                                TimelineCanvas(
-                                    nights      = nights,
-                                    windowStart = windowStart,
-                                    windowEnd   = windowEnd,
-                                    onStageTap  = { selectedStage = it },
-                                    modifier    = Modifier
-                                        .fillMaxWidth()
-                                        .height(canvasHeightDp)
-                                        .testTag("tl_canvas")
-                                )
+                            TimelineAxisHeader()
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier.fillMaxSize().testTag("tl_list")
+                            ) {
+                                item(key = "load_older_sentinel") {
+                                    LoadOlderSentinel(
+                                        loadingMore = state.loadingMore,
+                                        hasMore = state.hasMore,
+                                    )
+                                }
+                                items(nights, key = { (date, _) -> date.toEpochDay() }) { (date, sessions) ->
+                                    when (viewMode) {
+                                        TimelineViewMode.BARS -> NightRow(
+                                            date = date,
+                                            sessions = sessions,
+                                            onClick = { selectedNight = NightSelection(date, sessions) },
+                                        )
+                                        TimelineViewMode.MOUNTAIN -> NightRowMountain(
+                                            date = date,
+                                            sessions = sessions,
+                                            onClick = { selectedNight = NightSelection(date, sessions) },
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
@@ -201,175 +252,337 @@ fun TimelineScreen(
         }
     }
 
-    // ── Bottom sheet — stage detail ────────────────────────────────────────
-    selectedStage?.let { stage ->
+    // ── Bottom sheet — night detail (toutes sessions de la nuit) ───────────
+    selectedNight?.let { night ->
         ModalBottomSheet(
-            onDismissRequest = { selectedStage = null },
+            onDismissRequest = { selectedNight = null },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             containerColor = MaterialTheme.colorScheme.surface
         ) {
-            StageDetailSheet(stage = stage)
+            NightDetailSheet(
+                night = night,
+                onOpenHypnogram = { sessionId ->
+                    val iso = night.date.toString()
+                    selectedNight = null
+                    onOpenHypnogram(sessionId, iso)
+                },
+            )
         }
     }
 }
 
-// ── Axis header ─────────────────────────────────────────────────────────────
+// ── Axis header — 24h fixe avec ticks toutes les GRID_STEP_HOURS heures ────
 
 @Composable
-private fun TimelineAxisHeader(
-    windowStart: Int,
-    windowEnd: Int,
-    modifier: Modifier = Modifier
-) {
+private fun TimelineAxisHeader(modifier: Modifier = Modifier) {
     val onSurface = MaterialTheme.colorScheme.onSurface
-    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
 
     Canvas(
         modifier = modifier.fillMaxWidth().height(AXIS_BOTTOM_DP.dp)
     ) {
-        val canvasW   = size.width
-        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
+        val canvasW = size.width
+        val labelPx = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
         val paint = android.graphics.Paint().apply {
-            textSize  = 9.sp.toPx()
-            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textSize = 9.sp.toPx()
+            color = onSurface.copy(alpha = 0.7f).toArgb()
             textAlign = android.graphics.Paint.Align.CENTER
         }
-        val step = if (windowDuration >= 720) 2 else 1
-        var h = windowStart / 60
-        val endHour = (windowEnd + 59) / 60
-        while (h <= endHour) {
+        var h = 0
+        while (h <= 24) {
             val hMin = h * 60
-            if (hMin in windowStart..windowEnd) {
-                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
-                drawIntoCanvas { canvas ->
-                    canvas.nativeCanvas.drawText("%02d:00".format(h % 24), x, size.height * 0.8f, paint)
-                }
+            val x = labelPx + (hMin.toFloat() / windowDuration) * drawableW
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawText("%02dh".format(h % 24), x, size.height * 0.8f, paint)
             }
-            h += step
+            h += GRID_STEP_HOURS
         }
     }
 }
 
-// ── Canvas ──────────────────────────────────────────────────────────────────
+// ── Sentinel (top of LazyColumn) ────────────────────────────────────────────
 
 @Composable
-private fun TimelineCanvas(
-    nights: List<Pair<LocalDate, List<SleepSessionResponse>>>,
-    windowStart: Int,
-    windowEnd: Int,
-    onStageTap: (StageHitBox) -> Unit,
-    modifier: Modifier = Modifier
+private fun LoadOlderSentinel(
+    loadingMore: Boolean,
+    hasMore: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp)
+            .testTag("tl_sentinel"),
+        contentAlignment = Alignment.Center
+    ) {
+        when {
+            loadingMore -> CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            !hasMore -> Text(
+                text = "Aucune donnée plus ancienne",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            )
+            else -> Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}
+
+// ── Single night row (1 Canvas par nuit, lazy-loaded) ───────────────────────
+
+@Composable
+private fun NightRow(
+    date: LocalDate,
+    sessions: List<SleepSessionResponse>,
+    onClick: () -> Unit,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
-    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
-    val hitBoxes = remember { mutableListOf<StageHitBox>() }
-    val dateFmt  = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
+    val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
+    val label = remember(date) { date.format(dateFmt) }
+    val gridColor = onSurface.copy(alpha = 0.08f)
 
     Canvas(
-        modifier = modifier.pointerInput(Unit) {
-            detectTapGestures { offset ->
-                hitBoxes.firstOrNull { box ->
-                    offset.x >= box.left && offset.x <= box.right &&
-                    offset.y >= box.top  && offset.y <= box.bottom
-                }?.let { onStageTap(it) }
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ROW_HEIGHT_DP.dp)
+            .pointerInput(date) {
+                detectTapGestures { onClick() }
             }
-        }
     ) {
-        hitBoxes.clear()
-
-        val canvasW   = size.width
-        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
+        val canvasW = size.width
+        val labelPx = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
-        val rowH      = ROW_HEIGHT_DP.dp.toPx()
-        val barH      = BAR_HEIGHT_DP.dp.toPx()
-        val axisBot   = AXIS_BOTTOM_DP.dp.toPx()
+        val rowH = ROW_HEIGHT_DP.dp.toPx()
+        val barH = BAR_HEIGHT_DP.dp.toPx()
+        val barTop = (rowH - barH) / 2f
 
         val datePaint = android.graphics.Paint().apply {
-            textSize  = 10.sp.toPx()
-            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textSize = 10.sp.toPx()
+            color = onSurface.copy(alpha = 0.6f).toArgb()
             textAlign = android.graphics.Paint.Align.LEFT
         }
-        val tickPaint = android.graphics.Paint().apply {
-            textSize  = 9.sp.toPx()
-            color     = onSurface.copy(alpha = 0.5f).toArgb()
-            textAlign = android.graphics.Paint.Align.CENTER
+
+        // Grid verticale en fond — toutes les GRID_STEP_HOURS heures.
+        var h = 0
+        while (h <= 24) {
+            val x = labelPx + (h * 60f / windowDuration) * drawableW
+            drawLine(
+                color = gridColor,
+                start = Offset(x, 0f),
+                end = Offset(x, rowH),
+                strokeWidth = 1f,
+            )
+            h += GRID_STEP_HOURS
         }
 
-        nights.forEachIndexed { rowIndex, (date, sessions) ->
-            val rowTop = rowIndex * rowH
-            val barTop = rowTop + (rowH - barH) / 2f
-            val label  = date.format(dateFmt)
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                label,
+                LABEL_PADDING_DP.dp.toPx(),
+                rowH / 2f + datePaint.textSize / 3f,
+                datePaint,
+            )
+        }
 
-            // Date label
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawText(
-                    label,
-                    LABEL_PADDING_DP.dp.toPx(),
-                    rowTop + rowH / 2f + datePaint.textSize / 3f,
-                    datePaint
+        sessions.forEach { session ->
+            val stages = session.stages?.sortedBy { it.stage_start } ?: emptyList()
+            if (stages.isEmpty()) {
+                drawFallbackBar(
+                    session = session,
+                    labelPx = labelPx,
+                    drawableW = drawableW,
+                    barTop = barTop,
+                    barH = barH,
+                )
+            } else {
+                stages.forEachIndexed { idx, stage ->
+                    drawStageSegment(
+                        stage = stage,
+                        labelPx = labelPx,
+                        drawableW = drawableW,
+                        barTop = barTop,
+                        barH = barH,
+                        roundLeft = idx == 0,
+                        roundRight = idx == stages.size - 1,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Mountain view — graph "ligne montagne" 5 niveaux par nuit ───────────────
+
+private data class MountainSegment(
+    val startMin: Int,
+    val endMin: Int,
+    val level: Int,
+    val color: Color,
+)
+
+private data class MicroAwakeMark(val minute: Int)
+
+/**
+ * Convertit les sessions d'une nuit en segments mountain :
+ * - micro-AWAKE (<5min) → MicroAwakeMark, le segment courant continue à son niveau
+ * - AWAKE >=5min → segment à L1 avec couleur AWAKE
+ * - DEEP/LIGHT/REM → segment à leur niveau (2/3/4) avec leur couleur
+ *
+ * Entre 2 sessions consécutives, le path retombe à L0 puis remonte.
+ */
+private fun buildMountainData(
+    sessions: List<SleepSessionResponse>,
+): Pair<List<MountainSegment>, List<MicroAwakeMark>> {
+    val segments = mutableListOf<MountainSegment>()
+    val ticks = mutableListOf<MicroAwakeMark>()
+
+    sessions.forEach { session ->
+        val sortedStages = session.stages?.sortedBy { it.stage_start } ?: return@forEach
+        sortedStages.forEach { stage ->
+            val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return@forEach
+            val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return@forEach
+            val durationMin = Duration.between(ss, se).toMinutes()
+            val startMin = ss.hour * 60 + ss.minute
+            var endMin = se.hour * 60 + se.minute
+            if (endMin < startMin) endMin += 1440
+
+            if (stage.stage == "AWAKE" && durationMin < MICRO_AWAKE_THRESHOLD_MIN) {
+                ticks.add(MicroAwakeMark(startMin))
+            } else {
+                segments.add(
+                    MountainSegment(
+                        startMin = startMin,
+                        endMin = endMin,
+                        level = mountainLevel(stage.stage),
+                        color = stageColor(stage.stage),
+                    )
                 )
             }
+        }
+    }
+    return Pair(segments, ticks)
+}
 
-            // Draw stages for all sessions of this night
-            sessions.forEach { session ->
-                val stages = session.stages
-                if (stages.isNullOrEmpty()) {
-                    // Fallback: single bar spanning sleep duration
-                    drawFallbackBar(
-                        session      = session,
-                        windowStart  = windowStart,
-                        windowDuration = windowDuration,
-                        labelPx      = labelPx,
-                        drawableW    = drawableW,
-                        barTop       = barTop,
-                        barH         = barH,
-                        nightLabel   = label,
-                        hitBoxes     = hitBoxes
-                    )
-                } else {
-                    stages.sortedBy { it.stage_start }.forEach { stage ->
-                        drawStageSegment(
-                            stage        = stage,
-                            windowStart  = windowStart,
-                            windowDuration = windowDuration,
-                            labelPx      = labelPx,
-                            drawableW    = drawableW,
-                            barTop       = barTop,
-                            barH         = barH,
-                            nightLabel   = label,
-                            hitBoxes     = hitBoxes
-                        )
+@Composable
+private fun NightRowMountain(
+    date: LocalDate,
+    sessions: List<SleepSessionResponse>,
+    onClick: () -> Unit,
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
+    val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
+    val label = remember(date) { date.format(dateFmt) }
+    val gridColor = onSurface.copy(alpha = 0.08f)
+    val lineColor = onSurface.copy(alpha = 0.85f)
+    val tickColor = ColorAwake.copy(alpha = 0.9f)
+
+    val (segments, ticks) = remember(sessions) { buildMountainData(sessions) }
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(MOUNTAIN_ROW_HEIGHT_DP.dp)
+            .pointerInput(date) { detectTapGestures { onClick() } }
+    ) {
+        val canvasW = size.width
+        val labelPx = LABEL_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx
+        val rowH = MOUNTAIN_ROW_HEIGHT_DP.dp.toPx()
+        val plotTop = 6.dp.toPx()
+        val plotBot = rowH - 6.dp.toPx()
+        val plotH = plotBot - plotTop
+        // 5 paliers (L0..L4) → 4 intervalles
+        fun yForLevel(level: Int): Float = plotBot - (level / 4f) * plotH
+
+        val datePaint = android.graphics.Paint().apply {
+            textSize = 10.sp.toPx()
+            color = onSurface.copy(alpha = 0.6f).toArgb()
+            textAlign = android.graphics.Paint.Align.LEFT
+        }
+
+        // Grid verticale (heures)
+        var h = 0
+        while (h <= 24) {
+            val x = labelPx + (h * 60f / windowDuration) * drawableW
+            drawLine(gridColor, Offset(x, 0f), Offset(x, rowH), strokeWidth = 1f)
+            h += GRID_STEP_HOURS
+        }
+
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                label,
+                LABEL_PADDING_DP.dp.toPx(),
+                rowH / 2f + datePaint.textSize / 3f,
+                datePaint,
+            )
+        }
+
+        fun xForMin(min: Int): Float =
+            labelPx + (min.coerceIn(WINDOW_START_MIN, WINDOW_END_MIN).toFloat() / windowDuration) * drawableW
+
+        // Aire colorée sous la ligne — un rect par segment, du niveau jusqu'à L0
+        val l0y = yForLevel(0)
+        segments.forEach { seg ->
+            val x = xForMin(seg.startMin)
+            val xEnd = xForMin(seg.endMin)
+            val w = (xEnd - x).coerceAtLeast(1f)
+            val y = yForLevel(seg.level)
+            drawRect(
+                color = seg.color.copy(alpha = 0.55f),
+                topLeft = Offset(x, y),
+                size = Size(w, l0y - y),
+            )
+        }
+
+        // Polyline reliant les niveaux — démarre à L0, suit les segments, retombe à L0
+        if (segments.isNotEmpty()) {
+            val path = androidx.compose.ui.graphics.Path()
+            // Démarre à L0 au début du 1er segment
+            val first = segments.first()
+            path.moveTo(xForMin(first.startMin), l0y)
+            // Monte au niveau du 1er segment
+            path.lineTo(xForMin(first.startMin), yForLevel(first.level))
+            // Trace tous les segments
+            segments.forEachIndexed { idx, seg ->
+                val xStart = xForMin(seg.startMin)
+                val xEnd = xForMin(seg.endMin)
+                val y = yForLevel(seg.level)
+                path.lineTo(xEnd, y)
+                // Transition vers le segment suivant : on saute à son niveau au moment de son début
+                if (idx < segments.size - 1) {
+                    val next = segments[idx + 1]
+                    val xNextStart = xForMin(next.startMin)
+                    if (xNextStart > xEnd) {
+                        // Gap entre segments → retombe à L0
+                        path.lineTo(xEnd, l0y)
+                        path.lineTo(xNextStart, l0y)
+                        path.lineTo(xNextStart, yForLevel(next.level))
+                    } else {
+                        // Continue directement au niveau suivant
+                        path.lineTo(xEnd, yForLevel(next.level))
                     }
                 }
             }
+            // Fin : retombe à L0
+            val last = segments.last()
+            path.lineTo(xForMin(last.endMin), l0y)
+            drawPath(path, lineColor, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.4.dp.toPx()))
         }
 
-        // X-axis hour ticks at bottom
-        val axisTopY = size.height - axisBot
-        val step = if (windowDuration >= 720) 2 else 1
-        var h = windowStart / 60
-        val endHour = (windowEnd + 59) / 60
-        while (h <= endHour) {
-            val hMin = h * 60
-            if (hMin in windowStart..windowEnd) {
-                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
-                drawLine(
-                    color       = onSurface.copy(alpha = 0.2f),
-                    start       = Offset(x, axisTopY),
-                    end         = Offset(x, axisTopY + 4.dp.toPx()),
-                    strokeWidth = 1.dp.toPx()
-                )
-                drawIntoCanvas { canvas ->
-                    canvas.nativeCanvas.drawText(
-                        "%02d:00".format(h % 24),
-                        x,
-                        size.height - 2.dp.toPx(),
-                        tickPaint
-                    )
-                }
-            }
-            h += step
+        // Traits verticaux pour micro-awakes
+        ticks.forEach { tick ->
+            val x = xForMin(tick.minute)
+            drawLine(
+                color = tickColor,
+                start = Offset(x, plotTop),
+                end = Offset(x, l0y),
+                strokeWidth = 1.2.dp.toPx(),
+            )
         }
     }
 }
@@ -378,123 +591,193 @@ private fun TimelineCanvas(
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawFallbackBar(
     session: SleepSessionResponse,
-    windowStart: Int,
-    windowDuration: Int,
     labelPx: Float,
     drawableW: Float,
     barTop: Float,
     barH: Float,
-    nightLabel: String,
-    hitBoxes: MutableList<StageHitBox>
 ) {
     val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull() ?: return
-    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull() ?: return
-    var startMin = start.hour * 60 + start.minute
-    var endMin   = end.hour * 60 + end.minute
-    if (endMin < startMin) endMin += 1440
-
-    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
-    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
-    if (endOff <= startOff) return
-
-    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val barW = xEnd - x
-    if (barW <= 0f) return
-
-    drawRect(color = ColorDeep.copy(alpha = 0.6f), topLeft = Offset(x, barTop), size = Size(barW, barH))
-    hitBoxes.add(StageHitBox(x, barTop, xEnd, barTop + barH, "LIGHT",
-        session.sleep_start, session.sleep_end, nightLabel))
+    val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull() ?: return
+    val startMin = start.hour * 60 + start.minute
+    var endMin = end.hour * 60 + end.minute
+    if (endMin < startMin) endMin += 1440 // session traverse minuit
+    drawBar(startMin, endMin, ColorDeep.copy(alpha = 0.6f), labelPx, drawableW, barTop, barH, roundLeft = true, roundRight = true)
 }
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStageSegment(
     stage: SleepStageResponse,
-    windowStart: Int,
-    windowDuration: Int,
     labelPx: Float,
     drawableW: Float,
     barTop: Float,
     barH: Float,
-    nightLabel: String,
-    hitBoxes: MutableList<StageHitBox>
+    roundLeft: Boolean,
+    roundRight: Boolean,
 ) {
     val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return
     val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return
-    var startMin = ss.hour * 60 + ss.minute
-    var endMin   = se.hour * 60 + se.minute
+    val startMin = ss.hour * 60 + ss.minute
+    var endMin = se.hour * 60 + se.minute
     if (endMin < startMin) endMin += 1440
+    drawBar(startMin, endMin, stageColor(stage.stage), labelPx, drawableW, barTop, barH, roundLeft, roundRight)
+}
 
-    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
-    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
-    if (endOff <= startOff) return
-
-    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val barW = xEnd - x
-    if (barW <= 0f) return
-
-    // AWAKE segments are shorter to distinguish them visually
-    val segH  = if (stage.stage == "AWAKE") barH * 0.5f else barH
-    val segTop = barTop + (barH - segH) / 2f
-
-    drawRect(
-        color   = stageColor(stage.stage),
-        topLeft = Offset(x, segTop),
-        size    = Size(barW, segH)
-    )
-    hitBoxes.add(StageHitBox(x, segTop, xEnd, segTop + segH,
-        stage.stage, stage.stage_start, stage.stage_end, nightLabel))
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBar(
+    startMin: Int,
+    endMin: Int,
+    color: Color,
+    labelPx: Float,
+    drawableW: Float,
+    barTop: Float,
+    barH: Float,
+    roundLeft: Boolean = false,
+    roundRight: Boolean = false,
+) {
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
+    val s = startMin.coerceIn(WINDOW_START_MIN, WINDOW_END_MIN)
+    val e = endMin.coerceIn(WINDOW_START_MIN, WINDOW_END_MIN)
+    if (e <= s) return
+    val x = labelPx + (s.toFloat() / windowDuration) * drawableW
+    val xEnd = labelPx + (e.toFloat() / windowDuration) * drawableW
+    val barW = (xEnd - x).coerceAtLeast(1.5f)
+    if (!roundLeft && !roundRight) {
+        drawRect(color = color, topLeft = Offset(x, barTop), size = Size(barW, barH))
+        return
+    }
+    val cornerR = 3.dp.toPx().coerceAtMost(barW / 2f).coerceAtMost(barH / 2f)
+    val rect = androidx.compose.ui.geometry.Rect(x, barTop, x + barW, barTop + barH)
+    val path = androidx.compose.ui.graphics.Path().apply {
+        if (roundLeft && roundRight) {
+            addRoundRect(androidx.compose.ui.geometry.RoundRect(rect, androidx.compose.ui.geometry.CornerRadius(cornerR)))
+        } else if (roundLeft) {
+            moveTo(rect.left + cornerR, rect.top)
+            lineTo(rect.right, rect.top)
+            lineTo(rect.right, rect.bottom)
+            lineTo(rect.left + cornerR, rect.bottom)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.left, rect.bottom - 2 * cornerR, rect.left + 2 * cornerR, rect.bottom), 90f, 90f, false)
+            lineTo(rect.left, rect.top + cornerR)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.left, rect.top, rect.left + 2 * cornerR, rect.top + 2 * cornerR), 180f, 90f, false)
+            close()
+        } else {
+            moveTo(rect.left, rect.top)
+            lineTo(rect.right - cornerR, rect.top)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.right - 2 * cornerR, rect.top, rect.right, rect.top + 2 * cornerR), 270f, 90f, false)
+            lineTo(rect.right, rect.bottom - cornerR)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.right - 2 * cornerR, rect.bottom - 2 * cornerR, rect.right, rect.bottom), 0f, 90f, false)
+            lineTo(rect.left, rect.bottom)
+            close()
+        }
+    }
+    drawPath(path, color)
 }
 
 // ── Bottom sheet detail ──────────────────────────────────────────────────────
 
 @Composable
-private fun StageDetailSheet(stage: StageHitBox) {
-    val start = runCatching { OffsetDateTime.parse(stage.stageStart) }.getOrNull()
-    val end   = runCatching { OffsetDateTime.parse(stage.stageEnd) }.getOrNull()
-    val duration = if (start != null && end != null) Duration.between(start, end) else null
-    val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+private fun NightDetailSheet(
+    night: NightSelection,
+    onOpenHypnogram: (sessionId: String) -> Unit,
+) {
+    val timeFmt = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val dateFmt = remember { DateTimeFormatter.ofPattern("EEEE d MMMM yyyy", Locale.FRENCH) }
+
+    val totalSleep = remember(night) {
+        night.sessions.sumOf { s ->
+            val start = runCatching { OffsetDateTime.parse(s.sleep_start) }.getOrNull()
+            val end = runCatching { OffsetDateTime.parse(s.sleep_end) }.getOrNull()
+            if (start != null && end != null) Duration.between(start, end).toMinutes() else 0L
+        }
+    }
+    val stageTotals = remember(night) {
+        val acc = mutableMapOf<String, Long>()
+        night.sessions.forEach { s ->
+            s.stages?.forEach { st ->
+                val start = runCatching { OffsetDateTime.parse(st.stage_start) }.getOrNull()
+                val end = runCatching { OffsetDateTime.parse(st.stage_end) }.getOrNull()
+                if (start != null && end != null) {
+                    acc[st.stage] = (acc[st.stage] ?: 0L) + Duration.between(start, end).toMinutes()
+                }
+            }
+        }
+        acc
+    }
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 24.dp, vertical = 16.dp)
             .padding(bottom = 32.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         Text(
-            text = stage.nightLabel,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+            text = night.date.format(dateFmt).replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
         )
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            Box(
-                modifier = Modifier
-                    .size(12.dp)
-                    .clip(CircleShape)
-                    .background(stageColor(stage.stageType))
-            )
-            Text(
-                text = stageDisplayName(stage.stageType),
-                style = MaterialTheme.typography.titleMedium,
-                color = stageColor(stage.stageType)
-            )
+
+        Text(
+            text = "Sommeil total : ${formatDuration(totalSleep)}",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        if (stageTotals.isNotEmpty()) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                listOf("DEEP", "LIGHT", "REM", "AWAKE").forEach { stageType ->
+                    val mins = stageTotals[stageType] ?: 0L
+                    if (mins > 0) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(10.dp)
+                                    .clip(CircleShape)
+                                    .background(stageColor(stageType)),
+                            )
+                            Text(
+                                text = stageDisplayName(stageType),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Text(
+                                text = formatDuration(mins),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                            )
+                        }
+                    }
+                }
+            }
         }
-        if (duration != null) {
-            val h  = duration.toHours()
-            val mm = duration.toMinutes() % 60
-            Text(
-                text = if (h > 0) "${h}h ${mm.toString().padStart(2, '0')}min" else "${mm}min",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        }
-        if (start != null && end != null) {
-            Text(
-                text = "${start.format(timeFmt)} → ${end.format(timeFmt)}",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-            )
+
+        Text(
+            text = "${night.sessions.size} session${if (night.sessions.size > 1) "s" else ""} de sommeil",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+        )
+
+        // Lien vers l'hypnogramme — une session = un bouton.
+        night.sessions.forEachIndexed { idx, session ->
+            val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
+            val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+            val rangeLabel = if (start != null && end != null) {
+                "${start.format(timeFmt)} → ${end.format(timeFmt)}"
+            } else "Session ${idx + 1}"
+            OutlinedButton(
+                onClick = { onOpenHypnogram(session.id) },
+                modifier = Modifier.fillMaxWidth().testTag("tl_open_hypnogram_$idx"),
+            ) {
+                Text("Hypnogramme · $rangeLabel")
+            }
         }
     }
+}
+
+private fun formatDuration(minutes: Long): String {
+    if (minutes <= 0) return "—"
+    val h = minutes / 60
+    val mm = minutes % 60
+    return if (h > 0) "${h}h ${mm.toString().padStart(2, '0')}min" else "${mm}min"
 }

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepository.kt
-git_blob: 364919410d349ed4baeb81b851d72150ee1c7d95
-last_synced: '2026-05-09T04:03:35Z'
-loc: 5
+git_blob: 8afdf07ec5313001294fbc9c250c660af2fadb10
+last_synced: '2026-05-09T14:31:04Z'
+loc: 10
 annotations: []
 imports: []
 exports: []
@@ -23,8 +23,13 @@ tags:
 ```kotlin
 package fr.datasaillance.nightfall.data.sleep
 
+import java.time.LocalDate
+
 interface SleepRepository {
-    suspend fun getSessions(): Result<List<SleepSessionResponse>>
+    suspend fun getSessions(
+        from: LocalDate? = null,
+        to: LocalDate? = null,
+    ): Result<List<SleepSessionResponse>>
 }
 ```
 
@@ -33,5 +38,5 @@ interface SleepRepository {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `SleepRepository` (class) — lines 3-5
-- `getSessions` (function) — lines 4-4
+- `SleepRepository` (class) — lines 5-10
+- `getSessions` (function) — lines 6-9

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/SleepRepositoryImpl.kt
-git_blob: 9287ff0337e7f2932d15291a09cd90db0c871fc5
-last_synced: '2026-05-09T08:38:11Z'
-loc: 28
+git_blob: 307e29d048168be30e5e98e07d67e181b3795702
+last_synced: '2026-05-09T14:31:04Z'
+loc: 37
 annotations: []
 imports: []
 exports: []
@@ -27,18 +27,27 @@ import fr.datasaillance.nightfall.data.auth.TokenDataStore
 import fr.datasaillance.nightfall.data.http.NightfallApi
 import timber.log.Timber
 import java.io.IOException
+import java.time.LocalDate
 
 class SleepRepositoryImpl(
     private val api: NightfallApi,
     private val tokenDataStore: TokenDataStore
 ) : SleepRepository {
 
-    override suspend fun getSessions(): Result<List<SleepSessionResponse>> {
+    override suspend fun getSessions(
+        from: LocalDate?,
+        to: LocalDate?,
+    ): Result<List<SleepSessionResponse>> {
         val token = tokenDataStore.getToken()
             ?: return Result.failure(IOException("No auth token"))
         return try {
-            val sessions = api.getSleepSessions("Bearer $token", includeStages = true)
-            Timber.i("sleep_sessions_fetched count=${sessions.size}")
+            val sessions = api.getSleepSessions(
+                token = "Bearer $token",
+                from = from?.toString(),
+                to = to?.toString(),
+                includeStages = true,
+            )
+            Timber.i("sleep_sessions_fetched count=${sessions.size} from=$from to=$to")
             Result.success(sessions)
         } catch (e: retrofit2.HttpException) {
             Timber.w("sleep_fetch_http_error code=${e.code()}")
@@ -56,5 +65,5 @@ class SleepRepositoryImpl(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `SleepRepositoryImpl` (class) — lines 8-28
-- `getSessions` (function) — lines 13-27
+- `SleepRepositoryImpl` (class) — lines 9-37
+- `getSessions` (function) — lines 14-36

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
-git_blob: 8922e44fc45634f554cd2d4b07faa3593e990cc7
-last_synced: '2026-05-09T07:04:02Z'
-loc: 23
+git_blob: f3315e4424fd681e2b7bbb9f7efe5404d6416213
+last_synced: '2026-05-09T14:31:04Z'
+loc: 26
 annotations: []
 imports: []
 exports: []
@@ -36,8 +36,11 @@ sealed class NavDestination(
     object Profile  : NavDestination("profile",  "Profil")
     object Import   : NavDestination("import",   "Importer")
     object Settings : NavDestination("settings", "Paramètres")
-    object Hypnogram : NavDestination("hypnogram/{sessionId}", "Hypnogramme") {
-        fun route(id: String): String = "hypnogram/$id"
+    object Hypnogram : NavDestination("hypnogram/{sessionId}?date={date}", "Hypnogramme") {
+        // date facultative (ISO yyyy-MM-dd) — quand fournie, on fetch uniquement cette nuit
+        // au lieu de télécharger tout l'historique sleep_sessions du user.
+        fun route(id: String, date: String? = null): String =
+            if (date != null) "hypnogram/$id?date=$date" else "hypnogram/$id"
     }
 
     companion object {
@@ -51,6 +54,6 @@ sealed class NavDestination(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavDestination` (class) — lines 3-23
-- `route` (function) — lines 17-17
-- `bottomNavItems` (function) — lines 21-21
+- `NavDestination` (class) — lines 3-26
+- `route` (function) — lines 19-20
+- `bottomNavItems` (function) — lines 24-24

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: f30caf03537af9ccc83d3653d7458a9e1397c042
-last_synced: '2026-05-09T08:38:11Z'
-loc: 268
+git_blob: 746313483e3255e10d40d6204879d3d4fbe09549
+last_synced: '2026-05-09T14:31:04Z'
+loc: 283
 annotations: []
 imports: []
 exports: []
@@ -172,9 +172,17 @@ fun NavGraph(
             }
             composable(
                 route = NavDestination.Hypnogram.route,
-                arguments = listOf(navArgument("sessionId") { type = NavType.StringType })
+                arguments = listOf(
+                    navArgument("sessionId") { type = NavType.StringType },
+                    navArgument("date") {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                )
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
+                val dateArg = backStackEntry.arguments?.getString("date")
                 val hypnogramRepository: SleepRepository = remember(api, tokenDataStore) {
                     if (api != null && tokenDataStore != null) {
                         SleepRepositoryImpl(api, tokenDataStore)
@@ -182,8 +190,8 @@ fun NavGraph(
                         NoOpSleepRepository()
                     }
                 }
-                val hypnogramViewModel = remember(sessionId, hypnogramRepository) {
-                    HypnogramViewModel(sessionId, hypnogramRepository)
+                val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
+                    HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
                 }
                 HypnogramScreen(
                     viewModel = hypnogramViewModel,
@@ -199,7 +207,12 @@ fun NavGraph(
                     }
                 }
                 val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
-                TimelineScreen(viewModel = timelineViewModel)
+                TimelineScreen(
+                    viewModel = timelineViewModel,
+                    onOpenHypnogram = { sessionId, isoDate ->
+                        navController.navigate(NavDestination.Hypnogram.route(sessionId, isoDate))
+                    },
+                )
             }
             composable(NavDestination.Activity.route) { ActivityScreen() }
             composable(NavDestination.Profile.route) {
@@ -239,8 +252,10 @@ fun NavGraph(
 }
 
 private class NoOpSleepRepository : SleepRepository {
-    override suspend fun getSessions(): Result<List<SleepSessionResponse>> =
-        Result.success(emptyList())
+    override suspend fun getSessions(
+        from: java.time.LocalDate?,
+        to: java.time.LocalDate?,
+    ): Result<List<SleepSessionResponse>> = Result.success(emptyList())
 }
 
 private class NoOpImportRepository : ImportRepository {
@@ -296,23 +311,23 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 57-216
-- `NoOpSleepRepository` (class) — lines 218-221
-- `getSessions` (function) — lines 219-220
-- `NoOpImportRepository` (class) — lines 223-238
-- `pingBackend` (function) — lines 224-224
-- `extractCsvEntries` (function) — lines 226-229
-- `uploadCsv` (function) — lines 231-237
-- `NoOpNightfallApi` (class) — lines 240-252
-- `health` (function) — lines 241-241
-- `login` (function) — lines 242-242
-- `register` (function) — lines 243-243
-- `requestPasswordReset` (function) — lines 244-244
-- `googleStart` (function) — lines 245-245
-- `getSleepSessions` (function) — lines 246-246
-- `importSleep` (function) — lines 247-247
-- `importHeartRate` (function) — lines 248-248
-- `importSteps` (function) — lines 249-249
-- `importExercise` (function) — lines 250-250
-- `importSleepStages` (function) — lines 251-251
-- `ensureComposeNavigators` (function) — lines 260-268
+- `NavGraph` (function) — lines 57-229
+- `NoOpSleepRepository` (class) — lines 231-236
+- `getSessions` (function) — lines 232-235
+- `NoOpImportRepository` (class) — lines 238-253
+- `pingBackend` (function) — lines 239-239
+- `extractCsvEntries` (function) — lines 241-244
+- `uploadCsv` (function) — lines 246-252
+- `NoOpNightfallApi` (class) — lines 255-267
+- `health` (function) — lines 256-256
+- `login` (function) — lines 257-257
+- `register` (function) — lines 258-258
+- `requestPasswordReset` (function) — lines 259-259
+- `googleStart` (function) — lines 260-260
+- `getSleepSessions` (function) — lines 261-261
+- `importSleep` (function) — lines 262-262
+- `importHeartRate` (function) — lines 263-263
+- `importSteps` (function) — lines 264-264
+- `importExercise` (function) — lines 265-265
+- `importSleepStages` (function) — lines 266-266
+- `ensureComposeNavigators` (function) — lines 275-283

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
-git_blob: ea4e5479bc273af0f644f239ba66a90ce852a087
-last_synced: '2026-05-09T08:38:11Z'
-loc: 92
+git_blob: 083db3585a42a6107d943419db94b21083dc6ed4
+last_synced: '2026-05-09T14:31:04Z'
+loc: 102
 annotations: []
 imports: []
 exports: []
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.IOException
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
 sealed class HypnogramUiState {
@@ -45,7 +46,8 @@ sealed class HypnogramUiState {
 
 class HypnogramViewModel(
     private val sessionId: String,
-    private val repository: SleepRepository
+    private val repository: SleepRepository,
+    private val hintDate: String? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HypnogramUiState>(HypnogramUiState.Idle)
@@ -62,8 +64,16 @@ class HypnogramViewModel(
         viewModelScope.launch {
             yield()
             try {
-                Timber.d("scope=hypno_vm session_id=$sessionId loading")
-                val result = repository.getSessions()
+                Timber.d("scope=hypno_vm session_id=$sessionId hint_date=$hintDate loading")
+                // Si une hint date est fournie (via nav arg) on cadre la requête sur cette nuit
+                // au lieu de fetcher tout l'historique. Fenêtre [date-1, date+1] pour couvrir
+                // les sessions à cheval sur minuit.
+                val parsedHint = hintDate?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+                val result = if (parsedHint != null) {
+                    repository.getSessions(from = parsedHint.minusDays(1), to = parsedHint.plusDays(1))
+                } else {
+                    repository.getSessions()
+                }
                 if (result.isFailure) {
                     val code = (result.exceptionOrNull() as? retrofit2.HttpException)?.code()
                     if (code != null) Timber.w("scope=hypno_vm http_code=$code")
@@ -120,10 +130,10 @@ class HypnogramViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `HypnogramUiState` (class) — lines 16-21
-- `Success` (class) — lines 19-19
-- `Error` (class) — lines 20-20
-- `HypnogramViewModel` (class) — lines 23-92
-- `retry` (function) — lines 35-35
-- `loadSession` (function) — lines 37-81
-- `mapError` (function) — lines 83-91
+- `HypnogramUiState` (class) — lines 17-22
+- `Success` (class) — lines 20-20
+- `Error` (class) — lines 21-21
+- `HypnogramViewModel` (class) — lines 24-102
+- `retry` (function) — lines 37-37
+- `loadSession` (function) — lines 39-91
+- `mapError` (function) — lines 93-101

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
-git_blob: 7c969ead13e75a3a6805f87bd3d20228409d176e
-last_synced: '2026-05-09T07:04:02Z'
-loc: 80
+git_blob: 0846e3a7cbd041f20a2abf4c029f4655e28157e6
+last_synced: '2026-05-09T14:31:04Z'
+loc: 151
 annotations: []
 imports: []
 exports: []
@@ -34,55 +34,78 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import timber.log.Timber
 import java.io.IOException
+import java.time.LocalDate
 import java.time.OffsetDateTime
 
+private const val PAGE_DAYS = 30L
+// Pour le 1er chargement : on n'a pas de borne d'historique, donc on étend la
+// fenêtre vers le passé jusqu'à trouver des données ou abandonner.
+private const val INITIAL_MAX_BACKOFF_PAGES = 24  // ~2 ans
+
 sealed class TimelineUiState {
-    object Idle    : TimelineUiState()
+    object Idle : TimelineUiState()
     object Loading : TimelineUiState()
-    data class Success(val sessions: List<SleepSessionResponse>) : TimelineUiState()
-    object Empty   : TimelineUiState()
+    data class Success(
+        val sessions: List<SleepSessionResponse>,
+        val loadingMore: Boolean = false,
+        val hasMore: Boolean = true,
+    ) : TimelineUiState()
+    object Empty : TimelineUiState()
     data class Error(val message: String) : TimelineUiState()
 }
 
 class TimelineViewModel(
-    private val repository: SleepRepository
+    private val repository: SleepRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
     val uiState: StateFlow<TimelineUiState> = _uiState.asStateFlow()
 
+    // Borne basse de la fenêtre actuellement chargée (= sleep_start le plus ancien).
+    // null tant que rien n'a été chargé.
+    private var oldestLoaded: LocalDate? = null
+
     init {
-        loadSessions()
+        loadInitial()
     }
 
-    fun retry() = loadSessions()
+    fun retry() = loadInitial()
 
-    private fun loadSessions() {
+    private fun loadInitial() {
         _uiState.value = TimelineUiState.Loading
+        oldestLoaded = null
         viewModelScope.launch {
             yield()
             try {
-                val result = repository.getSessions()
-                if (result.isFailure) {
-                    _uiState.value = TimelineUiState.Error(mapError(result.exceptionOrNull()))
-                    return@launch
+                val today = LocalDate.now()
+                var from = today.minusDays(PAGE_DAYS)
+                var to = today
+                var sessions: List<SleepSessionResponse>? = null
+                var attempts = 0
+                while (attempts < INITIAL_MAX_BACKOFF_PAGES) {
+                    val result = repository.getSessions(from = from, to = to)
+                    if (result.isFailure) {
+                        _uiState.value = TimelineUiState.Error(mapError(result.exceptionOrNull()))
+                        return@launch
+                    }
+                    val batch = result.getOrNull() ?: emptyList()
+                    if (batch.isNotEmpty()) {
+                        sessions = batch
+                        oldestLoaded = from
+                        break
+                    }
+                    // Pas de données : on étend la fenêtre vers le passé.
+                    to = from.minusDays(1)
+                    from = to.minusDays(PAGE_DAYS)
+                    attempts++
                 }
-                val sessions = result.getOrNull()
-                // sessions can only be null from an unstubbed mock (SleepRepositoryImpl always
-                // returns a non-null List). Silent return preserves injected test state.
                 if (sessions == null) {
-                    Timber.w("scope=timeline_vm sessions_null")
-                    return@launch
-                }
-                if (sessions.isEmpty()) {
                     _uiState.value = TimelineUiState.Empty
                     return@launch
                 }
                 _uiState.value = TimelineUiState.Success(
-                    sessions.sortedBy { session ->
-                        runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }
-                            .getOrNull()
-                    }
+                    sessions = sortSessions(sessions),
+                    hasMore = true,
                 )
             } catch (e: Exception) {
                 Timber.w("scope=timeline_vm error=${e::class.simpleName}")
@@ -90,6 +113,54 @@ class TimelineViewModel(
             }
         }
     }
+
+    fun loadOlder() {
+        val current = _uiState.value as? TimelineUiState.Success ?: return
+        if (current.loadingMore || !current.hasMore) return
+        val anchor = oldestLoaded ?: return
+
+        _uiState.value = current.copy(loadingMore = true)
+        viewModelScope.launch {
+            try {
+                val to = anchor.minusDays(1)
+                val from = to.minusDays(PAGE_DAYS)
+                val result = repository.getSessions(from = from, to = to)
+                if (result.isFailure) {
+                    Timber.w("scope=timeline_vm load_older_failed")
+                    _uiState.value = current.copy(loadingMore = false)
+                    return@launch
+                }
+                val batch = result.getOrNull() ?: emptyList()
+                oldestLoaded = from
+                if (batch.isEmpty()) {
+                    // Une seule page vide ne signifie pas fin d'historique : on continue
+                    // plus loin via un prochain trigger. Pour éviter une boucle, on
+                    // marque hasMore=false seulement après plusieurs pages vides
+                    // consécutives — ici on garde simple et on laisse l'utilisateur
+                    // re-trigger manuellement (futur scroll). Marquage conservateur :
+                    _uiState.value = current.copy(
+                        loadingMore = false,
+                        hasMore = false,
+                    )
+                    return@launch
+                }
+                val merged = sortSessions(current.sessions + batch)
+                _uiState.value = current.copy(
+                    sessions = merged,
+                    loadingMore = false,
+                    hasMore = true,
+                )
+            } catch (e: Exception) {
+                Timber.w("scope=timeline_vm load_older_error error=${e::class.simpleName}")
+                _uiState.value = current.copy(loadingMore = false)
+            }
+        }
+    }
+
+    private fun sortSessions(list: List<SleepSessionResponse>): List<SleepSessionResponse> =
+        list.sortedBy { session ->
+            runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }.getOrNull()
+        }
 
     private fun mapError(throwable: Throwable?): String = when (throwable) {
         is IOException -> "Vérifiez votre connexion réseau"
@@ -108,10 +179,12 @@ class TimelineViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `TimelineUiState` (class) — lines 16-22
-- `Success` (class) — lines 19-19
-- `Error` (class) — lines 21-21
-- `TimelineViewModel` (class) — lines 24-80
-- `retry` (function) — lines 35-35
-- `loadSessions` (function) — lines 37-69
-- `mapError` (function) — lines 71-79
+- `TimelineUiState` (class) — lines 22-32
+- `Success` (class) — lines 25-29
+- `Error` (class) — lines 31-31
+- `TimelineViewModel` (class) — lines 34-151
+- `retry` (function) — lines 49-49
+- `loadInitial` (function) — lines 51-92
+- `loadOlder` (function) — lines 94-135
+- `sortSessions` (function) — lines 137-140
+- `mapError` (function) — lines 142-150

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
-git_blob: af95f089ced1500882b826646a1d087a99b2a252
-last_synced: '2026-05-09T08:38:11Z'
-loc: 320
+git_blob: 81fddfd2d3a8f7e42ecda80586f192c1599b921e
+last_synced: '2026-05-09T14:31:04Z'
+loc: 721
 annotations: []
 imports: []
 exports: []
@@ -25,9 +25,11 @@ package fr.datasaillance.nightfall.ui.screens.sleep
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -35,13 +37,17 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
@@ -59,11 +65,44 @@ private val ColorLight = Color(0xFF7A9AAA)
 private val ColorRem   = Color(0xFF07BCD3)
 private val ColorAwake = Color(0xFFD37C04)
 
+private const val HYPNO_MICRO_AWAKE_THRESHOLD_MIN = 5
+
+enum class HypnogramViewMode { BARS, MOUNTAIN }
+
 private fun stageColor(stageType: String): Color = when (stageType) {
     "DEEP"  -> ColorDeep
     "REM"   -> ColorRem
     "AWAKE" -> ColorAwake
     else    -> ColorLight
+}
+
+private fun hypnoMountainLevel(stage: String): Int = when (stage) {
+    "REM"   -> 4
+    "LIGHT" -> 3
+    "DEEP"  -> 2
+    "AWAKE" -> 1
+    else    -> 0
+}
+
+private fun hypnoStageDisplayName(type: String): String = when (type) {
+    "DEEP"  -> "Sommeil profond"
+    "LIGHT" -> "Sommeil léger"
+    "REM"   -> "Sommeil paradoxal"
+    "AWAKE" -> "Éveil"
+    else    -> type
+}
+
+/**
+ * Cherche le stage qui couvre un instant `t` (offset depuis le début).
+ * Retourne null si aucun stage ne le couvre (gap entre 2 sessions).
+ */
+private fun stageAtTime(
+    t: OffsetDateTime,
+    sortedStages: List<SleepStageResponse>,
+): SleepStageResponse? = sortedStages.firstOrNull { stage ->
+    val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return@firstOrNull false
+    val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return@firstOrNull false
+    !t.isBefore(ss) && t.isBefore(se)
 }
 
 private fun nightTitle(sleepStart: String): String {
@@ -83,6 +122,7 @@ fun HypnogramScreen(
     onBack: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    var viewMode by remember { mutableStateOf(HypnogramViewMode.BARS) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -104,6 +144,19 @@ fun HypnogramScreen(
                             onBack()
                         }) {
                             Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Retour")
+                        }
+                    },
+                    actions = {
+                        TextButton(
+                            onClick = {
+                                viewMode = if (viewMode == HypnogramViewMode.BARS) HypnogramViewMode.MOUNTAIN else HypnogramViewMode.BARS
+                            },
+                            modifier = Modifier.testTag("hyp_view_toggle"),
+                        ) {
+                            Text(
+                                text = if (viewMode == HypnogramViewMode.BARS) "Mountain" else "Barres",
+                                color = MaterialTheme.colorScheme.primary,
+                            )
                         }
                     },
                     colors = TopAppBarDefaults.topAppBarColors(
@@ -159,13 +212,24 @@ fun HypnogramScreen(
                         ) {
                             HypnogramSummarySection(state.sessions)
                             Spacer(modifier = Modifier.height(16.dp))
-                            HypnogramCanvas(
-                                sessions = state.sessions,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(120.dp)
-                                    .testTag("hyp_canvas")
-                            )
+                            when (viewMode) {
+                                HypnogramViewMode.BARS -> HypnogramCanvas(
+                                    sessions = state.sessions,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                        .height(140.dp)
+                                        .testTag("hyp_canvas")
+                                )
+                                HypnogramViewMode.MOUNTAIN -> HypnogramMountainCanvas(
+                                    sessions = state.sessions,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 16.dp)
+                                        .height(180.dp)
+                                        .testTag("hyp_canvas_mountain")
+                                )
+                            }
                             Spacer(modifier = Modifier.height(8.dp))
                             HypnogramLegend()
                             Spacer(modifier = Modifier.height(16.dp))
@@ -234,82 +298,419 @@ private fun HypnogramCanvas(
     val onSurface = MaterialTheme.colorScheme.onSurface
     val surface   = MaterialTheme.colorScheme.surface
 
-    Canvas(modifier = modifier) {
-        val canvasWidth = size.width
-        val stageZoneH  = 100.dp.toPx()
+    val sortedStarts = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }
+    val sortedEnds = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }
+    val start = sortedStarts.minOrNull()
+    val end = sortedEnds.maxOrNull()
+    val totalMs = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+    val allStages = sessions.flatMap { it.stages ?: emptyList() }.sortedBy { it.stage_start }
 
-        val start = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }.minOrNull()
-        val end   = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }.maxOrNull()
-        val totalDuration = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+    var scrubX by remember { mutableStateOf<Float?>(null) }
+    var canvasW by remember { mutableStateOf(0f) }
 
-        val allStages = sessions.flatMap { it.stages ?: emptyList() }
-        if (totalDuration <= 0 || allStages.isEmpty()) {
-            drawRect(
-                color   = surface.copy(alpha = 0.3f),
-                topLeft = Offset(0f, 0f),
-                size    = Size(canvasWidth, stageZoneH)
-            )
-            return@Canvas
-        }
+    Box(modifier = modifier) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(start, end, allStages.size) {
+                    detectDragGesturesAfterLongPress(
+                        onDragStart = { offset -> scrubX = offset.x.coerceIn(0f, canvasW) },
+                        onDrag = { change, _ -> scrubX = change.position.x.coerceIn(0f, canvasW) },
+                        onDragEnd = { scrubX = null },
+                        onDragCancel = { scrubX = null },
+                    )
+                }
+        ) {
+            canvasW = size.width
+            val canvasWidth = size.width
+            val stageZoneH = 110.dp.toPx()
+            val cornerR = 4.dp.toPx()
 
-        for (stage in allStages.sortedBy { it.stage_start }) {
-            val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: continue
-            val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: continue
-            val stageDurMs = Duration.between(ss, se).toMillis()
-            val offsetMs   = Duration.between(start, ss).toMillis()
-
-            val x     = (offsetMs.toFloat() / totalDuration) * canvasWidth
-            val width = (stageDurMs.toFloat() / totalDuration) * canvasWidth
-
-            val rectH: Float
-            val rectTop: Float
-            if (stage.stage == "AWAKE") {
-                rectH   = 60.dp.toPx()
-                rectTop = (stageZoneH - rectH) / 2f
-            } else {
-                rectH   = stageZoneH
-                rectTop = 0f
+            if (totalMs <= 0 || allStages.isEmpty() || start == null || end == null) {
+                drawRect(
+                    color = surface.copy(alpha = 0.3f),
+                    topLeft = Offset(0f, 0f),
+                    size = Size(canvasWidth, stageZoneH),
+                )
+                return@Canvas
             }
 
-            drawRect(
-                color   = stageColor(stage.stage),
-                topLeft = Offset(x, rectTop),
-                size    = Size(width, rectH)
-            )
-        }
-
-        val tickStart = start!!.toLocalDateTime().let { ldt ->
-            val h = ldt.hour
-            val nextH = if (ldt.minute > 0 || ldt.second > 0) h + 1 else h
-            start.withHour(nextH % 24).withMinute(0).withSecond(0).withNano(0)
-                .let { if (nextH >= 24) it.plusDays(1) else it }
-        }
-
-        val paint = android.graphics.Paint().apply {
-            textSize  = 10.sp.toPx()
-            color     = onSurface.copy(alpha = 0.5f).toArgb()
-            textAlign = android.graphics.Paint.Align.CENTER
-        }
-
-        var tick = tickStart
-        while (!tick.isAfter(end!!)) {
-            val tickOffsetMs = Duration.between(start, tick).toMillis()
-            val xTick = (tickOffsetMs.toFloat() / totalDuration) * canvasWidth
-            drawLine(
-                color       = onSurface.copy(alpha = 0.3f),
-                start       = Offset(xTick, 95.dp.toPx()),
-                end         = Offset(xTick, stageZoneH),
-                strokeWidth = 1.dp.toPx()
-            )
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawText(
-                    tick.format(DateTimeFormatter.ofPattern("HH:mm")),
-                    xTick,
-                    118.dp.toPx(),
-                    paint
+            val firstStageStart = allStages.first().stage_start
+            val lastStageEnd = allStages.last().stage_end
+            for (stage in allStages) {
+                val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: continue
+                val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: continue
+                val stageDurMs = Duration.between(ss, se).toMillis()
+                val offsetMs = Duration.between(start, ss).toMillis()
+                val x = (offsetMs.toFloat() / totalMs) * canvasWidth
+                val width = (stageDurMs.toFloat() / totalMs) * canvasWidth
+                drawRoundedSegment(
+                    color = stageColor(stage.stage),
+                    left = x,
+                    top = 0f,
+                    width = width,
+                    height = stageZoneH,
+                    cornerRadius = cornerR,
+                    roundLeft = stage.stage_start == firstStageStart,
+                    roundRight = stage.stage_end == lastStageEnd,
                 )
             }
-            tick = tick.plusHours(1)
+
+            // Axe : 4 ticks fixes — coucher (0%), 33%, 66%, réveil (100%)
+            drawAxisFourTicks(start, totalMs, canvasWidth, stageZoneH, onSurface)
+
+            // Curseur de scrub
+            scrubX?.let { x ->
+                drawLine(
+                    color = onSurface.copy(alpha = 0.7f),
+                    start = Offset(x, 0f),
+                    end = Offset(x, stageZoneH),
+                    strokeWidth = 1.5.dp.toPx(),
+                )
+            }
+        }
+
+        // Tooltip flottant pendant le scrub
+        scrubX?.let { x ->
+            if (canvasW > 0 && totalMs > 0 && start != null) {
+                val ratio = (x / canvasW).coerceIn(0f, 1f)
+                val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+                val stage = stageAtTime(t, allStages)
+                ScrubTooltip(
+                    timeText = t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                    stageText = stage?.let { hypnoStageDisplayName(it.stage) } ?: "—",
+                    stageDotColor = stage?.let { stageColor(it.stage) } ?: ColorLight,
+                    xPx = x,
+                    canvasWidthPx = canvasW,
+                )
+            }
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawAxisFourTicks(
+    start: OffsetDateTime,
+    totalMs: Long,
+    canvasWidth: Float,
+    stageZoneH: Float,
+    onSurface: Color,
+) {
+    val paint = android.graphics.Paint().apply {
+        textSize = 13.sp.toPx()
+        color = onSurface.copy(alpha = 0.7f).toArgb()
+        textAlign = android.graphics.Paint.Align.CENTER
+    }
+    val ratios = listOf(0f, 1 / 3f, 2 / 3f, 1f)
+    ratios.forEachIndexed { i, ratio ->
+        val xTick = ratio * canvasWidth
+        val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+        drawLine(
+            color = onSurface.copy(alpha = 0.3f),
+            start = Offset(xTick, stageZoneH - 5.dp.toPx()),
+            end = Offset(xTick, stageZoneH),
+            strokeWidth = 1.dp.toPx(),
+        )
+        // Aligne les labels aux extrémités pour éviter qu'ils dépassent l'écran
+        paint.textAlign = when (i) {
+            0 -> android.graphics.Paint.Align.LEFT
+            ratios.lastIndex -> android.graphics.Paint.Align.RIGHT
+            else -> android.graphics.Paint.Align.CENTER
+        }
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                xTick,
+                stageZoneH + 22.dp.toPx(),
+                paint,
+            )
+        }
+    }
+}
+
+@Composable
+private fun BoxScope.ScrubTooltip(
+    timeText: String,
+    stageText: String,
+    stageDotColor: Color,
+    xPx: Float,
+    canvasWidthPx: Float,
+) {
+    val density = LocalDensity.current
+    val approxTooltipWidthPx = with(density) { 160.dp.toPx() }
+    val centeredX = (xPx - approxTooltipWidthPx / 2f).coerceIn(0f, canvasWidthPx - approxTooltipWidthPx)
+
+    Surface(
+        modifier = Modifier
+            .offset { IntOffset(centeredX.toInt(), 0) }
+            .align(Alignment.TopStart)
+            .clip(RoundedCornerShape(8.dp)),
+        color = MaterialTheme.colorScheme.surface,
+        shadowElevation = 4.dp,
+        tonalElevation = 2.dp,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .clip(CircleShape)
+                    .background(stageDotColor),
+            )
+            Text(
+                text = timeText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Text(
+                text = stageText,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
+            )
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawRoundedSegment(
+    color: Color,
+    left: Float,
+    top: Float,
+    width: Float,
+    height: Float,
+    cornerRadius: Float,
+    roundLeft: Boolean,
+    roundRight: Boolean,
+) {
+    if (width <= 0f) return
+    val rect = androidx.compose.ui.geometry.Rect(left, top, left + width, top + height)
+    if (!roundLeft && !roundRight) {
+        drawRect(color, rect.topLeft, rect.size)
+        return
+    }
+    val radius = cornerRadius.coerceAtMost(width / 2f).coerceAtMost(height / 2f)
+    val path = androidx.compose.ui.graphics.Path().apply {
+        if (roundLeft && roundRight) {
+            addRoundRect(
+                androidx.compose.ui.geometry.RoundRect(rect, androidx.compose.ui.geometry.CornerRadius(radius))
+            )
+        } else if (roundLeft) {
+            // Coins arrondis seulement à gauche, droits à droite
+            moveTo(rect.left + radius, rect.top)
+            lineTo(rect.right, rect.top)
+            lineTo(rect.right, rect.bottom)
+            lineTo(rect.left + radius, rect.bottom)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.left, rect.bottom - 2 * radius, rect.left + 2 * radius, rect.bottom),
+                startAngleDegrees = 90f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            lineTo(rect.left, rect.top + radius)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.left, rect.top, rect.left + 2 * radius, rect.top + 2 * radius),
+                startAngleDegrees = 180f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            close()
+        } else {
+            // Coins arrondis seulement à droite
+            moveTo(rect.left, rect.top)
+            lineTo(rect.right - radius, rect.top)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.right - 2 * radius, rect.top, rect.right, rect.top + 2 * radius),
+                startAngleDegrees = 270f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            lineTo(rect.right, rect.bottom - radius)
+            arcTo(
+                rect = androidx.compose.ui.geometry.Rect(rect.right - 2 * radius, rect.bottom - 2 * radius, rect.right, rect.bottom),
+                startAngleDegrees = 0f, sweepAngleDegrees = 90f, forceMoveTo = false,
+            )
+            lineTo(rect.left, rect.bottom)
+            close()
+        }
+    }
+    drawPath(path, color)
+}
+
+// ── Mountain canvas — graph 5 niveaux pour 1 hypnogramme zoomé ─────────────
+
+private data class HypnoMountainSegment(
+    val startMs: Long,
+    val endMs: Long,
+    val level: Int,
+    val color: Color,
+)
+
+private data class HypnoMicroAwake(val tMs: Long)
+
+private fun buildHypnoMountain(
+    sessions: List<SleepSessionResponse>,
+    sessionStart: OffsetDateTime,
+): Pair<List<HypnoMountainSegment>, List<HypnoMicroAwake>> {
+    val segments = mutableListOf<HypnoMountainSegment>()
+    val ticks = mutableListOf<HypnoMicroAwake>()
+    sessions.flatMap { it.stages ?: emptyList() }
+        .sortedBy { it.stage_start }
+        .forEach { stage ->
+            val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return@forEach
+            val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return@forEach
+            val durMin = Duration.between(ss, se).toMinutes()
+            val startMs = Duration.between(sessionStart, ss).toMillis()
+            val endMs = Duration.between(sessionStart, se).toMillis()
+            if (stage.stage == "AWAKE" && durMin < HYPNO_MICRO_AWAKE_THRESHOLD_MIN) {
+                ticks.add(HypnoMicroAwake(startMs))
+            } else {
+                segments.add(
+                    HypnoMountainSegment(
+                        startMs = startMs,
+                        endMs = endMs,
+                        level = hypnoMountainLevel(stage.stage),
+                        color = stageColor(stage.stage),
+                    )
+                )
+            }
+        }
+    return Pair(segments, ticks)
+}
+
+@Composable
+private fun HypnogramMountainCanvas(
+    sessions: List<SleepSessionResponse>,
+    modifier: Modifier = Modifier,
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val gridColor = onSurface.copy(alpha = 0.1f)
+    val lineColor = onSurface.copy(alpha = 0.85f)
+    val tickColor = ColorAwake.copy(alpha = 0.9f)
+
+    val sortedStarts = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull() }
+    val sortedEnds = sessions.mapNotNull { runCatching { OffsetDateTime.parse(it.sleep_end) }.getOrNull() }
+    val start = sortedStarts.minOrNull()
+    val end = sortedEnds.maxOrNull()
+    val totalMs = if (start != null && end != null) Duration.between(start, end).toMillis() else 0L
+    val allStages = sessions.flatMap { it.stages ?: emptyList() }.sortedBy { it.stage_start }
+
+    var scrubX by remember { mutableStateOf<Float?>(null) }
+    var canvasW by remember { mutableStateOf(0f) }
+
+    Box(modifier = modifier) {
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(start, end, allStages.size) {
+                    detectDragGesturesAfterLongPress(
+                        onDragStart = { offset -> scrubX = offset.x.coerceIn(0f, canvasW) },
+                        onDrag = { change, _ -> scrubX = change.position.x.coerceIn(0f, canvasW) },
+                        onDragEnd = { scrubX = null },
+                        onDragCancel = { scrubX = null },
+                    )
+                }
+        ) {
+            canvasW = size.width
+            val plotTop = 8.dp.toPx()
+            val plotBot = size.height - 28.dp.toPx()
+            val plotH = plotBot - plotTop
+
+            if (start == null || end == null || totalMs <= 0L) return@Canvas
+
+            fun yForLevel(level: Int): Float = plotBot - (level / 4f) * plotH
+            fun xForMs(ms: Long): Float = (ms.toFloat() / totalMs) * canvasW
+
+            val (segments, ticks) = buildHypnoMountain(sessions, start)
+            val l0y = yForLevel(0)
+
+            for (lvl in 0..4) {
+                val y = yForLevel(lvl)
+                drawLine(gridColor, Offset(0f, y), Offset(canvasW, y), strokeWidth = 1f)
+            }
+
+            segments.forEach { seg ->
+                val x = xForMs(seg.startMs)
+                val xEnd = xForMs(seg.endMs)
+                val w = (xEnd - x).coerceAtLeast(1f)
+                val y = yForLevel(seg.level)
+                drawRect(seg.color.copy(alpha = 0.55f), Offset(x, y), Size(w, l0y - y))
+            }
+
+            if (segments.isNotEmpty()) {
+                val path = androidx.compose.ui.graphics.Path()
+                val first = segments.first()
+                path.moveTo(xForMs(first.startMs), l0y)
+                path.lineTo(xForMs(first.startMs), yForLevel(first.level))
+                segments.forEachIndexed { idx, seg ->
+                    val xEnd = xForMs(seg.endMs)
+                    path.lineTo(xEnd, yForLevel(seg.level))
+                    if (idx < segments.size - 1) {
+                        val next = segments[idx + 1]
+                        val xNextStart = xForMs(next.startMs)
+                        if (xNextStart > xEnd) {
+                            path.lineTo(xEnd, l0y)
+                            path.lineTo(xNextStart, l0y)
+                            path.lineTo(xNextStart, yForLevel(next.level))
+                        } else {
+                            path.lineTo(xEnd, yForLevel(next.level))
+                        }
+                    }
+                }
+                val last = segments.last()
+                path.lineTo(xForMs(last.endMs), l0y)
+                drawPath(path, lineColor, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.5.dp.toPx()))
+            }
+
+            ticks.forEach { tick ->
+                val x = xForMs(tick.tMs)
+                drawLine(tickColor, Offset(x, plotTop), Offset(x, l0y), strokeWidth = 1.4.dp.toPx())
+            }
+
+            // Axe X 4 ticks (coucher / 33% / 66% / réveil)
+            val paint = android.graphics.Paint().apply {
+                textSize = 13.sp.toPx()
+                color = onSurface.copy(alpha = 0.7f).toArgb()
+                textAlign = android.graphics.Paint.Align.CENTER
+            }
+            val ratios = listOf(0f, 1 / 3f, 2 / 3f, 1f)
+            ratios.forEachIndexed { i, ratio ->
+                val xTick = ratio * canvasW
+                val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+                drawLine(onSurface.copy(alpha = 0.3f), Offset(xTick, plotBot - 4.dp.toPx()), Offset(xTick, plotBot), strokeWidth = 1.dp.toPx())
+                paint.textAlign = when (i) {
+                    0 -> android.graphics.Paint.Align.LEFT
+                    ratios.lastIndex -> android.graphics.Paint.Align.RIGHT
+                    else -> android.graphics.Paint.Align.CENTER
+                }
+                drawIntoCanvas { canvas ->
+                    canvas.nativeCanvas.drawText(
+                        t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                        xTick,
+                        plotBot + 18.dp.toPx(),
+                        paint,
+                    )
+                }
+            }
+
+            // Curseur scrub
+            scrubX?.let { x ->
+                drawLine(
+                    color = onSurface.copy(alpha = 0.7f),
+                    start = Offset(x, plotTop),
+                    end = Offset(x, plotBot),
+                    strokeWidth = 1.5.dp.toPx(),
+                )
+            }
+        }
+
+        scrubX?.let { x ->
+            if (canvasW > 0 && totalMs > 0 && start != null) {
+                val ratio = (x / canvasW).coerceIn(0f, 1f)
+                val t = start.plus(Duration.ofMillis((totalMs * ratio).toLong()))
+                val stage = stageAtTime(t, allStages)
+                ScrubTooltip(
+                    timeText = t.format(DateTimeFormatter.ofPattern("HH:mm")),
+                    stageText = stage?.let { hypnoStageDisplayName(it.stage) } ?: "—",
+                    stageDotColor = stage?.let { stageColor(it.stage) } ?: ColorLight,
+                    xPx = x,
+                    canvasWidthPx = canvasW,
+                )
+            }
         }
     }
 }
@@ -348,10 +749,23 @@ private fun LegendItem(color: Color, label: String) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `stageColor` (function) — lines 39-44
-- `nightTitle` (function) — lines 46-54
-- `HypnogramScreen` (function) — lines 56-156
-- `HypnogramSummarySection` (function) — lines 158-204
-- `HypnogramCanvas` (function) — lines 206-292
-- `HypnogramLegend` (function) — lines 294-307
-- `LegendItem` (function) — lines 309-320
+- `HypnogramViewMode` (class) — lines 47-47
+- `stageColor` (function) — lines 49-54
+- `hypnoMountainLevel` (function) — lines 56-62
+- `hypnoStageDisplayName` (function) — lines 64-70
+- `stageAtTime` (function) — lines 76-83
+- `nightTitle` (function) — lines 85-93
+- `HypnogramScreen` (function) — lines 95-220
+- `HypnogramSummarySection` (function) — lines 222-268
+- `HypnogramCanvas` (function) — lines 270-366
+- `drawAxisFourTicks` (function) — lines 368-405
+- `ScrubTooltip` (function) — lines 407-451
+- `drawRoundedSegment` (function) — lines 453-509
+- `HypnoMountainSegment` (class) — lines 513-518
+- `HypnoMicroAwake` (class) — lines 520-520
+- `buildHypnoMountain` (function) — lines 522-550
+- `HypnogramMountainCanvas` (function) — lines 552-693
+- `yForLevel` (function) — lines 592-592
+- `xForMs` (function) — lines 593-593
+- `HypnogramLegend` (function) — lines 695-708
+- `LegendItem` (function) — lines 710-721

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
-git_blob: a5bc9731bc6edb08faa180fa5c9cff38df8c62a3
-last_synced: '2026-05-09T07:41:11Z'
-loc: 500
+git_blob: 14cb4f8d5d2c6d528f8d812cc6247699644399c9
+last_synced: '2026-05-09T14:31:05Z'
+loc: 783
 annotations: []
 imports: []
 exports: []
@@ -27,11 +27,14 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,9 +62,28 @@ import java.util.Locale
 
 private const val ROW_HEIGHT_DP    = 40
 private const val BAR_HEIGHT_DP    = 24
+private const val MOUNTAIN_ROW_HEIGHT_DP = 64
 private const val AXIS_BOTTOM_DP   = 24
 private const val LABEL_WIDTH_DP   = 48
 private const val LABEL_PADDING_DP = 4
+// Fenêtre fixe 24h pour Non-24 — les heures de sommeil glissent partout.
+private const val WINDOW_START_MIN = 0
+private const val WINDOW_END_MIN   = 1440
+// Grille verticale toutes les 3h pour rester lisible sur un écran portrait.
+private const val GRID_STEP_HOURS  = 3
+// Micro-réveil < ce seuil = trait vertical, pas de creux dans la mountain.
+private const val MICRO_AWAKE_THRESHOLD_MIN = 5
+
+enum class TimelineViewMode { BARS, MOUNTAIN }
+
+// Mountain : 5 niveaux (0 = éveil session, 1 = AWAKE intra, 2 = DEEP, 3 = LIGHT, 4 = REM)
+private fun mountainLevel(stage: String): Int = when (stage) {
+    "REM"   -> 4
+    "LIGHT" -> 3
+    "DEEP"  -> 2
+    "AWAKE" -> 1
+    else    -> 0
+}
 
 // ── Stage colours ──────────────────────────────────────────────────────────
 
@@ -86,18 +108,6 @@ private fun stageDisplayName(type: String): String = when (type) {
     else    -> type
 }
 
-// ── Window algorithm ──────────────────────────────────────────────────────
-
-private fun computeTimelineWindow(sessions: List<SleepSessionResponse>): Pair<Int, Int> {
-    val startMinutes = sessions.mapNotNull {
-        runCatching { OffsetDateTime.parse(it.sleep_start) }.getOrNull()
-    }.map { it.hour * 60 + it.minute }.sorted()
-    val medianMinutes = if (startMinutes.isEmpty()) 22 * 60 else startMinutes[startMinutes.size / 2]
-    val windowStart = (medianMinutes - 120).coerceAtLeast(0)
-    val windowEnd   = (windowStart + 960).coerceAtMost(1440)
-    return Pair(windowStart, windowEnd)
-}
-
 // ── Night aggregation — 1 row = 1 calendar date (keyed by sleep_start.date) ──
 
 private fun groupByNight(sessions: List<SleepSessionResponse>): List<Pair<LocalDate, List<SleepSessionResponse>>> =
@@ -109,14 +119,11 @@ private fun groupByNight(sessions: List<SleepSessionResponse>): List<Pair<LocalD
         .sortedBy { it.key }
         .map { (date, list) -> date to list }
 
-// ── Hit-box for tap detection on stage segments ────────────────────────────
+// ── Selection model — un click ouvre le détail d'UNE nuit complète ─────────
 
-private data class StageHitBox(
-    val left: Float, val top: Float, val right: Float, val bottom: Float,
-    val stageType: String,
-    val stageStart: String,
-    val stageEnd: String,
-    val nightLabel: String
+private data class NightSelection(
+    val date: LocalDate,
+    val sessions: List<SleepSessionResponse>,
 )
 
 // ── Screen ─────────────────────────────────────────────────────────────────
@@ -124,10 +131,12 @@ private data class StageHitBox(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TimelineScreen(
-    viewModel: TimelineViewModel
+    viewModel: TimelineViewModel,
+    onOpenHypnogram: (sessionId: String, isoDate: String?) -> Unit = { _, _ -> },
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var selectedStage by remember { mutableStateOf<StageHitBox?>(null) }
+    var selectedNight by remember { mutableStateOf<NightSelection?>(null) }
+    var viewMode by remember { mutableStateOf(TimelineViewMode.BARS) }
 
     Surface(
         modifier = Modifier.fillMaxSize(),
@@ -137,6 +146,19 @@ fun TimelineScreen(
             topBar = {
                 TopAppBar(
                     title = { Text("Drift circadien", style = MaterialTheme.typography.headlineMedium) },
+                    actions = {
+                        TextButton(
+                            onClick = {
+                                viewMode = if (viewMode == TimelineViewMode.BARS) TimelineViewMode.MOUNTAIN else TimelineViewMode.BARS
+                            },
+                            modifier = Modifier.testTag("tl_view_toggle"),
+                        ) {
+                            Text(
+                                text = if (viewMode == TimelineViewMode.BARS) "Mountain" else "Barres",
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    },
                     colors = TopAppBarDefaults.topAppBarColors(
                         containerColor = MaterialTheme.colorScheme.background
                     )
@@ -196,26 +218,55 @@ fun TimelineScreen(
 
                     is TimelineUiState.Success -> {
                         val nights = remember(state.sessions) { groupByNight(state.sessions) }
-                        val (windowStart, windowEnd) = remember(state.sessions) {
-                            computeTimelineWindow(state.sessions)
+                        val listState = rememberLazyListState()
+                        var initialScrollDone by remember { mutableStateOf(false) }
+
+                        // 1er rendu : scroll au bas de la liste pour afficher la nuit la plus récente.
+                        LaunchedEffect(nights.size, initialScrollDone) {
+                            if (!initialScrollDone && nights.isNotEmpty()) {
+                                listState.scrollToItem(nights.size) // +1 sentinel offset → last index
+                                initialScrollDone = true
+                            }
                         }
-                        val canvasHeightDp = (nights.size * ROW_HEIGHT_DP + AXIS_BOTTOM_DP).dp
+
+                        // Sentinel : quand l'utilisateur scrolle jusqu'en haut de la liste, on charge
+                        // 30 jours plus anciens. distinctUntilChanged évite les triggers répétés
+                        // pendant que la pagination est déjà en cours.
+                        LaunchedEffect(listState, state.hasMore, state.loadingMore) {
+                            snapshotFlow { listState.firstVisibleItemIndex }
+                                .distinctUntilChanged()
+                                .filter { it == 0 && state.hasMore && !state.loadingMore && initialScrollDone }
+                                .collect { viewModel.loadOlder() }
+                        }
 
                         Column(
                             modifier = Modifier.fillMaxSize().testTag("tl_screen")
                         ) {
-                            TimelineAxisHeader(windowStart = windowStart, windowEnd = windowEnd)
-                            Box(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                                TimelineCanvas(
-                                    nights      = nights,
-                                    windowStart = windowStart,
-                                    windowEnd   = windowEnd,
-                                    onStageTap  = { selectedStage = it },
-                                    modifier    = Modifier
-                                        .fillMaxWidth()
-                                        .height(canvasHeightDp)
-                                        .testTag("tl_canvas")
-                                )
+                            TimelineAxisHeader()
+                            LazyColumn(
+                                state = listState,
+                                modifier = Modifier.fillMaxSize().testTag("tl_list")
+                            ) {
+                                item(key = "load_older_sentinel") {
+                                    LoadOlderSentinel(
+                                        loadingMore = state.loadingMore,
+                                        hasMore = state.hasMore,
+                                    )
+                                }
+                                items(nights, key = { (date, _) -> date.toEpochDay() }) { (date, sessions) ->
+                                    when (viewMode) {
+                                        TimelineViewMode.BARS -> NightRow(
+                                            date = date,
+                                            sessions = sessions,
+                                            onClick = { selectedNight = NightSelection(date, sessions) },
+                                        )
+                                        TimelineViewMode.MOUNTAIN -> NightRowMountain(
+                                            date = date,
+                                            sessions = sessions,
+                                            onClick = { selectedNight = NightSelection(date, sessions) },
+                                        )
+                                    }
+                                }
                             }
                         }
                     }
@@ -224,175 +275,337 @@ fun TimelineScreen(
         }
     }
 
-    // ── Bottom sheet — stage detail ────────────────────────────────────────
-    selectedStage?.let { stage ->
+    // ── Bottom sheet — night detail (toutes sessions de la nuit) ───────────
+    selectedNight?.let { night ->
         ModalBottomSheet(
-            onDismissRequest = { selectedStage = null },
+            onDismissRequest = { selectedNight = null },
             sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
             containerColor = MaterialTheme.colorScheme.surface
         ) {
-            StageDetailSheet(stage = stage)
+            NightDetailSheet(
+                night = night,
+                onOpenHypnogram = { sessionId ->
+                    val iso = night.date.toString()
+                    selectedNight = null
+                    onOpenHypnogram(sessionId, iso)
+                },
+            )
         }
     }
 }
 
-// ── Axis header ─────────────────────────────────────────────────────────────
+// ── Axis header — 24h fixe avec ticks toutes les GRID_STEP_HOURS heures ────
 
 @Composable
-private fun TimelineAxisHeader(
-    windowStart: Int,
-    windowEnd: Int,
-    modifier: Modifier = Modifier
-) {
+private fun TimelineAxisHeader(modifier: Modifier = Modifier) {
     val onSurface = MaterialTheme.colorScheme.onSurface
-    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
 
     Canvas(
         modifier = modifier.fillMaxWidth().height(AXIS_BOTTOM_DP.dp)
     ) {
-        val canvasW   = size.width
-        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
+        val canvasW = size.width
+        val labelPx = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
         val paint = android.graphics.Paint().apply {
-            textSize  = 9.sp.toPx()
-            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textSize = 9.sp.toPx()
+            color = onSurface.copy(alpha = 0.7f).toArgb()
             textAlign = android.graphics.Paint.Align.CENTER
         }
-        val step = if (windowDuration >= 720) 2 else 1
-        var h = windowStart / 60
-        val endHour = (windowEnd + 59) / 60
-        while (h <= endHour) {
+        var h = 0
+        while (h <= 24) {
             val hMin = h * 60
-            if (hMin in windowStart..windowEnd) {
-                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
-                drawIntoCanvas { canvas ->
-                    canvas.nativeCanvas.drawText("%02d:00".format(h % 24), x, size.height * 0.8f, paint)
-                }
+            val x = labelPx + (hMin.toFloat() / windowDuration) * drawableW
+            drawIntoCanvas { canvas ->
+                canvas.nativeCanvas.drawText("%02dh".format(h % 24), x, size.height * 0.8f, paint)
             }
-            h += step
+            h += GRID_STEP_HOURS
         }
     }
 }
 
-// ── Canvas ──────────────────────────────────────────────────────────────────
+// ── Sentinel (top of LazyColumn) ────────────────────────────────────────────
 
 @Composable
-private fun TimelineCanvas(
-    nights: List<Pair<LocalDate, List<SleepSessionResponse>>>,
-    windowStart: Int,
-    windowEnd: Int,
-    onStageTap: (StageHitBox) -> Unit,
-    modifier: Modifier = Modifier
+private fun LoadOlderSentinel(
+    loadingMore: Boolean,
+    hasMore: Boolean,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp)
+            .testTag("tl_sentinel"),
+        contentAlignment = Alignment.Center
+    ) {
+        when {
+            loadingMore -> CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                strokeWidth = 2.dp,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            !hasMore -> Text(
+                text = "Aucune donnée plus ancienne",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+            )
+            else -> Spacer(modifier = Modifier.height(4.dp))
+        }
+    }
+}
+
+// ── Single night row (1 Canvas par nuit, lazy-loaded) ───────────────────────
+
+@Composable
+private fun NightRow(
+    date: LocalDate,
+    sessions: List<SleepSessionResponse>,
+    onClick: () -> Unit,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
-    val windowDuration = (windowEnd - windowStart).takeIf { it > 0 } ?: return
-    val hitBoxes = remember { mutableListOf<StageHitBox>() }
-    val dateFmt  = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
+    val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
+    val label = remember(date) { date.format(dateFmt) }
+    val gridColor = onSurface.copy(alpha = 0.08f)
 
     Canvas(
-        modifier = modifier.pointerInput(Unit) {
-            detectTapGestures { offset ->
-                hitBoxes.firstOrNull { box ->
-                    offset.x >= box.left && offset.x <= box.right &&
-                    offset.y >= box.top  && offset.y <= box.bottom
-                }?.let { onStageTap(it) }
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(ROW_HEIGHT_DP.dp)
+            .pointerInput(date) {
+                detectTapGestures { onClick() }
             }
-        }
     ) {
-        hitBoxes.clear()
-
-        val canvasW   = size.width
-        val labelPx   = LABEL_WIDTH_DP.dp.toPx()
+        val canvasW = size.width
+        val labelPx = LABEL_WIDTH_DP.dp.toPx()
         val drawableW = canvasW - labelPx
-        val rowH      = ROW_HEIGHT_DP.dp.toPx()
-        val barH      = BAR_HEIGHT_DP.dp.toPx()
-        val axisBot   = AXIS_BOTTOM_DP.dp.toPx()
+        val rowH = ROW_HEIGHT_DP.dp.toPx()
+        val barH = BAR_HEIGHT_DP.dp.toPx()
+        val barTop = (rowH - barH) / 2f
 
         val datePaint = android.graphics.Paint().apply {
-            textSize  = 10.sp.toPx()
-            color     = onSurface.copy(alpha = 0.6f).toArgb()
+            textSize = 10.sp.toPx()
+            color = onSurface.copy(alpha = 0.6f).toArgb()
             textAlign = android.graphics.Paint.Align.LEFT
         }
-        val tickPaint = android.graphics.Paint().apply {
-            textSize  = 9.sp.toPx()
-            color     = onSurface.copy(alpha = 0.5f).toArgb()
-            textAlign = android.graphics.Paint.Align.CENTER
+
+        // Grid verticale en fond — toutes les GRID_STEP_HOURS heures.
+        var h = 0
+        while (h <= 24) {
+            val x = labelPx + (h * 60f / windowDuration) * drawableW
+            drawLine(
+                color = gridColor,
+                start = Offset(x, 0f),
+                end = Offset(x, rowH),
+                strokeWidth = 1f,
+            )
+            h += GRID_STEP_HOURS
         }
 
-        nights.forEachIndexed { rowIndex, (date, sessions) ->
-            val rowTop = rowIndex * rowH
-            val barTop = rowTop + (rowH - barH) / 2f
-            val label  = date.format(dateFmt)
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                label,
+                LABEL_PADDING_DP.dp.toPx(),
+                rowH / 2f + datePaint.textSize / 3f,
+                datePaint,
+            )
+        }
 
-            // Date label
-            drawIntoCanvas { canvas ->
-                canvas.nativeCanvas.drawText(
-                    label,
-                    LABEL_PADDING_DP.dp.toPx(),
-                    rowTop + rowH / 2f + datePaint.textSize / 3f,
-                    datePaint
+        sessions.forEach { session ->
+            val stages = session.stages?.sortedBy { it.stage_start } ?: emptyList()
+            if (stages.isEmpty()) {
+                drawFallbackBar(
+                    session = session,
+                    labelPx = labelPx,
+                    drawableW = drawableW,
+                    barTop = barTop,
+                    barH = barH,
+                )
+            } else {
+                stages.forEachIndexed { idx, stage ->
+                    drawStageSegment(
+                        stage = stage,
+                        labelPx = labelPx,
+                        drawableW = drawableW,
+                        barTop = barTop,
+                        barH = barH,
+                        roundLeft = idx == 0,
+                        roundRight = idx == stages.size - 1,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ── Mountain view — graph "ligne montagne" 5 niveaux par nuit ───────────────
+
+private data class MountainSegment(
+    val startMin: Int,
+    val endMin: Int,
+    val level: Int,
+    val color: Color,
+)
+
+private data class MicroAwakeMark(val minute: Int)
+
+/**
+ * Convertit les sessions d'une nuit en segments mountain :
+ * - micro-AWAKE (<5min) → MicroAwakeMark, le segment courant continue à son niveau
+ * - AWAKE >=5min → segment à L1 avec couleur AWAKE
+ * - DEEP/LIGHT/REM → segment à leur niveau (2/3/4) avec leur couleur
+ *
+ * Entre 2 sessions consécutives, le path retombe à L0 puis remonte.
+ */
+private fun buildMountainData(
+    sessions: List<SleepSessionResponse>,
+): Pair<List<MountainSegment>, List<MicroAwakeMark>> {
+    val segments = mutableListOf<MountainSegment>()
+    val ticks = mutableListOf<MicroAwakeMark>()
+
+    sessions.forEach { session ->
+        val sortedStages = session.stages?.sortedBy { it.stage_start } ?: return@forEach
+        sortedStages.forEach { stage ->
+            val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return@forEach
+            val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return@forEach
+            val durationMin = Duration.between(ss, se).toMinutes()
+            val startMin = ss.hour * 60 + ss.minute
+            var endMin = se.hour * 60 + se.minute
+            if (endMin < startMin) endMin += 1440
+
+            if (stage.stage == "AWAKE" && durationMin < MICRO_AWAKE_THRESHOLD_MIN) {
+                ticks.add(MicroAwakeMark(startMin))
+            } else {
+                segments.add(
+                    MountainSegment(
+                        startMin = startMin,
+                        endMin = endMin,
+                        level = mountainLevel(stage.stage),
+                        color = stageColor(stage.stage),
+                    )
                 )
             }
+        }
+    }
+    return Pair(segments, ticks)
+}
 
-            // Draw stages for all sessions of this night
-            sessions.forEach { session ->
-                val stages = session.stages
-                if (stages.isNullOrEmpty()) {
-                    // Fallback: single bar spanning sleep duration
-                    drawFallbackBar(
-                        session      = session,
-                        windowStart  = windowStart,
-                        windowDuration = windowDuration,
-                        labelPx      = labelPx,
-                        drawableW    = drawableW,
-                        barTop       = barTop,
-                        barH         = barH,
-                        nightLabel   = label,
-                        hitBoxes     = hitBoxes
-                    )
-                } else {
-                    stages.sortedBy { it.stage_start }.forEach { stage ->
-                        drawStageSegment(
-                            stage        = stage,
-                            windowStart  = windowStart,
-                            windowDuration = windowDuration,
-                            labelPx      = labelPx,
-                            drawableW    = drawableW,
-                            barTop       = barTop,
-                            barH         = barH,
-                            nightLabel   = label,
-                            hitBoxes     = hitBoxes
-                        )
+@Composable
+private fun NightRowMountain(
+    date: LocalDate,
+    sessions: List<SleepSessionResponse>,
+    onClick: () -> Unit,
+) {
+    val onSurface = MaterialTheme.colorScheme.onSurface
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
+    val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
+    val label = remember(date) { date.format(dateFmt) }
+    val gridColor = onSurface.copy(alpha = 0.08f)
+    val lineColor = onSurface.copy(alpha = 0.85f)
+    val tickColor = ColorAwake.copy(alpha = 0.9f)
+
+    val (segments, ticks) = remember(sessions) { buildMountainData(sessions) }
+
+    Canvas(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(MOUNTAIN_ROW_HEIGHT_DP.dp)
+            .pointerInput(date) { detectTapGestures { onClick() } }
+    ) {
+        val canvasW = size.width
+        val labelPx = LABEL_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx
+        val rowH = MOUNTAIN_ROW_HEIGHT_DP.dp.toPx()
+        val plotTop = 6.dp.toPx()
+        val plotBot = rowH - 6.dp.toPx()
+        val plotH = plotBot - plotTop
+        // 5 paliers (L0..L4) → 4 intervalles
+        fun yForLevel(level: Int): Float = plotBot - (level / 4f) * plotH
+
+        val datePaint = android.graphics.Paint().apply {
+            textSize = 10.sp.toPx()
+            color = onSurface.copy(alpha = 0.6f).toArgb()
+            textAlign = android.graphics.Paint.Align.LEFT
+        }
+
+        // Grid verticale (heures)
+        var h = 0
+        while (h <= 24) {
+            val x = labelPx + (h * 60f / windowDuration) * drawableW
+            drawLine(gridColor, Offset(x, 0f), Offset(x, rowH), strokeWidth = 1f)
+            h += GRID_STEP_HOURS
+        }
+
+        drawIntoCanvas { canvas ->
+            canvas.nativeCanvas.drawText(
+                label,
+                LABEL_PADDING_DP.dp.toPx(),
+                rowH / 2f + datePaint.textSize / 3f,
+                datePaint,
+            )
+        }
+
+        fun xForMin(min: Int): Float =
+            labelPx + (min.coerceIn(WINDOW_START_MIN, WINDOW_END_MIN).toFloat() / windowDuration) * drawableW
+
+        // Aire colorée sous la ligne — un rect par segment, du niveau jusqu'à L0
+        val l0y = yForLevel(0)
+        segments.forEach { seg ->
+            val x = xForMin(seg.startMin)
+            val xEnd = xForMin(seg.endMin)
+            val w = (xEnd - x).coerceAtLeast(1f)
+            val y = yForLevel(seg.level)
+            drawRect(
+                color = seg.color.copy(alpha = 0.55f),
+                topLeft = Offset(x, y),
+                size = Size(w, l0y - y),
+            )
+        }
+
+        // Polyline reliant les niveaux — démarre à L0, suit les segments, retombe à L0
+        if (segments.isNotEmpty()) {
+            val path = androidx.compose.ui.graphics.Path()
+            // Démarre à L0 au début du 1er segment
+            val first = segments.first()
+            path.moveTo(xForMin(first.startMin), l0y)
+            // Monte au niveau du 1er segment
+            path.lineTo(xForMin(first.startMin), yForLevel(first.level))
+            // Trace tous les segments
+            segments.forEachIndexed { idx, seg ->
+                val xStart = xForMin(seg.startMin)
+                val xEnd = xForMin(seg.endMin)
+                val y = yForLevel(seg.level)
+                path.lineTo(xEnd, y)
+                // Transition vers le segment suivant : on saute à son niveau au moment de son début
+                if (idx < segments.size - 1) {
+                    val next = segments[idx + 1]
+                    val xNextStart = xForMin(next.startMin)
+                    if (xNextStart > xEnd) {
+                        // Gap entre segments → retombe à L0
+                        path.lineTo(xEnd, l0y)
+                        path.lineTo(xNextStart, l0y)
+                        path.lineTo(xNextStart, yForLevel(next.level))
+                    } else {
+                        // Continue directement au niveau suivant
+                        path.lineTo(xEnd, yForLevel(next.level))
                     }
                 }
             }
+            // Fin : retombe à L0
+            val last = segments.last()
+            path.lineTo(xForMin(last.endMin), l0y)
+            drawPath(path, lineColor, style = androidx.compose.ui.graphics.drawscope.Stroke(width = 1.4.dp.toPx()))
         }
 
-        // X-axis hour ticks at bottom
-        val axisTopY = size.height - axisBot
-        val step = if (windowDuration >= 720) 2 else 1
-        var h = windowStart / 60
-        val endHour = (windowEnd + 59) / 60
-        while (h <= endHour) {
-            val hMin = h * 60
-            if (hMin in windowStart..windowEnd) {
-                val x = labelPx + ((hMin - windowStart).toFloat() / windowDuration) * drawableW
-                drawLine(
-                    color       = onSurface.copy(alpha = 0.2f),
-                    start       = Offset(x, axisTopY),
-                    end         = Offset(x, axisTopY + 4.dp.toPx()),
-                    strokeWidth = 1.dp.toPx()
-                )
-                drawIntoCanvas { canvas ->
-                    canvas.nativeCanvas.drawText(
-                        "%02d:00".format(h % 24),
-                        x,
-                        size.height - 2.dp.toPx(),
-                        tickPaint
-                    )
-                }
-            }
-            h += step
+        // Traits verticaux pour micro-awakes
+        ticks.forEach { tick ->
+            val x = xForMin(tick.minute)
+            drawLine(
+                color = tickColor,
+                start = Offset(x, plotTop),
+                end = Offset(x, l0y),
+                strokeWidth = 1.2.dp.toPx(),
+            )
         }
     }
 }
@@ -401,125 +614,195 @@ private fun TimelineCanvas(
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawFallbackBar(
     session: SleepSessionResponse,
-    windowStart: Int,
-    windowDuration: Int,
     labelPx: Float,
     drawableW: Float,
     barTop: Float,
     barH: Float,
-    nightLabel: String,
-    hitBoxes: MutableList<StageHitBox>
 ) {
     val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull() ?: return
-    val end   = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull() ?: return
-    var startMin = start.hour * 60 + start.minute
-    var endMin   = end.hour * 60 + end.minute
-    if (endMin < startMin) endMin += 1440
-
-    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
-    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
-    if (endOff <= startOff) return
-
-    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val barW = xEnd - x
-    if (barW <= 0f) return
-
-    drawRect(color = ColorDeep.copy(alpha = 0.6f), topLeft = Offset(x, barTop), size = Size(barW, barH))
-    hitBoxes.add(StageHitBox(x, barTop, xEnd, barTop + barH, "LIGHT",
-        session.sleep_start, session.sleep_end, nightLabel))
+    val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull() ?: return
+    val startMin = start.hour * 60 + start.minute
+    var endMin = end.hour * 60 + end.minute
+    if (endMin < startMin) endMin += 1440 // session traverse minuit
+    drawBar(startMin, endMin, ColorDeep.copy(alpha = 0.6f), labelPx, drawableW, barTop, barH, roundLeft = true, roundRight = true)
 }
 
 private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawStageSegment(
     stage: SleepStageResponse,
-    windowStart: Int,
-    windowDuration: Int,
     labelPx: Float,
     drawableW: Float,
     barTop: Float,
     barH: Float,
-    nightLabel: String,
-    hitBoxes: MutableList<StageHitBox>
+    roundLeft: Boolean,
+    roundRight: Boolean,
 ) {
     val ss = runCatching { OffsetDateTime.parse(stage.stage_start) }.getOrNull() ?: return
     val se = runCatching { OffsetDateTime.parse(stage.stage_end) }.getOrNull() ?: return
-    var startMin = ss.hour * 60 + ss.minute
-    var endMin   = se.hour * 60 + se.minute
+    val startMin = ss.hour * 60 + ss.minute
+    var endMin = se.hour * 60 + se.minute
     if (endMin < startMin) endMin += 1440
+    drawBar(startMin, endMin, stageColor(stage.stage), labelPx, drawableW, barTop, barH, roundLeft, roundRight)
+}
 
-    val startOff = (startMin - windowStart).coerceIn(0, windowDuration)
-    val endOff   = (endMin   - windowStart).coerceIn(0, windowDuration)
-    if (endOff <= startOff) return
-
-    val x    = (labelPx + (startOff.toFloat() / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val xEnd = (labelPx + (endOff.toFloat()   / windowDuration) * drawableW).coerceIn(labelPx, labelPx + drawableW)
-    val barW = xEnd - x
-    if (barW <= 0f) return
-
-    // AWAKE segments are shorter to distinguish them visually
-    val segH  = if (stage.stage == "AWAKE") barH * 0.5f else barH
-    val segTop = barTop + (barH - segH) / 2f
-
-    drawRect(
-        color   = stageColor(stage.stage),
-        topLeft = Offset(x, segTop),
-        size    = Size(barW, segH)
-    )
-    hitBoxes.add(StageHitBox(x, segTop, xEnd, segTop + segH,
-        stage.stage, stage.stage_start, stage.stage_end, nightLabel))
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawBar(
+    startMin: Int,
+    endMin: Int,
+    color: Color,
+    labelPx: Float,
+    drawableW: Float,
+    barTop: Float,
+    barH: Float,
+    roundLeft: Boolean = false,
+    roundRight: Boolean = false,
+) {
+    val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
+    val s = startMin.coerceIn(WINDOW_START_MIN, WINDOW_END_MIN)
+    val e = endMin.coerceIn(WINDOW_START_MIN, WINDOW_END_MIN)
+    if (e <= s) return
+    val x = labelPx + (s.toFloat() / windowDuration) * drawableW
+    val xEnd = labelPx + (e.toFloat() / windowDuration) * drawableW
+    val barW = (xEnd - x).coerceAtLeast(1.5f)
+    if (!roundLeft && !roundRight) {
+        drawRect(color = color, topLeft = Offset(x, barTop), size = Size(barW, barH))
+        return
+    }
+    val cornerR = 3.dp.toPx().coerceAtMost(barW / 2f).coerceAtMost(barH / 2f)
+    val rect = androidx.compose.ui.geometry.Rect(x, barTop, x + barW, barTop + barH)
+    val path = androidx.compose.ui.graphics.Path().apply {
+        if (roundLeft && roundRight) {
+            addRoundRect(androidx.compose.ui.geometry.RoundRect(rect, androidx.compose.ui.geometry.CornerRadius(cornerR)))
+        } else if (roundLeft) {
+            moveTo(rect.left + cornerR, rect.top)
+            lineTo(rect.right, rect.top)
+            lineTo(rect.right, rect.bottom)
+            lineTo(rect.left + cornerR, rect.bottom)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.left, rect.bottom - 2 * cornerR, rect.left + 2 * cornerR, rect.bottom), 90f, 90f, false)
+            lineTo(rect.left, rect.top + cornerR)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.left, rect.top, rect.left + 2 * cornerR, rect.top + 2 * cornerR), 180f, 90f, false)
+            close()
+        } else {
+            moveTo(rect.left, rect.top)
+            lineTo(rect.right - cornerR, rect.top)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.right - 2 * cornerR, rect.top, rect.right, rect.top + 2 * cornerR), 270f, 90f, false)
+            lineTo(rect.right, rect.bottom - cornerR)
+            arcTo(androidx.compose.ui.geometry.Rect(rect.right - 2 * cornerR, rect.bottom - 2 * cornerR, rect.right, rect.bottom), 0f, 90f, false)
+            lineTo(rect.left, rect.bottom)
+            close()
+        }
+    }
+    drawPath(path, color)
 }
 
 // ── Bottom sheet detail ──────────────────────────────────────────────────────
 
 @Composable
-private fun StageDetailSheet(stage: StageHitBox) {
-    val start = runCatching { OffsetDateTime.parse(stage.stageStart) }.getOrNull()
-    val end   = runCatching { OffsetDateTime.parse(stage.stageEnd) }.getOrNull()
-    val duration = if (start != null && end != null) Duration.between(start, end) else null
-    val timeFmt = DateTimeFormatter.ofPattern("HH:mm")
+private fun NightDetailSheet(
+    night: NightSelection,
+    onOpenHypnogram: (sessionId: String) -> Unit,
+) {
+    val timeFmt = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    val dateFmt = remember { DateTimeFormatter.ofPattern("EEEE d MMMM yyyy", Locale.FRENCH) }
+
+    val totalSleep = remember(night) {
+        night.sessions.sumOf { s ->
+            val start = runCatching { OffsetDateTime.parse(s.sleep_start) }.getOrNull()
+            val end = runCatching { OffsetDateTime.parse(s.sleep_end) }.getOrNull()
+            if (start != null && end != null) Duration.between(start, end).toMinutes() else 0L
+        }
+    }
+    val stageTotals = remember(night) {
+        val acc = mutableMapOf<String, Long>()
+        night.sessions.forEach { s ->
+            s.stages?.forEach { st ->
+                val start = runCatching { OffsetDateTime.parse(st.stage_start) }.getOrNull()
+                val end = runCatching { OffsetDateTime.parse(st.stage_end) }.getOrNull()
+                if (start != null && end != null) {
+                    acc[st.stage] = (acc[st.stage] ?: 0L) + Duration.between(start, end).toMinutes()
+                }
+            }
+        }
+        acc
+    }
 
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 24.dp, vertical = 16.dp)
             .padding(bottom = 32.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
         Text(
-            text = stage.nightLabel,
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+            text = night.date.format(dateFmt).replaceFirstChar { it.uppercase() },
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface,
         )
-        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            Box(
-                modifier = Modifier
-                    .size(12.dp)
-                    .clip(CircleShape)
-                    .background(stageColor(stage.stageType))
-            )
-            Text(
-                text = stageDisplayName(stage.stageType),
-                style = MaterialTheme.typography.titleMedium,
-                color = stageColor(stage.stageType)
-            )
+
+        Text(
+            text = "Sommeil total : ${formatDuration(totalSleep)}",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+
+        if (stageTotals.isNotEmpty()) {
+            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                listOf("DEEP", "LIGHT", "REM", "AWAKE").forEach { stageType ->
+                    val mins = stageTotals[stageType] ?: 0L
+                    if (mins > 0) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(10.dp)
+                                    .clip(CircleShape)
+                                    .background(stageColor(stageType)),
+                            )
+                            Text(
+                                text = stageDisplayName(stageType),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                                modifier = Modifier.weight(1f),
+                            )
+                            Text(
+                                text = formatDuration(mins),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+                            )
+                        }
+                    }
+                }
+            }
         }
-        if (duration != null) {
-            val h  = duration.toHours()
-            val mm = duration.toMinutes() % 60
-            Text(
-                text = if (h > 0) "${h}h ${mm.toString().padStart(2, '0')}min" else "${mm}min",
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-        }
-        if (start != null && end != null) {
-            Text(
-                text = "${start.format(timeFmt)} → ${end.format(timeFmt)}",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
-            )
+
+        Text(
+            text = "${night.sessions.size} session${if (night.sessions.size > 1) "s" else ""} de sommeil",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f),
+        )
+
+        // Lien vers l'hypnogramme — une session = un bouton.
+        night.sessions.forEachIndexed { idx, session ->
+            val start = runCatching { OffsetDateTime.parse(session.sleep_start) }.getOrNull()
+            val end = runCatching { OffsetDateTime.parse(session.sleep_end) }.getOrNull()
+            val rangeLabel = if (start != null && end != null) {
+                "${start.format(timeFmt)} → ${end.format(timeFmt)}"
+            } else "Session ${idx + 1}"
+            OutlinedButton(
+                onClick = { onOpenHypnogram(session.id) },
+                modifier = Modifier.fillMaxWidth().testTag("tl_open_hypnogram_$idx"),
+            ) {
+                Text("Hypnogramme · $rangeLabel")
+            }
         }
     }
+}
+
+private fun formatDuration(minutes: Long): String {
+    if (minutes <= 0) return "—"
+    val h = minutes / 60
+    val mm = minutes % 60
+    return if (h > 0) "${h}h ${mm.toString().padStart(2, '0')}min" else "${mm}min"
 }
 ```
 
@@ -528,14 +811,24 @@ private fun StageDetailSheet(stage: StageHitBox) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `stageColor` (function) — lines 50-56
-- `stageDisplayName` (function) — lines 58-64
-- `computeTimelineWindow` (function) — lines 68-76
-- `groupByNight` (function) — lines 80-87
-- `StageHitBox` (class) — lines 91-97
-- `TimelineScreen` (function) — lines 101-214
-- `TimelineAxisHeader` (function) — lines 218-252
-- `TimelineCanvas` (function) — lines 256-375
-- `drawFallbackBar` (function) — lines 379-408
-- `drawStageSegment` (function) — lines 410-447
-- `StageDetailSheet` (function) — lines 451-500
+- `TimelineViewMode` (class) — lines 54-54
+- `mountainLevel` (function) — lines 57-63
+- `stageColor` (function) — lines 72-78
+- `stageDisplayName` (function) — lines 80-86
+- `groupByNight` (function) — lines 90-97
+- `NightSelection` (class) — lines 101-104
+- `TimelineScreen` (function) — lines 108-272
+- `TimelineAxisHeader` (function) — lines 276-302
+- `LoadOlderSentinel` (function) — lines 306-332
+- `NightRow` (function) — lines 336-416
+- `MountainSegment` (class) — lines 420-425
+- `MicroAwakeMark` (class) — lines 427-427
+- `buildMountainData` (function) — lines 437-468
+- `NightRowMountain` (function) — lines 470-588
+- `yForLevel` (function) — lines 500-500
+- `xForMin` (function) — lines 525-526
+- `drawFallbackBar` (function) — lines 592-605
+- `drawStageSegment` (function) — lines 607-622
+- `drawBar` (function) — lines 624-671
+- `NightDetailSheet` (function) — lines 675-776
+- `formatDuration` (function) — lines 778-783

--- a/docs/vault/specs/2026-05-09-local-first-migration.md
+++ b/docs/vault/specs/2026-05-09-local-first-migration.md
@@ -1,0 +1,125 @@
+---
+title: "Migration local-first — données santé sur le téléphone"
+slug: 2026-05-09-local-first-migration
+status: draft
+created: 2026-05-09
+implements: []
+tested_by: []
+---
+
+# Spec — Migration local-first des données santé
+
+## Vision
+
+Aujourd'hui Nightfall stocke les données Art.9 chiffrées sur le VPS de l'utilisateur. C'est un **compromis acceptable** mais pas l'idéal du `C1 — Local-first absolu` de la VISION. Le VPS introduit :
+- Une dépendance réseau (timeout, latence, panne)
+- Un point de fuite potentiel (logs OS, snapshots VM, sauvegardes hébergeur)
+- Un coût opérationnel (maintenance, mises à jour, certifs)
+- Un anti-pattern produit : un import de 60k stages en 30s sur un VPS faible vs millisecondes en SQLite local
+
+**Cible** : toutes les données santé restent sur le téléphone. Le serveur FastAPI devient **optionnel** (mode "backup chiffré E2EE" pour multi-device).
+
+## Décisions techniques
+
+### Stockage local
+- **Room (SQLAlchemy → Kotlin)** : ORM officiel Jetpack, schémas miroirs des modèles `server/db/models.py`
+- **SQLCipher** : chiffrement transparent au repos avec clé Android Keystore (KeyAlias dédié, hardware-backed quand dispo)
+- Tables : `users` (1 ligne), `sleep_sessions`, `sleep_stages`, `heart_rate_hourly`, `steps_hourly`, `exercise_sessions`, + `audit_log` (RGPD C2)
+
+### Parsing CSV Samsung
+- Portage Kotlin du `server/services/csv_import.py` (parse_samsung_csv + parse_*_rows)
+- Mêmes règles : skip ligne metadata, `utf-8-sig` pour BOM, mapping stage codes 40001-40004, etc.
+- Bulk insert Room par batch de 1000 avec `OnConflictStrategy.IGNORE` (équivalent `ON CONFLICT DO NOTHING`)
+
+### Architecture Repository
+- `SleepRepository` interface inchangée — l'app ne sait pas si la donnée vient de Room ou de Retrofit
+- 2 implémentations : `LocalSleepRepository` (Room) et `RemoteSleepRepository` (existant)
+- `RepositoryFactory` choisit selon flag utilisateur (par défaut : local)
+
+### Migration des données existantes
+- Premier lancement post-migration : si VPS configuré et données présentes, l'app propose un export/import depuis le VPS vers le local
+- Téléchargement en streaming par fenêtre de 30 jours pour éviter timeout sur gros historiques
+- Vérification d'intégrité par count avant suppression côté serveur (optionnelle)
+
+### Mode backup E2EE (Phase D)
+- Hors scope de cette spec — esquissé pour ne pas peindre dans un coin
+- Idée : chiffrement côté client avec clé dérivée d'un passphrase, upload du blob chiffré sur le VPS
+- Le serveur ne voit jamais les clés ni le contenu déchiffré
+- Implique signature/MAC pour intégrité
+
+## Phases
+
+### Phase A — Stockage local (Foundation)
+**Livrables**
+- `android-app/app/src/main/java/.../data/local/database/NightfallDatabase.kt` (Room DB v1)
+- Entities : `SleepSessionEntity`, `SleepStageEntity`, `HeartRateHourlyEntity`, `StepsHourlyEntity`, `ExerciseSessionEntity`
+- DAOs : `SleepDao`, `HeartRateDao`, `StepsDao`, `ExerciseDao` (read + bulk write)
+- Init SQLCipher avec clé depuis Android Keystore (KeyAlias `nightfall_db_key`)
+- Tests Room (Robolectric in-memory) sur les DAOs
+
+**Scope**
+- Aucun changement UI, aucun import, aucun read business
+- Juste l'infra DB qui tourne en parallèle du code existant
+
+### Phase B — Imports en local
+**Livrables**
+- Port Kotlin de `parse_samsung_csv` + `parse_sleep_rows` + `parse_sleep_stage_rows` + `parse_heartrate_rows` + `parse_steps_rows` + `parse_exercise_rows`
+- `LocalImportService` qui prend le ZIP Samsung depuis SAF, extrait les CSV en mémoire, parse, écrit en Room
+- `ImportRepositoryImpl` modifié : flag `useLocalImport` (par défaut true), bypass complet du `NightfallApi.importXxx`
+- Tests unit : 1 test par parser, fixtures CSV inline (équivalent des tests `tests/server/test_import_csv_multipart.py`)
+
+**Scope**
+- L'écran Import écrit en local dès qu'on touche ce flag
+- Le VPS reste fonctionnel pour les écrans qui n'ont pas migré
+
+### Phase C — Lectures locales
+**Livrables**
+- `LocalSleepRepository` implémentant `SleepRepository` via `SleepDao`
+- DI bascule sur `LocalSleepRepository` quand `useLocalRead = true`
+- Migration progressive des écrans : Sleep → Hypnogramme → Timeline (ordre inverse de criticité)
+- Tests Compose Robolectric : Hypnogramme en < 200ms avec fixture de 60k stages
+
+**Scope**
+- Backend FastAPI continue à tourner (utilisé par d'autres écrans pas encore migrés ou en fallback)
+- À la fin de cette phase, aucun écran ne lit le VPS pour les données santé
+
+### Phase D — VPS optionnel / backup E2EE
+**Livrables (hors scope détaillé ici, à re-spec)**
+- Mode "VPS désactivé" qui retire complètement les appels réseau santé
+- Optionnel : feature backup E2EE (passphrase user, blob chiffré stocké sur VPS)
+- Documentation utilisateur : comment migrer depuis l'ancien mode VPS vers local
+
+## Livrables (vue d'ensemble par phase)
+
+- [ ] Phase A — Room + SQLCipher + DAOs + tests
+- [ ] Phase B — port Kotlin des parsers Samsung CSV + tests + flag d'import local
+- [ ] Phase C — `LocalSleepRepository` + bascule progressive des écrans + tests
+- [ ] Phase D — désactivation VPS / backup E2EE optionnel (re-spec dédiée)
+
+## Tests d'acceptation
+
+1. **Import local sleep_stage en < 5s pour 60k rows** — given un ZIP Samsung valide, when l'utilisateur déclenche l'import en mode local, then les stages sont en DB Room en moins de 5 secondes (vs 30s+ via VPS aujourd'hui).
+2. **Hypnogramme s'affiche en < 200ms** — given une nuit avec 100 stages en DB Room locale, when l'utilisateur clique sur la nuit dans la Timeline, then l'écran Hypnogramme est rendu en moins de 200ms (vs 30s aujourd'hui).
+3. **Aucun appel réseau santé en mode local** — given le mode local activé, when on inspecte les requêtes HTTP sortantes pendant un import + lecture de toutes les vues santé, then aucune requête vers `/api/sleep`, `/api/heartrate`, `/api/steps`, `/api/exercise` n'est émise.
+4. **Données chiffrées au repos** — given une DB Room initialisée, when on inspecte le fichier `nightfall.db` sur le filesystem Android, then son contenu n'est pas lisible en clair (SQLCipher actif).
+5. **Désinstallation = suppression** — given des données santé en DB locale, when l'utilisateur désinstalle l'app, then aucune trace ne subsiste sur le téléphone (cohérent avec C2 droit à l'oubli).
+
+## Suite naturelle
+
+Après cette migration, deux pistes :
+- **Phase 6 — Synchronisation multi-device** via le mode backup E2EE — partager données entre tablette et téléphone du même user, sans confier le clair au VPS.
+- **Phase 7 — Wear OS / Garmin** — étendre la collecte directement depuis montre Android, court-circuitant complètement Samsung Health Cloud.
+
+## Risques et mitigations
+
+- **Perte clé Keystore (factory reset, perte device)** → données illisibles. Mitigation : export régulier en clair (avec confirm utilisateur fort) ou backup E2EE.
+- **Schéma Room évolue** → migrations Room bien documentées + tests de upgrade. Pattern identique à Alembic.
+- **Bug parser Samsung silencieux côté Android** → tests unit avec fixtures réelles (un set anonymisé du ZIP utilisateur de référence).
+- **Effort de port important (~3-4 semaines)** → faisable en 4 PRs séparées (1 par phase). Phase A et B peuvent tourner en parallèle du backend, pas besoin de tout migrer en bloc.
+
+## Lien avec les contraintes
+
+- **C1 — Local-first absolu** : ✅ atteint complètement
+- **C2 — RGPD santé maximum** : ✅ chiffrement Art.9 via SQLCipher + Keystore (équivalent fonctionnel de l'AES-256-GCM serveur)
+- **C3 — Sécurité intégrée** : `pentester` doit être étendu pour auditer Room/SQLCipher au lieu de juste FastAPI
+- **No LLM on health data** : inchangé


### PR DESCRIPTION
## Vue d'ensemble

Refonte complète de la Timeline et de l'Hypnogramme suite à l'import réussi de 60 644 sleep_stages. Plus une spec de migration local-first pour préparer la sortie du VPS.

## Timeline — `static/...TimelineScreen.kt`

### Pagination lazy
- Remplacement de `verticalScroll` par `LazyColumn`
- Initial load = derniers 30 jours (avec backoff jusqu'à 2 ans si pas de données)
- Sentinel en haut → `loadOlder()` charge la page suivante (-30 jours) au scroll
- Plus de download de l'historique complet à chaque ouverture

### Visuels
- Fenêtre 24h fixe (au lieu de 16h auto-centrée — cassait le sens "drift circadien")
- Quadrillage vertical toutes les 3h en fond (00h, 03h, 06h, ..., 21h, 24h)
- AWAKE en hauteur uniforme (plus de demi-hauteur visuellement bancal)
- Bords arrondis sur 1er/dernier stage de chaque session (cornerR=3dp)
- Stages très courts forcés à largeur min 1.5px (visibles même <2 min)

### Interaction
- Tap sur ligne → bottom sheet "détails de la nuit" (date complète, sommeil total, breakdown par phase, 1 bouton hypnogramme par session)
- Plus de hitbox par stage (impossibles à toucher pour les stages <5min)

### Vue Mountain (toggle)
- Bouton "Mountain / Barres" dans la TopAppBar
- Graph 5 niveaux : L0=éveil session, L1=AWAKE intra >5min, L2=DEEP, L3=LIGHT, L4=REM
- Aire colorée sous la ligne par stage, polyline noire au-dessus
- Micro-réveils <5min = trait vertical orange (n'interrompent pas les blocs sleep)

## Hypnogramme — `static/...HypnogramScreen.kt`

### Performance — fix bug bloquant
- **Avant** : ouvrir un hypnogramme téléchargeait **toutes** les sessions + stages de l'historique (60k+) → 30s d'attente
- **Après** : la date est passée via la nav route, on fetch fenêtre [date-1, date+1] uniquement → ~1s

### Visuels
- Marges latérales 16dp (était collé aux bords)
- AWAKE en hauteur uniforme (cohérent avec Timeline)
- Bords arrondis 1er/dernier stage
- Police axe 13sp (was 10sp)
- Hauteur Canvas 140dp (was 120dp)

### Vue Mountain (toggle aussi)
- Mêmes 5 paliers que la Timeline mountain
- Adapté à la fenêtre temporelle de la nuit (vs 24h fixe pour Timeline)

### Axe X simplifié + scrub
- 4 ticks : coucher (0%) / +33% / +66% / réveil (100%) — labels alignés extrémités pour pas dépasser
- Long-press n'importe où → curseur vertical + tooltip flottant `HH:mm — Phase` qui suit le doigt
- Pattern Material Design 3 (cf. Stripe / Apple Health)

## Spec migration locale

`docs/vault/specs/2026-05-09-local-first-migration.md` — plan en 4 phases pour basculer toutes les données santé du VPS vers Room+SQLCipher sur le téléphone. Aligne le projet sur le `C1 — Local-first absolu` de la VISION.

## Fichiers clés
- `viewmodel/sleep/TimelineViewModel.kt` — pagination par fenêtre 30j
- `viewmodel/sleep/HypnogramViewModel.kt` — accepte `hintDate` pour fetch ciblé
- `data/sleep/SleepRepository.kt` — signature étendue avec `from`/`to`
- `ui/navigation/NavDestination.kt` — route Hypnogram avec `?date=YYYY-MM-DD` optionnel
- `ui/screens/sleep/TimelineScreen.kt` — LazyColumn + 2 vues (Bars/Mountain) + bottom sheet
- `ui/screens/sleep/HypnogramScreen.kt` — 2 vues + scrub tooltip + axe 4 ticks

## Test plan
- [ ] Timeline ouverte → derniers 30 jours s'affichent, scroll vers le haut charge plus
- [ ] Toggle "Mountain" sur Timeline → graph paliers + aires colorées
- [ ] Tap nuit → bottom sheet avec totaux et bouton "Hypnogramme · HH:mm → HH:mm"
- [ ] Tap bouton hypnogramme → ouvre la nuit en < 2s (vs 30s avant)
- [ ] Sur hypnogramme : long-press → tooltip suit le doigt, axe à 4 valeurs HH:mm
- [ ] Toggle Mountain sur hypnogramme → vue 5 paliers cohérente