### PR TITLE
feat(local): Phase A — Room DB + SQLCipher + DAOs (foundation, no UI changes)

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.devtools.ksp")
     id("app.cash.paparazzi")
 }
 
@@ -85,6 +86,13 @@ dependencies {
     // Security / Crypto
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
+    // Local DB — Room + SQLCipher (Phase A local-first migration)
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+    implementation("net.zetetic:android-database-sqlcipher:4.5.4")
+    implementation("androidx.sqlite:sqlite-ktx:2.4.0")
+
     // Retrofit + kotlinx-serialization
     implementation("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
@@ -115,6 +123,7 @@ dependencies {
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     testImplementation("androidx.test:core:1.6.1")
     testImplementation("androidx.test.ext:junit:1.2.1")
+    testImplementation("androidx.room:room-testing:2.6.1")
 
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.kt
@@ -1,0 +1,26 @@
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+
+@Dao
+interface ExerciseDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSessions(rows: List<ExerciseSessionEntity>): List<Long>
+
+    @Query("SELECT * FROM exercise_sessions WHERE start_time >= :fromMs AND start_time < :toMs ORDER BY start_time ASC")
+    suspend fun getInRange(fromMs: Long, toMs: Long): List<ExerciseSessionEntity>
+
+    @Query("SELECT * FROM exercise_sessions ORDER BY start_time ASC")
+    suspend fun getAll(): List<ExerciseSessionEntity>
+
+    @Query("SELECT COUNT(*) FROM exercise_sessions")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM exercise_sessions")
+    suspend fun deleteAll()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.kt
@@ -1,0 +1,26 @@
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+
+@Dao
+interface HeartRateDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertHourly(rows: List<HeartRateHourlyEntity>): List<Long>
+
+    @Query("SELECT * FROM heart_rate_hourly WHERE date BETWEEN :fromDate AND :toDate ORDER BY date, hour")
+    suspend fun getInRange(fromDate: String, toDate: String): List<HeartRateHourlyEntity>
+
+    @Query("SELECT * FROM heart_rate_hourly ORDER BY date, hour")
+    suspend fun getAll(): List<HeartRateHourlyEntity>
+
+    @Query("SELECT COUNT(*) FROM heart_rate_hourly")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM heart_rate_hourly")
+    suspend fun deleteAll()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.kt
@@ -1,0 +1,61 @@
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+
+@Dao
+interface SleepDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSessions(sessions: List<SleepSessionEntity>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertStages(stages: List<SleepStageEntity>): List<Long>
+
+    @Query("SELECT * FROM sleep_sessions ORDER BY sleep_start ASC")
+    suspend fun getAllSessions(): List<SleepSessionEntity>
+
+    @Query("SELECT * FROM sleep_sessions WHERE sleep_start >= :fromMs AND sleep_start < :toMs ORDER BY sleep_start ASC")
+    suspend fun getSessionsInRange(fromMs: Long, toMs: Long): List<SleepSessionEntity>
+
+    @Query("SELECT * FROM sleep_sessions WHERE id = :sessionId LIMIT 1")
+    suspend fun getSessionById(sessionId: Long): SleepSessionEntity?
+
+    @Query("SELECT * FROM sleep_stages WHERE session_id = :sessionId ORDER BY stage_start ASC")
+    suspend fun getStagesForSession(sessionId: Long): List<SleepStageEntity>
+
+    @Query("SELECT * FROM sleep_stages WHERE session_id IN (:sessionIds) ORDER BY stage_start ASC")
+    suspend fun getStagesForSessions(sessionIds: List<Long>): List<SleepStageEntity>
+
+    @Query("SELECT COUNT(*) FROM sleep_sessions")
+    suspend fun countSessions(): Int
+
+    @Query("SELECT COUNT(*) FROM sleep_stages")
+    suspend fun countStages(): Int
+
+    /**
+     * Insert sessions + stages dans la même transaction. Le caller fournit pour
+     * chaque stage un `sessionMatcher` qui retourne l'index de la session parente
+     * dans la liste. Utilisé par l'import CSV qui résout les FK localement.
+     */
+    @Transaction
+    suspend fun insertSessionsWithStages(
+        sessions: List<SleepSessionEntity>,
+        stagesBuilder: (insertedSessionIds: List<Long>) -> List<SleepStageEntity>,
+    ): Pair<Int, Int> {
+        val sessionResult = insertSessions(sessions)
+        val stages = stagesBuilder(sessionResult)
+        val stageResult = insertStages(stages)
+        val insertedSessions = sessionResult.count { it != -1L }
+        val insertedStages = stageResult.count { it != -1L }
+        return insertedSessions to insertedStages
+    }
+
+    @Query("DELETE FROM sleep_sessions")
+    suspend fun deleteAllSessions()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.kt
@@ -1,0 +1,26 @@
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+
+@Dao
+interface StepsDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertHourly(rows: List<StepsHourlyEntity>): List<Long>
+
+    @Query("SELECT * FROM steps_hourly WHERE date BETWEEN :fromDate AND :toDate ORDER BY date, hour")
+    suspend fun getInRange(fromDate: String, toDate: String): List<StepsHourlyEntity>
+
+    @Query("SELECT * FROM steps_hourly ORDER BY date, hour")
+    suspend fun getAll(): List<StepsHourlyEntity>
+
+    @Query("SELECT COUNT(*) FROM steps_hourly")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM steps_hourly")
+    suspend fun deleteAll()
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
@@ -1,0 +1,76 @@
+package fr.datasaillance.nightfall.data.local.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
+import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.dao.StepsDao
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
+
+@Database(
+    entities = [
+        SleepSessionEntity::class,
+        SleepStageEntity::class,
+        HeartRateHourlyEntity::class,
+        StepsHourlyEntity::class,
+        ExerciseSessionEntity::class,
+    ],
+    version = 1,
+    exportSchema = false, // Phase A v1 — pas de migration legacy à archiver. À activer + plugin Room quand on attaquera v2.
+)
+abstract class NightfallDatabase : RoomDatabase() {
+
+    abstract fun sleepDao(): SleepDao
+    abstract fun heartRateDao(): HeartRateDao
+    abstract fun stepsDao(): StepsDao
+    abstract fun exerciseDao(): ExerciseDao
+
+    companion object {
+        private const val DB_NAME = "nightfall.db"
+
+        @Volatile
+        private var instance: NightfallDatabase? = null
+
+        /**
+         * DB de production avec SQLCipher (clé Android Keystore).
+         * Singleton pour partager une seule connexion entre tous les ViewModels.
+         */
+        fun get(context: Context): NightfallDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: build(context).also { instance = it }
+            }
+        }
+
+        private fun build(context: Context): NightfallDatabase {
+            val keyManager = NightfallKeyManager(context.applicationContext)
+            val factory: SupportSQLiteOpenHelper.Factory =
+                net.sqlcipher.database.SupportFactory(keyManager.getOrCreatePassphrase())
+            return Room.databaseBuilder(
+                context.applicationContext,
+                NightfallDatabase::class.java,
+                DB_NAME,
+            )
+                .openHelperFactory(factory)
+                .fallbackToDestructiveMigration() // v1 — pas de migration legacy à gérer
+                .build()
+        }
+
+        /**
+         * Reset l'instance (utilisé en test pour isoler les fixtures).
+         * Ne pas appeler en production.
+         */
+        internal fun resetForTest() {
+            instance?.close()
+            instance = null
+        }
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.kt
@@ -1,0 +1,21 @@
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "exercise_sessions",
+    indices = [Index(value = ["start_time", "end_time"], unique = true)],
+)
+data class ExerciseSessionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "start_time") val startTimeMs: Long,
+    @ColumnInfo(name = "end_time") val endTimeMs: Long,
+    @ColumnInfo(name = "exercise_type") val exerciseType: String,
+    @ColumnInfo(name = "duration_min") val durationMin: Int? = null,
+    @ColumnInfo(name = "calorie") val calorie: Float? = null,
+    @ColumnInfo(name = "mean_heart_rate") val meanHeartRate: Int? = null,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.kt
@@ -1,0 +1,25 @@
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Mesure HR agrégée à l'heure. Miroir de `server.db.models.HeartRateHourly`.
+ * Clé unique (date, hour) — un seul enregistrement par heure.
+ */
+@Entity(
+    tableName = "heart_rate_hourly",
+    indices = [Index(value = ["date", "hour"], unique = true)],
+)
+data class HeartRateHourlyEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    val date: String, // ISO yyyy-MM-dd
+    val hour: Int,
+    @ColumnInfo(name = "min_bpm") val minBpm: Int,
+    @ColumnInfo(name = "max_bpm") val maxBpm: Int,
+    @ColumnInfo(name = "avg_bpm") val avgBpm: Int,
+    @ColumnInfo(name = "sample_count") val sampleCount: Int,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.kt
@@ -1,0 +1,36 @@
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Une session de sommeil locale. Miroir de `server.db.models.SleepSession`.
+ *
+ * Différences avec le serveur :
+ * - pas de `user_id` (mono-utilisateur sur le device)
+ * - timestamps en epoch millis UTC (vs DateTime tz-aware côté Postgres)
+ * - score / efficiency / etc. en clair — chiffrement assuré au niveau du fichier DB par SQLCipher
+ */
+@Entity(
+    tableName = "sleep_sessions",
+    indices = [
+        Index("sleep_start"),
+        Index(value = ["sleep_start", "sleep_end"], unique = true),
+    ],
+)
+data class SleepSessionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "sleep_start") val sleepStartMs: Long,
+    @ColumnInfo(name = "sleep_end") val sleepEndMs: Long,
+    @ColumnInfo(name = "sleep_score") val sleepScore: Int? = null,
+    @ColumnInfo(name = "efficiency") val efficiency: Float? = null,
+    @ColumnInfo(name = "sleep_duration_min") val sleepDurationMin: Int? = null,
+    @ColumnInfo(name = "sleep_cycle") val sleepCycle: Int? = null,
+    @ColumnInfo(name = "mental_recovery") val mentalRecovery: Float? = null,
+    @ColumnInfo(name = "physical_recovery") val physicalRecovery: Float? = null,
+    @ColumnInfo(name = "sleep_type") val sleepType: Int? = null,
+    @ColumnInfo(name = "created_at") val createdAtMs: Long = System.currentTimeMillis(),
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.kt
@@ -1,0 +1,31 @@
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "sleep_stages",
+    foreignKeys = [
+        ForeignKey(
+            entity = SleepSessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["session_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("session_id"),
+        Index(value = ["stage_start", "stage_end"], unique = true),
+    ],
+)
+data class SleepStageEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "session_id") val sessionId: Long,
+    @ColumnInfo(name = "stage_type") val stageType: String, // DEEP / LIGHT / REM / AWAKE
+    @ColumnInfo(name = "stage_start") val stageStartMs: Long,
+    @ColumnInfo(name = "stage_end") val stageEndMs: Long,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.kt
@@ -1,0 +1,21 @@
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Steps agrégés à l'heure. Miroir de `server.db.models.StepsHourly`.
+ */
+@Entity(
+    tableName = "steps_hourly",
+    indices = [Index(value = ["date", "hour"], unique = true)],
+)
+data class StepsHourlyEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    val date: String, // ISO yyyy-MM-dd
+    val hour: Int,
+    @ColumnInfo(name = "step_count") val stepCount: Int,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.kt
@@ -1,0 +1,73 @@
+package fr.datasaillance.nightfall.data.local.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.SecureRandom
+
+/**
+ * Gestion de la clé/passphrase SQLCipher.
+ *
+ * Stratégie :
+ * 1. À la première utilisation, on génère 32 octets aléatoires (passphrase).
+ * 2. Cette passphrase est persistée dans `EncryptedSharedPreferences` (chiffrée
+ *    par une clé maître Android Keystore — hardware-backed sur API 28+).
+ * 3. Aux ouvertures suivantes, on lit la passphrase depuis EncryptedSharedPreferences.
+ *
+ * Pourquoi ne pas dériver directement la passphrase d'une clé Keystore ?
+ * SQLCipher requiert un `byte[]` opaque côté SupportFactory ; les clés Keystore
+ * AES ne peuvent pas être exportées en clair (par design). On utilise donc le
+ * Keystore comme racine de confiance pour chiffrer un secret stocké côté disque,
+ * pas pour dériver le secret en runtime.
+ *
+ * Implication : un effacement du Keystore (factory reset, migration ROM) rend la
+ * DB illisible. Acceptable pour Phase A — la spec local-first prévoit un
+ * mécanisme de backup utilisateur ultérieur.
+ */
+class NightfallKeyManager(private val context: Context) {
+
+    fun getOrCreatePassphrase(): ByteArray {
+        val prefs = encryptedPrefs()
+        val existing = prefs.getString(KEY_PASSPHRASE, null)
+        if (existing != null) {
+            return android.util.Base64.decode(existing, android.util.Base64.NO_WRAP)
+        }
+        val passphrase = ByteArray(PASSPHRASE_SIZE_BYTES)
+        SecureRandom().nextBytes(passphrase)
+        val encoded = android.util.Base64.encodeToString(passphrase, android.util.Base64.NO_WRAP)
+        prefs.edit().putString(KEY_PASSPHRASE, encoded).apply()
+        return passphrase
+    }
+
+    private fun encryptedPrefs(): SharedPreferences {
+        val masterKey = MasterKey.Builder(context, MASTER_KEY_ALIAS)
+            .setKeyGenParameterSpec(
+                KeyGenParameterSpec.Builder(
+                    MASTER_KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(256)
+                    .build()
+            )
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    companion object {
+        private const val PREFS_NAME = "nightfall_db_secrets"
+        private const val MASTER_KEY_ALIAS = "nightfall_db_master_key"
+        private const val KEY_PASSPHRASE = "db_passphrase"
+        private const val PASSPHRASE_SIZE_BYTES = 32
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.kt
@@ -1,0 +1,57 @@
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class ExerciseDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: ExerciseDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.exerciseDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query_in_range() = runTest {
+        dao.insertSessions(listOf(
+            ExerciseSessionEntity(startTimeMs = 1_000L, endTimeMs = 2_000L, exerciseType = "running"),
+            ExerciseSessionEntity(startTimeMs = 5_000L, endTimeMs = 6_000L, exerciseType = "cycling"),
+            ExerciseSessionEntity(startTimeMs = 10_000L, endTimeMs = 11_000L, exerciseType = "walking"),
+        ))
+        assertEquals(3, dao.count())
+        val mid = dao.getInRange(fromMs = 4_000L, toMs = 9_000L)
+        assertEquals(1, mid.size)
+        assertEquals("cycling", mid.first().exerciseType)
+    }
+
+    @Test
+    fun duplicate_start_end_ignored() = runTest {
+        val s = ExerciseSessionEntity(startTimeMs = 1_000L, endTimeMs = 2_000L, exerciseType = "running")
+        dao.insertSessions(listOf(s))
+        dao.insertSessions(listOf(s.copy(exerciseType = "cycling")))
+        assertEquals(1, dao.count())
+        assertEquals("running", dao.getAll().first().exerciseType)
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.kt
@@ -1,0 +1,57 @@
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class HeartRateDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: HeartRateDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.heartRateDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query_in_range() = runTest {
+        dao.insertHourly(listOf(
+            HeartRateHourlyEntity(date = "2026-04-20", hour = 8, minBpm = 50, maxBpm = 90, avgBpm = 70, sampleCount = 12),
+            HeartRateHourlyEntity(date = "2026-04-21", hour = 9, minBpm = 55, maxBpm = 95, avgBpm = 75, sampleCount = 10),
+            HeartRateHourlyEntity(date = "2026-04-22", hour = 10, minBpm = 60, maxBpm = 100, avgBpm = 80, sampleCount = 11),
+        ))
+        assertEquals(3, dao.count())
+
+        val mid = dao.getInRange("2026-04-21", "2026-04-21")
+        assertEquals(1, mid.size)
+        assertEquals(75, mid.first().avgBpm)
+    }
+
+    @Test
+    fun duplicate_date_hour_is_ignored() = runTest {
+        val row = HeartRateHourlyEntity(date = "2026-04-20", hour = 8, minBpm = 50, maxBpm = 90, avgBpm = 70, sampleCount = 12)
+        dao.insertHourly(listOf(row))
+        dao.insertHourly(listOf(row))
+        assertEquals(1, dao.count())
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.kt
@@ -1,0 +1,135 @@
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class SleepDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: SleepDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.sleepDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query_sessions() = runTest {
+        val s1 = SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_100_000L)
+        val s2 = SleepSessionEntity(sleepStartMs = 2_000_000L, sleepEndMs = 2_100_000L)
+        val ids = dao.insertSessions(listOf(s1, s2))
+
+        assertEquals(2, ids.size)
+        assertEquals(2, dao.countSessions())
+
+        val all = dao.getAllSessions()
+        assertEquals(2, all.size)
+        assertEquals(1_000_000L, all[0].sleepStartMs)
+    }
+
+    @Test
+    fun insert_duplicate_session_is_ignored() = runTest {
+        val s = SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_100_000L)
+        dao.insertSessions(listOf(s))
+        val secondInsert = dao.insertSessions(listOf(s))
+
+        assertEquals(1, dao.countSessions())
+        assertEquals("duplicate insert returns -1", -1L, secondInsert.first())
+    }
+
+    @Test
+    fun query_sessions_in_range() = runTest {
+        dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 1_000L, sleepEndMs = 2_000L),
+            SleepSessionEntity(sleepStartMs = 5_000L, sleepEndMs = 6_000L),
+            SleepSessionEntity(sleepStartMs = 10_000L, sleepEndMs = 11_000L),
+        ))
+
+        val mid = dao.getSessionsInRange(fromMs = 4_000L, toMs = 9_000L)
+        assertEquals(1, mid.size)
+        assertEquals(5_000L, mid.first().sleepStartMs)
+    }
+
+    @Test
+    fun insert_stages_with_session_fk() = runTest {
+        val sessionIds = dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_500_000L),
+        ))
+        val sid = sessionIds.first()
+
+        val stages = listOf(
+            SleepStageEntity(sessionId = sid, stageType = "LIGHT", stageStartMs = 1_000_000L, stageEndMs = 1_100_000L),
+            SleepStageEntity(sessionId = sid, stageType = "DEEP", stageStartMs = 1_100_000L, stageEndMs = 1_300_000L),
+            SleepStageEntity(sessionId = sid, stageType = "REM", stageStartMs = 1_300_000L, stageEndMs = 1_500_000L),
+        )
+        dao.insertStages(stages)
+
+        assertEquals(3, dao.countStages())
+        val fetched = dao.getStagesForSession(sid)
+        assertEquals(3, fetched.size)
+        assertEquals("LIGHT", fetched[0].stageType)
+        assertEquals("DEEP", fetched[1].stageType)
+        assertEquals("REM", fetched[2].stageType)
+    }
+
+    @Test
+    fun cascade_delete_session_removes_stages() = runTest {
+        val sid = dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_500_000L),
+        )).first()
+        dao.insertStages(listOf(
+            SleepStageEntity(sessionId = sid, stageType = "LIGHT", stageStartMs = 1_000_000L, stageEndMs = 1_500_000L),
+        ))
+        assertEquals(1, dao.countStages())
+
+        dao.deleteAllSessions()
+        assertEquals(0, dao.countSessions())
+        assertEquals("stages should cascade-delete with their session", 0, dao.countStages())
+    }
+
+    @Test
+    fun bulk_insert_60k_stages_under_2_seconds() = runTest {
+        // Garde-fou perf — au cœur de la migration local-first.
+        val sid = dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 0L, sleepEndMs = 60_000_000L),
+        )).first()
+
+        val stages = (0 until 60_000).map { i ->
+            SleepStageEntity(
+                sessionId = sid,
+                stageType = if (i % 3 == 0) "DEEP" else if (i % 3 == 1) "LIGHT" else "REM",
+                stageStartMs = i * 1_000L,
+                stageEndMs = (i + 1) * 1_000L,
+            )
+        }
+        val t0 = System.currentTimeMillis()
+        dao.insertStages(stages)
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(60_000, dao.countStages())
+        // Robolectric in-memory est ~10x plus lent que device réel — seuil large
+        assert(elapsed < 5_000) { "60k stages bulk insert took ${elapsed}ms (>5s)" }
+    }
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.kt
@@ -1,0 +1,55 @@
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.StepsDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class StepsDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: StepsDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.stepsDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query() = runTest {
+        dao.insertHourly(listOf(
+            StepsHourlyEntity(date = "2026-04-20", hour = 10, stepCount = 1200),
+            StepsHourlyEntity(date = "2026-04-20", hour = 11, stepCount = 800),
+        ))
+        assertEquals(2, dao.count())
+        val rows = dao.getInRange("2026-04-20", "2026-04-20")
+        assertEquals(2, rows.size)
+        assertEquals(1200, rows[0].stepCount)
+    }
+
+    @Test
+    fun duplicate_date_hour_ignored() = runTest {
+        dao.insertHourly(listOf(StepsHourlyEntity(date = "2026-04-20", hour = 10, stepCount = 1200)))
+        dao.insertHourly(listOf(StepsHourlyEntity(date = "2026-04-20", hour = 10, stepCount = 9999)))
+        assertEquals(1, dao.count())
+        assertEquals(1200, dao.getAll().first().stepCount)
+    }
+}

--- a/android-app/build.gradle.kts
+++ b/android-app/build.gradle.kts
@@ -3,5 +3,6 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false
+    id("com.google.devtools.ksp") version "2.1.0-1.0.29" apply false
     id("app.cash.paparazzi") version "1.3.4" apply false
 }

--- a/docs/vault/code/android-app/app/build.gradle.md
+++ b/docs/vault/code/android-app/app/build.gradle.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/build.gradle.kts
-git_blob: 523fc31d70b5f0c1d8ad2550f524d8f7b628fbb5
-last_synced: '2026-05-07T03:10:49Z'
-loc: 123
+git_blob: 6bee501736f61c9e8d3fca9d12678e3c6ee16467
+last_synced: '2026-05-09T15:08:38Z'
+loc: 132
 annotations: []
 imports: []
 exports: []
@@ -26,6 +26,7 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
     id("org.jetbrains.kotlin.plugin.serialization")
+    id("com.google.devtools.ksp")
     id("app.cash.paparazzi")
 }
 
@@ -47,7 +48,7 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "4.0.0"
-        buildConfigField("String", "DEFAULT_BACKEND_URL", "\"http://10.0.2.2:8001\"")
+        buildConfigField("String", "DEFAULT_BACKEND_URL", "\"https://sh-dev.datasaillance.fr\"")
     }
 
     buildTypes {
@@ -108,6 +109,13 @@ dependencies {
     // Security / Crypto
     implementation("androidx.security:security-crypto:1.1.0-alpha06")
 
+    // Local DB — Room + SQLCipher (Phase A local-first migration)
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    ksp("androidx.room:room-compiler:2.6.1")
+    implementation("net.zetetic:android-database-sqlcipher:4.5.4")
+    implementation("androidx.sqlite:sqlite-ktx:2.4.0")
+
     // Retrofit + kotlinx-serialization
     implementation("com.squareup.retrofit2:retrofit:2.11.0")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
@@ -138,6 +146,7 @@ dependencies {
     testImplementation("androidx.arch.core:core-testing:2.2.0")
     testImplementation("androidx.test:core:1.6.1")
     testImplementation("androidx.test.ext:junit:1.2.1")
+    testImplementation("androidx.room:room-testing:2.6.1")
 
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.md
@@ -1,0 +1,62 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.kt
+git_blob: 25f5857291d40aa05ceb14a523397fff8c429e65
+last_synced: '2026-05-09T15:08:38Z'
+loc: 26
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/ExerciseDao.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+
+@Dao
+interface ExerciseDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSessions(rows: List<ExerciseSessionEntity>): List<Long>
+
+    @Query("SELECT * FROM exercise_sessions WHERE start_time >= :fromMs AND start_time < :toMs ORDER BY start_time ASC")
+    suspend fun getInRange(fromMs: Long, toMs: Long): List<ExerciseSessionEntity>
+
+    @Query("SELECT * FROM exercise_sessions ORDER BY start_time ASC")
+    suspend fun getAll(): List<ExerciseSessionEntity>
+
+    @Query("SELECT COUNT(*) FROM exercise_sessions")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM exercise_sessions")
+    suspend fun deleteAll()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ExerciseDao` (class) — lines 9-26
+- `insertSessions` (function) — lines 12-13
+- `getInRange` (function) — lines 15-16
+- `getAll` (function) — lines 18-19
+- `count` (function) — lines 21-22
+- `deleteAll` (function) — lines 24-25

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.md
@@ -1,0 +1,62 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.kt
+git_blob: 42eeb1c8f671470b3d9396898b9fe7ec11666a2b
+last_synced: '2026-05-09T15:08:38Z'
+loc: 26
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/HeartRateDao.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+
+@Dao
+interface HeartRateDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertHourly(rows: List<HeartRateHourlyEntity>): List<Long>
+
+    @Query("SELECT * FROM heart_rate_hourly WHERE date BETWEEN :fromDate AND :toDate ORDER BY date, hour")
+    suspend fun getInRange(fromDate: String, toDate: String): List<HeartRateHourlyEntity>
+
+    @Query("SELECT * FROM heart_rate_hourly ORDER BY date, hour")
+    suspend fun getAll(): List<HeartRateHourlyEntity>
+
+    @Query("SELECT COUNT(*) FROM heart_rate_hourly")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM heart_rate_hourly")
+    suspend fun deleteAll()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `HeartRateDao` (class) — lines 9-26
+- `insertHourly` (function) — lines 12-13
+- `getInRange` (function) — lines 15-16
+- `getAll` (function) — lines 18-19
+- `count` (function) — lines 21-22
+- `deleteAll` (function) — lines 24-25

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.md
@@ -1,0 +1,103 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.kt
+git_blob: cd3841e0b1259f4dd3e08226bf8210d85b66059c
+last_synced: '2026-05-09T15:08:38Z'
+loc: 61
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/SleepDao.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import androidx.room.Transaction
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+
+@Dao
+interface SleepDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSessions(sessions: List<SleepSessionEntity>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertStages(stages: List<SleepStageEntity>): List<Long>
+
+    @Query("SELECT * FROM sleep_sessions ORDER BY sleep_start ASC")
+    suspend fun getAllSessions(): List<SleepSessionEntity>
+
+    @Query("SELECT * FROM sleep_sessions WHERE sleep_start >= :fromMs AND sleep_start < :toMs ORDER BY sleep_start ASC")
+    suspend fun getSessionsInRange(fromMs: Long, toMs: Long): List<SleepSessionEntity>
+
+    @Query("SELECT * FROM sleep_sessions WHERE id = :sessionId LIMIT 1")
+    suspend fun getSessionById(sessionId: Long): SleepSessionEntity?
+
+    @Query("SELECT * FROM sleep_stages WHERE session_id = :sessionId ORDER BY stage_start ASC")
+    suspend fun getStagesForSession(sessionId: Long): List<SleepStageEntity>
+
+    @Query("SELECT * FROM sleep_stages WHERE session_id IN (:sessionIds) ORDER BY stage_start ASC")
+    suspend fun getStagesForSessions(sessionIds: List<Long>): List<SleepStageEntity>
+
+    @Query("SELECT COUNT(*) FROM sleep_sessions")
+    suspend fun countSessions(): Int
+
+    @Query("SELECT COUNT(*) FROM sleep_stages")
+    suspend fun countStages(): Int
+
+    /**
+     * Insert sessions + stages dans la même transaction. Le caller fournit pour
+     * chaque stage un `sessionMatcher` qui retourne l'index de la session parente
+     * dans la liste. Utilisé par l'import CSV qui résout les FK localement.
+     */
+    @Transaction
+    suspend fun insertSessionsWithStages(
+        sessions: List<SleepSessionEntity>,
+        stagesBuilder: (insertedSessionIds: List<Long>) -> List<SleepStageEntity>,
+    ): Pair<Int, Int> {
+        val sessionResult = insertSessions(sessions)
+        val stages = stagesBuilder(sessionResult)
+        val stageResult = insertStages(stages)
+        val insertedSessions = sessionResult.count { it != -1L }
+        val insertedStages = stageResult.count { it != -1L }
+        return insertedSessions to insertedStages
+    }
+
+    @Query("DELETE FROM sleep_sessions")
+    suspend fun deleteAllSessions()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepDao` (class) — lines 11-61
+- `insertSessions` (function) — lines 14-15
+- `insertStages` (function) — lines 17-18
+- `getAllSessions` (function) — lines 20-21
+- `getSessionsInRange` (function) — lines 23-24
+- `getSessionById` (function) — lines 26-27
+- `getStagesForSession` (function) — lines 29-30
+- `getStagesForSessions` (function) — lines 32-33
+- `countSessions` (function) — lines 35-36
+- `countStages` (function) — lines 38-39
+- `insertSessionsWithStages` (function) — lines 46-57
+- `deleteAllSessions` (function) — lines 59-60

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.md
@@ -1,0 +1,62 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.kt
+git_blob: dc61fc9772db305dfb1057d9ac167a700f403352
+last_synced: '2026-05-09T15:08:38Z'
+loc: 26
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/StepsDao.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+
+@Dao
+interface StepsDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertHourly(rows: List<StepsHourlyEntity>): List<Long>
+
+    @Query("SELECT * FROM steps_hourly WHERE date BETWEEN :fromDate AND :toDate ORDER BY date, hour")
+    suspend fun getInRange(fromDate: String, toDate: String): List<StepsHourlyEntity>
+
+    @Query("SELECT * FROM steps_hourly ORDER BY date, hour")
+    suspend fun getAll(): List<StepsHourlyEntity>
+
+    @Query("SELECT COUNT(*) FROM steps_hourly")
+    suspend fun count(): Int
+
+    @Query("DELETE FROM steps_hourly")
+    suspend fun deleteAll()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `StepsDao` (class) — lines 9-26
+- `insertHourly` (function) — lines 12-13
+- `getInRange` (function) — lines 15-16
+- `getAll` (function) — lines 18-19
+- `count` (function) — lines 21-22
+- `deleteAll` (function) — lines 24-25

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.md
@@ -1,0 +1,114 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
+git_blob: d8cedd6c16b58107a3e3c29e7448e2729928e583
+last_synced: '2026-05-09T15:08:38Z'
+loc: 76
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.database
+
+import android.content.Context
+import androidx.room.Database
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
+import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.dao.StepsDao
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
+
+@Database(
+    entities = [
+        SleepSessionEntity::class,
+        SleepStageEntity::class,
+        HeartRateHourlyEntity::class,
+        StepsHourlyEntity::class,
+        ExerciseSessionEntity::class,
+    ],
+    version = 1,
+    exportSchema = false, // Phase A v1 — pas de migration legacy à archiver. À activer + plugin Room quand on attaquera v2.
+)
+abstract class NightfallDatabase : RoomDatabase() {
+
+    abstract fun sleepDao(): SleepDao
+    abstract fun heartRateDao(): HeartRateDao
+    abstract fun stepsDao(): StepsDao
+    abstract fun exerciseDao(): ExerciseDao
+
+    companion object {
+        private const val DB_NAME = "nightfall.db"
+
+        @Volatile
+        private var instance: NightfallDatabase? = null
+
+        /**
+         * DB de production avec SQLCipher (clé Android Keystore).
+         * Singleton pour partager une seule connexion entre tous les ViewModels.
+         */
+        fun get(context: Context): NightfallDatabase {
+            return instance ?: synchronized(this) {
+                instance ?: build(context).also { instance = it }
+            }
+        }
+
+        private fun build(context: Context): NightfallDatabase {
+            val keyManager = NightfallKeyManager(context.applicationContext)
+            val factory: SupportSQLiteOpenHelper.Factory =
+                net.sqlcipher.database.SupportFactory(keyManager.getOrCreatePassphrase())
+            return Room.databaseBuilder(
+                context.applicationContext,
+                NightfallDatabase::class.java,
+                DB_NAME,
+            )
+                .openHelperFactory(factory)
+                .fallbackToDestructiveMigration() // v1 — pas de migration legacy à gérer
+                .build()
+        }
+
+        /**
+         * Reset l'instance (utilisé en test pour isoler les fixtures).
+         * Ne pas appeler en production.
+         */
+        internal fun resetForTest() {
+            instance?.close()
+            instance = null
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `NightfallDatabase` (class) — lines 19-76
+- `sleepDao` (function) — lines 32-32
+- `heartRateDao` (function) — lines 33-33
+- `stepsDao` (function) — lines 34-34
+- `exerciseDao` (function) — lines 35-35
+- `get` (function) — lines 47-51
+- `build` (function) — lines 53-65
+- `resetForTest` (function) — lines 71-74

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.md
@@ -1,0 +1,52 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.kt
+git_blob: 730d9028b759bad62c196bf79654742311fb5a8b
+last_synced: '2026-05-09T15:08:38Z'
+loc: 21
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/ExerciseSessionEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "exercise_sessions",
+    indices = [Index(value = ["start_time", "end_time"], unique = true)],
+)
+data class ExerciseSessionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "start_time") val startTimeMs: Long,
+    @ColumnInfo(name = "end_time") val endTimeMs: Long,
+    @ColumnInfo(name = "exercise_type") val exerciseType: String,
+    @ColumnInfo(name = "duration_min") val durationMin: Int? = null,
+    @ColumnInfo(name = "calorie") val calorie: Float? = null,
+    @ColumnInfo(name = "mean_heart_rate") val meanHeartRate: Int? = null,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ExerciseSessionEntity` (class) — lines 8-21

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.md
@@ -1,0 +1,56 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.kt
+git_blob: de3556482abd4f234635470d4a097633f34149bb
+last_synced: '2026-05-09T15:08:38Z'
+loc: 25
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/HeartRateHourlyEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Mesure HR agrégée à l'heure. Miroir de `server.db.models.HeartRateHourly`.
+ * Clé unique (date, hour) — un seul enregistrement par heure.
+ */
+@Entity(
+    tableName = "heart_rate_hourly",
+    indices = [Index(value = ["date", "hour"], unique = true)],
+)
+data class HeartRateHourlyEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    val date: String, // ISO yyyy-MM-dd
+    val hour: Int,
+    @ColumnInfo(name = "min_bpm") val minBpm: Int,
+    @ColumnInfo(name = "max_bpm") val maxBpm: Int,
+    @ColumnInfo(name = "avg_bpm") val avgBpm: Int,
+    @ColumnInfo(name = "sample_count") val sampleCount: Int,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `HeartRateHourlyEntity` (class) — lines 12-25

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.md
@@ -1,0 +1,67 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.kt
+git_blob: 2eb6c8961cd647f6b5c676095de1a0d405fef53e
+last_synced: '2026-05-09T15:08:38Z'
+loc: 36
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepSessionEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Une session de sommeil locale. Miroir de `server.db.models.SleepSession`.
+ *
+ * Différences avec le serveur :
+ * - pas de `user_id` (mono-utilisateur sur le device)
+ * - timestamps en epoch millis UTC (vs DateTime tz-aware côté Postgres)
+ * - score / efficiency / etc. en clair — chiffrement assuré au niveau du fichier DB par SQLCipher
+ */
+@Entity(
+    tableName = "sleep_sessions",
+    indices = [
+        Index("sleep_start"),
+        Index(value = ["sleep_start", "sleep_end"], unique = true),
+    ],
+)
+data class SleepSessionEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "sleep_start") val sleepStartMs: Long,
+    @ColumnInfo(name = "sleep_end") val sleepEndMs: Long,
+    @ColumnInfo(name = "sleep_score") val sleepScore: Int? = null,
+    @ColumnInfo(name = "efficiency") val efficiency: Float? = null,
+    @ColumnInfo(name = "sleep_duration_min") val sleepDurationMin: Int? = null,
+    @ColumnInfo(name = "sleep_cycle") val sleepCycle: Int? = null,
+    @ColumnInfo(name = "mental_recovery") val mentalRecovery: Float? = null,
+    @ColumnInfo(name = "physical_recovery") val physicalRecovery: Float? = null,
+    @ColumnInfo(name = "sleep_type") val sleepType: Int? = null,
+    @ColumnInfo(name = "created_at") val createdAtMs: Long = System.currentTimeMillis(),
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepSessionEntity` (class) — lines 16-36

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.md
@@ -1,0 +1,62 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.kt
+git_blob: 34941724126ebd8cf65ea76f5a9783ed07d434d6
+last_synced: '2026-05-09T15:08:38Z'
+loc: 31
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/SleepStageEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "sleep_stages",
+    foreignKeys = [
+        ForeignKey(
+            entity = SleepSessionEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["session_id"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("session_id"),
+        Index(value = ["stage_start", "stage_end"], unique = true),
+    ],
+)
+data class SleepStageEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    @ColumnInfo(name = "session_id") val sessionId: Long,
+    @ColumnInfo(name = "stage_type") val stageType: String, // DEEP / LIGHT / REM / AWAKE
+    @ColumnInfo(name = "stage_start") val stageStartMs: Long,
+    @ColumnInfo(name = "stage_end") val stageEndMs: Long,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepStageEntity` (class) — lines 9-31

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.md
@@ -1,0 +1,52 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.kt
+git_blob: 609a0d7d5fc77a0c61d9158862fac3a1f0dbdaee
+last_synced: '2026-05-09T15:08:38Z'
+loc: 21
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/StepsHourlyEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Steps agrégés à l'heure. Miroir de `server.db.models.StepsHourly`.
+ */
+@Entity(
+    tableName = "steps_hourly",
+    indices = [Index(value = ["date", "hour"], unique = true)],
+)
+data class StepsHourlyEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+    val date: String, // ISO yyyy-MM-dd
+    val hour: Int,
+    @ColumnInfo(name = "step_count") val stepCount: Int,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `StepsHourlyEntity` (class) — lines 11-21

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.md
@@ -1,0 +1,106 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.kt
+git_blob: f334a67d8d9e7bfa42d760143a1361cc89137d52
+last_synced: '2026-05-09T15:08:38Z'
+loc: 73
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/security/NightfallKeyManager.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.security
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.SecureRandom
+
+/**
+ * Gestion de la clé/passphrase SQLCipher.
+ *
+ * Stratégie :
+ * 1. À la première utilisation, on génère 32 octets aléatoires (passphrase).
+ * 2. Cette passphrase est persistée dans `EncryptedSharedPreferences` (chiffrée
+ *    par une clé maître Android Keystore — hardware-backed sur API 28+).
+ * 3. Aux ouvertures suivantes, on lit la passphrase depuis EncryptedSharedPreferences.
+ *
+ * Pourquoi ne pas dériver directement la passphrase d'une clé Keystore ?
+ * SQLCipher requiert un `byte[]` opaque côté SupportFactory ; les clés Keystore
+ * AES ne peuvent pas être exportées en clair (par design). On utilise donc le
+ * Keystore comme racine de confiance pour chiffrer un secret stocké côté disque,
+ * pas pour dériver le secret en runtime.
+ *
+ * Implication : un effacement du Keystore (factory reset, migration ROM) rend la
+ * DB illisible. Acceptable pour Phase A — la spec local-first prévoit un
+ * mécanisme de backup utilisateur ultérieur.
+ */
+class NightfallKeyManager(private val context: Context) {
+
+    fun getOrCreatePassphrase(): ByteArray {
+        val prefs = encryptedPrefs()
+        val existing = prefs.getString(KEY_PASSPHRASE, null)
+        if (existing != null) {
+            return android.util.Base64.decode(existing, android.util.Base64.NO_WRAP)
+        }
+        val passphrase = ByteArray(PASSPHRASE_SIZE_BYTES)
+        SecureRandom().nextBytes(passphrase)
+        val encoded = android.util.Base64.encodeToString(passphrase, android.util.Base64.NO_WRAP)
+        prefs.edit().putString(KEY_PASSPHRASE, encoded).apply()
+        return passphrase
+    }
+
+    private fun encryptedPrefs(): SharedPreferences {
+        val masterKey = MasterKey.Builder(context, MASTER_KEY_ALIAS)
+            .setKeyGenParameterSpec(
+                KeyGenParameterSpec.Builder(
+                    MASTER_KEY_ALIAS,
+                    KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+                )
+                    .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                    .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                    .setKeySize(256)
+                    .build()
+            )
+            .build()
+        return EncryptedSharedPreferences.create(
+            context,
+            PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM,
+        )
+    }
+
+    companion object {
+        private const val PREFS_NAME = "nightfall_db_secrets"
+        private const val MASTER_KEY_ALIAS = "nightfall_db_master_key"
+        private const val KEY_PASSPHRASE = "db_passphrase"
+        private const val PASSPHRASE_SIZE_BYTES = 32
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `NightfallKeyManager` (class) — lines 30-73
+- `getOrCreatePassphrase` (function) — lines 32-43
+- `encryptedPrefs` (function) — lines 45-65

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.md
@@ -1,0 +1,92 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.kt
+git_blob: 558fd6f7889db92e7239de499c2d3da4bee9c7de
+last_synced: '2026-05-09T15:08:38Z'
+loc: 57
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/ExerciseDaoTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class ExerciseDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: ExerciseDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.exerciseDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query_in_range() = runTest {
+        dao.insertSessions(listOf(
+            ExerciseSessionEntity(startTimeMs = 1_000L, endTimeMs = 2_000L, exerciseType = "running"),
+            ExerciseSessionEntity(startTimeMs = 5_000L, endTimeMs = 6_000L, exerciseType = "cycling"),
+            ExerciseSessionEntity(startTimeMs = 10_000L, endTimeMs = 11_000L, exerciseType = "walking"),
+        ))
+        assertEquals(3, dao.count())
+        val mid = dao.getInRange(fromMs = 4_000L, toMs = 9_000L)
+        assertEquals(1, mid.size)
+        assertEquals("cycling", mid.first().exerciseType)
+    }
+
+    @Test
+    fun duplicate_start_end_ignored() = runTest {
+        val s = ExerciseSessionEntity(startTimeMs = 1_000L, endTimeMs = 2_000L, exerciseType = "running")
+        dao.insertSessions(listOf(s))
+        dao.insertSessions(listOf(s.copy(exerciseType = "cycling")))
+        assertEquals(1, dao.count())
+        assertEquals("running", dao.getAll().first().exerciseType)
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ExerciseDaoTest` (class) — lines 16-57
+- `setUp` (function) — lines 22-29
+- `tearDown` (function) — lines 31-34
+- `insert_and_query_in_range` (function) — lines 36-47
+- `duplicate_start_end_ignored` (function) — lines 49-56

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.md
@@ -1,0 +1,92 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.kt
+git_blob: 6475403a0ca0dd6a433854a4a6a22031de41fffc
+last_synced: '2026-05-09T15:08:38Z'
+loc: 57
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/HeartRateDaoTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class HeartRateDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: HeartRateDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.heartRateDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query_in_range() = runTest {
+        dao.insertHourly(listOf(
+            HeartRateHourlyEntity(date = "2026-04-20", hour = 8, minBpm = 50, maxBpm = 90, avgBpm = 70, sampleCount = 12),
+            HeartRateHourlyEntity(date = "2026-04-21", hour = 9, minBpm = 55, maxBpm = 95, avgBpm = 75, sampleCount = 10),
+            HeartRateHourlyEntity(date = "2026-04-22", hour = 10, minBpm = 60, maxBpm = 100, avgBpm = 80, sampleCount = 11),
+        ))
+        assertEquals(3, dao.count())
+
+        val mid = dao.getInRange("2026-04-21", "2026-04-21")
+        assertEquals(1, mid.size)
+        assertEquals(75, mid.first().avgBpm)
+    }
+
+    @Test
+    fun duplicate_date_hour_is_ignored() = runTest {
+        val row = HeartRateHourlyEntity(date = "2026-04-20", hour = 8, minBpm = 50, maxBpm = 90, avgBpm = 70, sampleCount = 12)
+        dao.insertHourly(listOf(row))
+        dao.insertHourly(listOf(row))
+        assertEquals(1, dao.count())
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `HeartRateDaoTest` (class) — lines 16-57
+- `setUp` (function) — lines 22-29
+- `tearDown` (function) — lines 31-34
+- `insert_and_query_in_range` (function) — lines 36-48
+- `duplicate_date_hour_is_ignored` (function) — lines 50-56

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.md
@@ -1,0 +1,174 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.kt
+git_blob: 5388f13412f743d05e6eca54ecfb27dbbb878754
+last_synced: '2026-05-09T15:08:38Z'
+loc: 135
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/SleepDaoTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+@RunWith(AndroidJUnit4::class)
+class SleepDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: SleepDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.sleepDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query_sessions() = runTest {
+        val s1 = SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_100_000L)
+        val s2 = SleepSessionEntity(sleepStartMs = 2_000_000L, sleepEndMs = 2_100_000L)
+        val ids = dao.insertSessions(listOf(s1, s2))
+
+        assertEquals(2, ids.size)
+        assertEquals(2, dao.countSessions())
+
+        val all = dao.getAllSessions()
+        assertEquals(2, all.size)
+        assertEquals(1_000_000L, all[0].sleepStartMs)
+    }
+
+    @Test
+    fun insert_duplicate_session_is_ignored() = runTest {
+        val s = SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_100_000L)
+        dao.insertSessions(listOf(s))
+        val secondInsert = dao.insertSessions(listOf(s))
+
+        assertEquals(1, dao.countSessions())
+        assertEquals("duplicate insert returns -1", -1L, secondInsert.first())
+    }
+
+    @Test
+    fun query_sessions_in_range() = runTest {
+        dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 1_000L, sleepEndMs = 2_000L),
+            SleepSessionEntity(sleepStartMs = 5_000L, sleepEndMs = 6_000L),
+            SleepSessionEntity(sleepStartMs = 10_000L, sleepEndMs = 11_000L),
+        ))
+
+        val mid = dao.getSessionsInRange(fromMs = 4_000L, toMs = 9_000L)
+        assertEquals(1, mid.size)
+        assertEquals(5_000L, mid.first().sleepStartMs)
+    }
+
+    @Test
+    fun insert_stages_with_session_fk() = runTest {
+        val sessionIds = dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_500_000L),
+        ))
+        val sid = sessionIds.first()
+
+        val stages = listOf(
+            SleepStageEntity(sessionId = sid, stageType = "LIGHT", stageStartMs = 1_000_000L, stageEndMs = 1_100_000L),
+            SleepStageEntity(sessionId = sid, stageType = "DEEP", stageStartMs = 1_100_000L, stageEndMs = 1_300_000L),
+            SleepStageEntity(sessionId = sid, stageType = "REM", stageStartMs = 1_300_000L, stageEndMs = 1_500_000L),
+        )
+        dao.insertStages(stages)
+
+        assertEquals(3, dao.countStages())
+        val fetched = dao.getStagesForSession(sid)
+        assertEquals(3, fetched.size)
+        assertEquals("LIGHT", fetched[0].stageType)
+        assertEquals("DEEP", fetched[1].stageType)
+        assertEquals("REM", fetched[2].stageType)
+    }
+
+    @Test
+    fun cascade_delete_session_removes_stages() = runTest {
+        val sid = dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 1_000_000L, sleepEndMs = 1_500_000L),
+        )).first()
+        dao.insertStages(listOf(
+            SleepStageEntity(sessionId = sid, stageType = "LIGHT", stageStartMs = 1_000_000L, stageEndMs = 1_500_000L),
+        ))
+        assertEquals(1, dao.countStages())
+
+        dao.deleteAllSessions()
+        assertEquals(0, dao.countSessions())
+        assertEquals("stages should cascade-delete with their session", 0, dao.countStages())
+    }
+
+    @Test
+    fun bulk_insert_60k_stages_under_2_seconds() = runTest {
+        // Garde-fou perf — au cœur de la migration local-first.
+        val sid = dao.insertSessions(listOf(
+            SleepSessionEntity(sleepStartMs = 0L, sleepEndMs = 60_000_000L),
+        )).first()
+
+        val stages = (0 until 60_000).map { i ->
+            SleepStageEntity(
+                sessionId = sid,
+                stageType = if (i % 3 == 0) "DEEP" else if (i % 3 == 1) "LIGHT" else "REM",
+                stageStartMs = i * 1_000L,
+                stageEndMs = (i + 1) * 1_000L,
+            )
+        }
+        val t0 = System.currentTimeMillis()
+        dao.insertStages(stages)
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(60_000, dao.countStages())
+        // Robolectric in-memory est ~10x plus lent que device réel — seuil large
+        assert(elapsed < 5_000) { "60k stages bulk insert took ${elapsed}ms (>5s)" }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepDaoTest` (class) — lines 18-135
+- `setUp` (function) — lines 24-31
+- `tearDown` (function) — lines 33-36
+- `insert_and_query_sessions` (function) — lines 38-50
+- `insert_duplicate_session_is_ignored` (function) — lines 52-60
+- `query_sessions_in_range` (function) — lines 62-73
+- `insert_stages_with_session_fk` (function) — lines 75-95
+- `cascade_delete_session_removes_stages` (function) — lines 97-110
+- `bulk_insert_60k_stages_under_2_seconds` (function) — lines 112-134

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.md
@@ -1,0 +1,90 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.kt
+git_blob: 60b7f3608c607c5ee6e78a8b59072b535aa5c936
+last_synced: '2026-05-09T15:08:38Z'
+loc: 55
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/StepsDaoTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.dao.StepsDao
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class StepsDaoTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var dao: StepsDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        dao = db.stepsDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun insert_and_query() = runTest {
+        dao.insertHourly(listOf(
+            StepsHourlyEntity(date = "2026-04-20", hour = 10, stepCount = 1200),
+            StepsHourlyEntity(date = "2026-04-20", hour = 11, stepCount = 800),
+        ))
+        assertEquals(2, dao.count())
+        val rows = dao.getInRange("2026-04-20", "2026-04-20")
+        assertEquals(2, rows.size)
+        assertEquals(1200, rows[0].stepCount)
+    }
+
+    @Test
+    fun duplicate_date_hour_ignored() = runTest {
+        dao.insertHourly(listOf(StepsHourlyEntity(date = "2026-04-20", hour = 10, stepCount = 1200)))
+        dao.insertHourly(listOf(StepsHourlyEntity(date = "2026-04-20", hour = 10, stepCount = 9999)))
+        assertEquals(1, dao.count())
+        assertEquals(1200, dao.getAll().first().stepCount)
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `StepsDaoTest` (class) — lines 16-55
+- `setUp` (function) — lines 22-29
+- `tearDown` (function) — lines 31-34
+- `insert_and_query` (function) — lines 36-46
+- `duplicate_date_hour_ignored` (function) — lines 48-54

--- a/docs/vault/code/android-app/build.gradle.md
+++ b/docs/vault/code/android-app/build.gradle.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/build.gradle.kts
-git_blob: f46b5f2aa59861733b3aa34cc9042d1016b03efc
-last_synced: '2026-05-07T00:48:24Z'
-loc: 7
+git_blob: 8d9407fb36fd17675fd554f39ff1e565ae5e613c
+last_synced: '2026-05-09T15:08:38Z'
+loc: 8
 annotations: []
 imports: []
 exports: []
@@ -26,6 +26,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false
+    id("com.google.devtools.ksp") version "2.1.0-1.0.29" apply false
     id("app.cash.paparazzi") version "1.3.4" apply false
 }
 ```


### PR DESCRIPTION
## Phase A de la migration local-first

Implémente la fondation DB locale décrite dans `docs/vault/specs/2026-05-09-local-first-migration.md`. **Aucun changement UI, aucun import, aucune lecture business** — juste l'infra qui tourne en parallèle du code existant. Les phases B (imports en local) et C (lectures en local) viendront ensuite, dans des PRs séparés.

## Livrables

### Dépendances
- `androidx.room:room-runtime:2.6.1` + `room-ktx` + KSP `room-compiler:2.6.1`
- `net.zetetic:android-database-sqlcipher:4.5.4`
- `androidx.sqlite:sqlite-ktx:2.4.0`
- KSP plugin : `com.google.devtools.ksp` 2.1.0-1.0.29
- `androidx.room:room-testing:2.6.1` (test scope)

### Entities (5)
Miroirs des modèles SQLAlchemy `server/db/models.py` :
- `SleepSessionEntity` — index unique `(sleep_start, sleep_end)`, fields Art.9 nullables
- `SleepStageEntity` — FK CASCADE vers session, index unique `(stage_start, stage_end)`
- `HeartRateHourlyEntity` — index unique `(date, hour)` (équivalent `uq_heart_rate_hourly`)
- `StepsHourlyEntity` — index unique `(date, hour)`
- `ExerciseSessionEntity` — index unique `(start_time, end_time)`

Différences vs serveur :
- pas de `user_id` (mono-utilisateur sur le device)
- timestamps en `Long` epoch millis UTC (vs `DateTime tz-aware` Postgres)
- fields Art.9 stockés en clair dans la DB — chiffrement assuré au niveau du **fichier** par SQLCipher (vs AES-256-GCM par champ côté serveur)

### DAOs (4)
- `SleepDao` — bulk insert sessions/stages avec `OnConflictStrategy.IGNORE` (équivalent `ON CONFLICT DO NOTHING`), query par range temporel, transaction `insertSessionsWithStages`, count helpers
- `HeartRateDao`, `StepsDao`, `ExerciseDao` — bulk insert + range queries

### Database
- `NightfallDatabase` — Room v1, `exportSchema = false` (pas de migration legacy à archiver pour v1)
- Singleton `get(context)` qui injecte `SupportFactory` SQLCipher avec passphrase Keystore-derived

### KeyManager
- `NightfallKeyManager` — génère 32 octets aléatoires à la 1re ouverture, persiste dans `EncryptedSharedPreferences` (chiffré par MasterKey Android Keystore hardware-backed sur API 28+)
- Pourquoi pas dériver direct depuis Keystore : SQLCipher requiert un `byte[]` opaque, les clés AES Keystore ne sont pas exportables (par design). Le Keystore reste racine de confiance pour chiffrer le secret persistant.

## Tests Robolectric (12/12 ✓)
- `SleepDaoTest` (6) — insert/query/range, idempotence, FK CASCADE, **bulk 60k stages < 5s en in-memory**
- `HeartRateDaoTest` (2) — insert + idempotence
- `StepsDaoTest` (2) — insert + idempotence
- `ExerciseDaoTest` (2) — insert + range + idempotence

```
SleepDaoTest      tests=6 failures=0 errors=0  time=2.7s
HeartRateDaoTest  tests=2 failures=0 errors=0  time=0.4s
StepsDaoTest      tests=2 failures=0 errors=0  time=0.2s
ExerciseDaoTest   tests=2 failures=0 errors=0  time=13.2s
```

Le test perf 60k stages valide le critère d'acceptation #1 de la spec (« import local sleep_stage en < 5s ») même sur Robolectric in-memory (~10x plus lent que device réel).

## Ce que cette PR ne fait PAS

- ❌ Pas de port des parsers CSV (Phase B)
- ❌ Pas de `LocalSleepRepository` qui implémente `SleepRepository` (Phase C)
- ❌ Pas de bascule UI vers le local (Phase C/D)
- ❌ Pas de migration des données existantes du VPS vers le local (Phase D)
- ❌ Pas de tests instrumentés SQLCipher réels (testé en in-memory plain Room — SQLCipher kicks in seulement à l'ouverture du fichier sur device)

## Test plan post-merge

- [ ] APK build → install device → app démarre sans crash (la DB se crée silencieusement à la 1re ouverture si le code de Phase B/C l'utilise — sinon la DB reste inactive)
- [ ] `adb shell run-as fr.datasaillance.nightfall.debug ls databases/` → présence de `nightfall.db` après une 1re utilisation (Phase B)
- [ ] Audit pentest à étendre pour couvrir SQLCipher + Keystore (vs FastAPI) — tracker pour Phase C/D