### PR TITLE
feat(local): Phase B — port Kotlin parsers Samsung CSV + bypass VPS imports

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
@@ -2,14 +2,10 @@ package fr.datasaillance.nightfall.data.import_
 
 import android.content.ContentResolver
 import android.net.Uri
-import fr.datasaillance.nightfall.data.http.CountingRequestBody
-import fr.datasaillance.nightfall.data.http.ImportApiResponse
 import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.local.import_.LocalImportService
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.MultipartBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.zip.ZipInputStream
@@ -17,8 +13,14 @@ import java.util.zip.ZipInputStream
 private const val MAX_UNCOMPRESSED_BYTES = 200_000_000L
 private const val MAX_ZIP_ENTRIES = 100
 
+/**
+ * Phase B local-first : les imports écrivent directement en Room locale via
+ * `LocalImportService`. Plus aucun upload réseau santé. L'API n'est conservée
+ * que pour le ping de connectivité (vérification VPS up).
+ */
 class ImportRepositoryImpl(
     private val api: NightfallApi,
+    private val localImportService: LocalImportService,
 ) : ImportRepository {
 
     override suspend fun pingBackend(): Boolean {
@@ -103,23 +105,17 @@ class ImportRepositoryImpl(
                 contentResolver.openInputStream(uri)?.readBytes()
                     ?: throw IOException("Cannot read file for $type")
             }
-
-        val mediaType = "text/csv".toMediaType()
-        val requestBody = bytes.toRequestBody(mediaType)
-        val countingBody = CountingRequestBody(
-            delegate = requestBody,
-            totalBytes = totalBytes,
-            onProgress = onProgress,
-        )
-        val part = MultipartBody.Part.createFormData("file", "${type.samsungFilenamePrefix}.csv", countingBody)
-
-        val response: ImportApiResponse = when (type) {
-            ImportDataType.SLEEP -> api.importSleep(part)
-            ImportDataType.HEART_RATE -> api.importHeartRate(part)
-            ImportDataType.STEPS -> api.importSteps(part)
-            ImportDataType.EXERCISE -> api.importExercise(part)
-            ImportDataType.SLEEP_STAGE -> api.importSleepStages(part)
+        // Pas de progression réseau ici (parsing local quasi-instantané) — on émet 0
+        // au début et 1 à la fin pour garder le contrat de l'UI.
+        onProgress(0f)
+        val r = when (type) {
+            ImportDataType.SLEEP -> localImportService.importSleep(bytes)
+            ImportDataType.SLEEP_STAGE -> localImportService.importSleepStages(bytes)
+            ImportDataType.HEART_RATE -> localImportService.importHeartRate(bytes)
+            ImportDataType.STEPS -> localImportService.importSteps(bytes)
+            ImportDataType.EXERCISE -> localImportService.importExercise(bytes)
         }
-        return ImportResult(type = type, inserted = response.inserted, skipped = response.skipped)
+        onProgress(1f)
+        return ImportResult(type = type, inserted = r.inserted, skipped = r.skipped)
     }
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.kt
@@ -1,0 +1,234 @@
+package fr.datasaillance.nightfall.data.local.import_
+
+import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
+import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.dao.StepsDao
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Résultat d'un import CSV pour un type donné.
+ * Équivalent du `(inserted, skipped)` retourné par `parse_*_rows` côté serveur.
+ */
+data class LocalImportResult(val inserted: Int, val skipped: Int)
+
+/**
+ * Importe les CSV Samsung Health directement en base Room locale, sans VPS.
+ *
+ * Port Kotlin de `server/services/csv_import.py::parse_sleep_rows / parse_sleep_stage_rows /
+ * parse_heartrate_rows / parse_steps_rows / parse_exercise_rows`.
+ *
+ * Les imports sont idempotents par construction : Room utilise `OnConflictStrategy.IGNORE`
+ * sur les index uniques `(start, end)` ou `(date, hour)`, équivalent fonctionnel du
+ * `ON CONFLICT DO NOTHING` Postgres.
+ */
+class LocalImportService(
+    private val sleepDao: SleepDao,
+    private val heartRateDao: HeartRateDao,
+    private val stepsDao: StepsDao,
+    private val exerciseDao: ExerciseDao,
+) {
+
+    /** Import sleep CSV (`com.samsung.shealth.sleep.*.csv`). */
+    suspend fun importSleep(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val entities = mutableListOf<SleepSessionEntity>()
+        var skipped = 0
+        for (row in rows) {
+            val start = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.sleep.start_time"])
+            val end = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.sleep.end_time"])
+            if (start == null || end == null) {
+                skipped++
+                continue
+            }
+            entities.add(
+                SleepSessionEntity(
+                    sleepStartMs = start,
+                    sleepEndMs = end,
+                    sleepScore = row["sleep_score"]?.toIntOrNullSafe(),
+                    efficiency = row["efficiency"]?.toFloatOrNullSafe(),
+                    sleepDurationMin = row["sleep_duration"]?.toIntOrNullSafe(),
+                    sleepCycle = row["sleep_cycle"]?.toIntOrNullSafe(),
+                    mentalRecovery = row["mental_recovery"]?.toFloatOrNullSafe(),
+                    physicalRecovery = row["physical_recovery"]?.toFloatOrNullSafe(),
+                    sleepType = row["sleep_type"]?.toIntOrNullSafe(),
+                ),
+            )
+        }
+        val ids = sleepDao.insertSessions(entities)
+        val inserted = ids.count { it != -1L }
+        skipped += entities.size - inserted // duplicates ignorés
+        return LocalImportResult(inserted, skipped)
+    }
+
+    /**
+     * Import sleep_stage CSV. Exige que les sessions parentes soient déjà en base
+     * (via `importSleep` précédemment) — chaque stage cherche la session qui le contient
+     * par lookup binary-search sur les `sleep_start` triés.
+     */
+    suspend fun importSleepStages(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val sessions = sleepDao.getAllSessions()
+        if (sessions.isEmpty()) {
+            // Pas de session parente en DB → tous les stages sont orphelins
+            return LocalImportResult(inserted = 0, skipped = rows.size)
+        }
+        val starts = sessions.map { it.sleepStartMs }
+
+        val toInsert = mutableListOf<SleepStageEntity>()
+        var skipped = 0
+        for (row in rows) {
+            val startMs = SamsungCsvParser.parseTimestampToMs(row["start_time"])
+            val endMs = SamsungCsvParser.parseTimestampToMs(row["end_time"])
+            val stageCode = row["stage"]?.toIntOrNullSafe()
+            if (startMs == null || endMs == null || stageCode == null) {
+                skipped++; continue
+            }
+            val stageType = SLEEP_STAGE_MAP[stageCode]
+            if (stageType == null) {
+                skipped++; continue
+            }
+            val sessionIdx = bisectRight(starts, startMs) - 1
+            if (sessionIdx < 0) {
+                skipped++; continue
+            }
+            val parent = sessions[sessionIdx]
+            if (parent.sleepEndMs < endMs) {
+                skipped++; continue
+            }
+            toInsert.add(
+                SleepStageEntity(
+                    sessionId = parent.id,
+                    stageType = stageType,
+                    stageStartMs = startMs,
+                    stageEndMs = endMs,
+                ),
+            )
+        }
+        val ids = sleepDao.insertStages(toInsert)
+        val inserted = ids.count { it != -1L }
+        skipped += toInsert.size - inserted
+        return LocalImportResult(inserted, skipped)
+    }
+
+    /** Import heart_rate CSV avec agrégation horaire (min / max / avg / count par (date, hour) UTC). */
+    suspend fun importHeartRate(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        // Slot par (date, hour) → liste de (bpm, min, max)
+        val slots = HashMap<Pair<String, Int>, MutableList<Triple<Int, Int, Int>>>()
+        for (row in rows) {
+            val tsMs = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.heart_rate.start_time"]) ?: continue
+            val bpm = row["com.samsung.health.heart_rate.heart_rate"]?.toFloatOrNullSafe()?.let { Math.round(it) } ?: continue
+            val mn = row["com.samsung.health.heart_rate.min"]?.toFloatOrNullSafe()?.let { Math.round(it) } ?: continue
+            val mx = row["com.samsung.health.heart_rate.max"]?.toFloatOrNullSafe()?.let { Math.round(it) } ?: continue
+            val (date, hour) = msToDateHour(tsMs)
+            slots.getOrPut(date to hour) { mutableListOf() }.add(Triple(bpm, mn, mx))
+        }
+        val entities = slots.map { (key, samples) ->
+            val (date, hour) = key
+            HeartRateHourlyEntity(
+                date = date,
+                hour = hour,
+                avgBpm = (samples.sumOf { it.first } / samples.size.toDouble()).let { Math.round(it).toInt() },
+                minBpm = samples.minOf { it.second },
+                maxBpm = samples.maxOf { it.third },
+                sampleCount = samples.size,
+            )
+        }
+        val ids = heartRateDao.insertHourly(entities)
+        val inserted = ids.count { it != -1L }
+        return LocalImportResult(inserted, entities.size - inserted)
+    }
+
+    /**
+     * Import steps CSV. Format actuel utilise `day_time` (millis) + `count`.
+     * Fallback supporté : colonnes `com.samsung.health.step_daily_trend.start_time / .count`.
+     */
+    suspend fun importSteps(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val slots = HashMap<Pair<String, Int>, Int>()
+        for (row in rows) {
+            val dayTime = row["day_time"]?.toLongOrNullSafe()
+            val tsMs: Long?
+            val count: Int?
+            if (dayTime != null) {
+                tsMs = dayTime
+                count = row["count"]?.toIntOrNullSafe()
+            } else {
+                tsMs = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.step_daily_trend.start_time"])
+                count = row["com.samsung.health.step_daily_trend.count"]?.toIntOrNullSafe()
+            }
+            if (tsMs == null || count == null) continue
+            val (date, hour) = msToDateHour(tsMs)
+            slots[date to hour] = (slots[date to hour] ?: 0) + count
+        }
+        val entities = slots.map { (key, c) -> StepsHourlyEntity(date = key.first, hour = key.second, stepCount = c) }
+        val ids = stepsDao.insertHourly(entities)
+        val inserted = ids.count { it != -1L }
+        return LocalImportResult(inserted, entities.size - inserted)
+    }
+
+    /** Import exercise CSV. */
+    suspend fun importExercise(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val entities = mutableListOf<ExerciseSessionEntity>()
+        var skipped = 0
+        for (row in rows) {
+            val start = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.exercise.start_time"])
+            val end = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.exercise.end_time"])
+            val typeCode = row["com.samsung.health.exercise.exercise_type"]?.toIntOrNullSafe()
+            val durationMs = row["com.samsung.health.exercise.duration"]?.toFloatOrNullSafe()
+            if (start == null || end == null || typeCode == null) {
+                skipped++; continue
+            }
+            val type = EXERCISE_TYPE_MAP[typeCode] ?: "samsung_$typeCode"
+            entities.add(
+                ExerciseSessionEntity(
+                    startTimeMs = start,
+                    endTimeMs = end,
+                    exerciseType = type,
+                    durationMin = durationMs?.let { (it / 60_000f).toInt() },
+                    calorie = row["com.samsung.health.exercise.calorie"]?.toFloatOrNullSafe(),
+                    meanHeartRate = row["com.samsung.health.exercise.mean_heart_rate"]?.toFloatOrNullSafe()?.let { Math.round(it) },
+                ),
+            )
+        }
+        val ids = exerciseDao.insertSessions(entities)
+        val inserted = ids.count { it != -1L }
+        skipped += entities.size - inserted
+        return LocalImportResult(inserted, skipped)
+    }
+
+    private fun msToDateHour(ms: Long): Pair<String, Int> {
+        val zdt = Instant.ofEpochMilli(ms).atZone(ZoneOffset.UTC)
+        return zdt.toLocalDate().format(DATE_FMT) to zdt.hour
+    }
+
+    companion object {
+        private val DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+        // bisect_right équivalent Python — retourne l'index où insérer `target` pour
+        // garder `list` triée, en plaçant à DROITE des entrées égales.
+        internal fun bisectRight(list: List<Long>, target: Long): Int {
+            var lo = 0
+            var hi = list.size
+            while (lo < hi) {
+                val mid = (lo + hi) ushr 1
+                if (target < list[mid]) hi = mid else lo = mid + 1
+            }
+            return lo
+        }
+    }
+}
+
+// Helpers de parsing tolérants — String?.toIntOrNull() est plus strict (refuse "12.0", " 12 ", etc.)
+private fun String.toIntOrNullSafe(): Int? = trim().takeIf { it.isNotEmpty() }?.toDoubleOrNull()?.toInt()
+private fun String.toFloatOrNullSafe(): Float? = trim().takeIf { it.isNotEmpty() }?.toFloatOrNull()
+private fun String.toLongOrNullSafe(): Long? = trim().takeIf { it.isNotEmpty() }?.toLongOrNull()

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.kt
@@ -1,0 +1,109 @@
+package fr.datasaillance.nightfall.data.local.import_
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Parser des CSV Samsung Health. Port Kotlin de `server/services/csv_import.py::parse_samsung_csv`.
+ *
+ * Particularités du format Samsung :
+ * - BOM UTF-8 (U+FEFF) en début de fichier — la décode UTF-8 standard ne le mange pas, on doit le strip.
+ * - Lignes commençant par `#` = commentaires/metadata → ignorées.
+ * - Première ligne après les commentaires = ligne metadata `namespace,user_id,version` (le user_id est un entier).
+ * - 2e ligne (ou 1re si pas de metadata) = header CSV.
+ *
+ * Détecte la ligne metadata par la présence d'un entier en 2e champ.
+ */
+object SamsungCsvParser {
+
+    private const val UTF8_BOM = '﻿'
+
+    /**
+     * Parse le contenu binaire d'un CSV Samsung. Retourne une liste de `Map<String, String>`
+     * (équivalent du `list[dict]` Python) — clés = noms de colonnes du header.
+     *
+     * @throws IllegalArgumentException si le contenu est mal formé (ex: lignes incohérentes)
+     */
+    fun parse(rawBytes: ByteArray): List<Map<String, String>> {
+        val text = rawBytes.toString(Charsets.UTF_8).removePrefix(UTF8_BOM.toString())
+        val lines = text.lineSequence()
+            .filter { !it.startsWith("#") }
+            .toList()
+        if (lines.isEmpty()) return emptyList()
+
+        // Détecte la ligne metadata Samsung (`com.samsung.<x>,<userid_int>,<version>`)
+        val firstParts = lines[0].split(",", limit = 3)
+        val withoutMetadata = if (firstParts.size >= 2 && firstParts[1].trim().toIntOrNull() != null) {
+            lines.drop(1)
+        } else {
+            lines
+        }
+        if (withoutMetadata.isEmpty()) return emptyList()
+
+        val header = parseCsvRow(withoutMetadata[0])
+        val rows = mutableListOf<Map<String, String>>()
+        for (i in 1 until withoutMetadata.size) {
+            val raw = withoutMetadata[i]
+            if (raw.isBlank()) continue
+            val cells = parseCsvRow(raw)
+            // Tolérant aux lignes avec extra cellule(s) finale(s) — on ignore les surplus.
+            val map = LinkedHashMap<String, String>(header.size)
+            for ((idx, name) in header.withIndex()) {
+                map[name] = if (idx < cells.size) cells[idx] else ""
+            }
+            rows.add(map)
+        }
+        return rows
+    }
+
+    /**
+     * Parse une ligne CSV avec gestion des champs entre guillemets (RFC 4180 minimal).
+     * Suffisant pour Samsung Health qui n'utilise pas de quoting complexe.
+     */
+    private fun parseCsvRow(line: String): List<String> {
+        val out = mutableListOf<String>()
+        val sb = StringBuilder()
+        var inQuotes = false
+        var i = 0
+        while (i < line.length) {
+            val c = line[i]
+            when {
+                c == '"' && inQuotes && i + 1 < line.length && line[i + 1] == '"' -> {
+                    sb.append('"'); i += 2; continue
+                }
+                c == '"' -> { inQuotes = !inQuotes; i++; continue }
+                c == ',' && !inQuotes -> { out.add(sb.toString()); sb.clear(); i++; continue }
+                else -> { sb.append(c); i++ }
+            }
+        }
+        out.add(sb.toString())
+        return out
+    }
+
+    /**
+     * Parse un timestamp Samsung Health en epoch millis UTC.
+     * Format : `yyyy-MM-dd HH:mm:ss[.SSS]`. Retourne null si invalide.
+     *
+     * Note : Samsung exporte en heure locale "naïve" sans tz, mais sépare le `time_offset`
+     * dans une colonne dédiée. On considère ici la valeur comme UTC pour cohérence avec
+     * l'implémentation serveur (cf. `_parse_ts` en Python).
+     */
+    fun parseTimestampToMs(value: String?): Long? {
+        if (value.isNullOrBlank()) return null
+        val v = value.trim()
+        return try {
+            val dt = if ("." in v) {
+                LocalDateTime.parse(v, FMT_WITH_MS)
+            } else {
+                LocalDateTime.parse(v, FMT_NO_MS)
+            }
+            dt.toInstant(ZoneOffset.UTC).toEpochMilli()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private val FMT_WITH_MS = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+    private val FMT_NO_MS = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.kt
@@ -1,0 +1,19 @@
+package fr.datasaillance.nightfall.data.local.import_
+
+/** Codes Samsung sleep_stage → libellé canonique (mêmes valeurs que server/services/csv_import.py). */
+internal val SLEEP_STAGE_MAP: Map<Int, String> = mapOf(
+    40001 to "AWAKE",
+    40002 to "LIGHT",
+    40003 to "DEEP",
+    40004 to "REM",
+)
+
+/** Codes Samsung exercise_type → libellé. Codes inconnus stockés comme `samsung_<code>`. */
+internal val EXERCISE_TYPE_MAP: Map<Int, String> = mapOf(
+    1001 to "running",
+    1002 to "cycling",
+    1007 to "walking",
+    1008 to "hiking",
+    3000 to "swimming",
+    90001 to "indoor_cycling",
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
@@ -1,0 +1,71 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import timber.log.Timber
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Implémentation locale de `SleepRepository` qui lit les données depuis la base
+ * Room SQLCipher au lieu d'appeler le VPS. Phase C de la migration local-first.
+ *
+ * Garde la même signature et les mêmes shapes (`SleepSessionResponse` /
+ * `SleepStageResponse`) que `SleepRepositoryImpl`, donc ViewModels et UI sont
+ * inchangés. Le parent du chargement saisit `from`/`to` comme avant.
+ */
+class LocalSleepRepository(
+    private val sleepDao: SleepDao,
+) : SleepRepository {
+
+    override suspend fun getSessions(
+        from: LocalDate?,
+        to: LocalDate?,
+    ): Result<List<SleepSessionResponse>> = runCatching {
+        val sessions = if (from != null && to != null) {
+            // [from 00:00 UTC, to+1 00:00 UTC) — `to` est inclusif côté API serveur,
+            // on applique le même offset que server/routers/sleep.py:175 (`to + 1d`).
+            val fromMs = from.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            val toMs = to.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            sleepDao.getSessionsInRange(fromMs, toMs)
+        } else {
+            sleepDao.getAllSessions()
+        }
+        Timber.i("local_sleep_sessions count=${sessions.size} from=$from to=$to")
+        if (sessions.isEmpty()) {
+            return@runCatching emptyList<SleepSessionResponse>()
+        }
+        // Charge tous les stages des sessions retournées en 1 requête
+        val ids = sessions.map { it.id }
+        val allStages = sleepDao.getStagesForSessions(ids).groupBy { it.sessionId }
+        sessions.map { session ->
+            session.toResponse(stages = allStages[session.id].orEmpty())
+        }
+    }
+}
+
+internal fun SleepSessionEntity.toResponse(stages: List<SleepStageEntity>): SleepSessionResponse =
+    SleepSessionResponse(
+        id = this.id.toString(),
+        sleep_start = msToIso(this.sleepStartMs),
+        sleep_end = msToIso(this.sleepEndMs),
+        created_at = msToIso(this.createdAtMs),
+        stages = stages.map { it.toResponse() },
+    )
+
+internal fun SleepStageEntity.toResponse(): SleepStageResponse =
+    SleepStageResponse(
+        id = this.id.toString(),
+        session_id = this.sessionId.toString(),
+        stage = this.stageType,
+        stage_start = msToIso(this.stageStartMs),
+        stage_end = msToIso(this.stageEndMs),
+    )
+
+private val ISO_FMT: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+private fun msToIso(ms: Long): String =
+    Instant.ofEpochMilli(ms).atOffset(ZoneOffset.UTC).format(ISO_FMT)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -31,6 +31,7 @@ import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.data.sleep.LocalSleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepositoryImpl
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
@@ -132,12 +133,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Sleep.route) {
-                val sleepRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val sleepRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val sleepViewModel = remember(sleepRepository) { SleepViewModel(sleepRepository) }
                 SleepScreen(
@@ -160,12 +158,9 @@ fun NavGraph(
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
                 val dateArg = backStackEntry.arguments?.getString("date")
-                val hypnogramRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val hypnogramRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
                     HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
@@ -176,12 +171,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Timeline.route) {
-                val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val timelineRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
                 TimelineScreen(

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -205,9 +205,17 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Import.route) {
-                val repository: ImportRepository = remember(api) {
+                val context = LocalContext.current
+                val repository: ImportRepository = remember(api, context) {
                     if (api != null) {
-                        ImportRepositoryImpl(api)
+                        val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                        val localService = fr.datasaillance.nightfall.data.local.import_.LocalImportService(
+                            sleepDao = db.sleepDao(),
+                            heartRateDao = db.heartRateDao(),
+                            stepsDao = db.stepsDao(),
+                            exerciseDao = db.exerciseDao(),
+                        )
+                        ImportRepositoryImpl(api, localService)
                     } else {
                         NoOpImportRepository()
                     }

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.kt
@@ -1,0 +1,292 @@
+package fr.datasaillance.nightfall.data.local.import_
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalImportServiceTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var service: LocalImportService
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        service = LocalImportService(
+            sleepDao = db.sleepDao(),
+            heartRateDao = db.heartRateDao(),
+            stepsDao = db.stepsDao(),
+            exerciseDao = db.exerciseDao(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private fun sleepCsv(rows: List<Triple<String, String, String?>> = emptyList()): ByteArray {
+        // metadata + header + rows. La 1re col=user_id, 2e=valid digit pour déclencher le strip metadata.
+        val header = "com.samsung.health.sleep.start_time,com.samsung.health.sleep.end_time,sleep_score"
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.shealth.sleep,12345,11")
+        sb.appendLine(header)
+        rows.forEach { (s, e, score) ->
+            sb.appendLine("$s,$e,${score ?: ""}")
+        }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun sleepStageCsv(rows: List<Triple<String, String, Int>>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.health.sleep_stage,12345,7")
+        sb.appendLine("start_time,end_time,stage")
+        rows.forEach { (s, e, code) -> sb.appendLine("$s,$e,$code") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun heartRateCsv(rows: List<Quad>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.health.heart_rate,12345,4")
+        sb.appendLine(
+            "com.samsung.health.heart_rate.start_time," +
+                "com.samsung.health.heart_rate.heart_rate," +
+                "com.samsung.health.heart_rate.min," +
+                "com.samsung.health.heart_rate.max",
+        )
+        rows.forEach { sb.appendLine("${it.ts},${it.bpm},${it.min},${it.max}") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun stepsCsv(rows: List<Pair<Long, Int>>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.shealth.tracker.pedometer_day_summary,12345,5")
+        sb.appendLine("day_time,count")
+        rows.forEach { (ts, c) -> sb.appendLine("$ts,$c") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun exerciseCsv(rows: List<ExRow>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.shealth.exercise,12345,8")
+        sb.appendLine(
+            "com.samsung.health.exercise.start_time," +
+                "com.samsung.health.exercise.end_time," +
+                "com.samsung.health.exercise.exercise_type," +
+                "com.samsung.health.exercise.duration",
+        )
+        rows.forEach { sb.appendLine("${it.start},${it.end},${it.code},${it.durationMs}") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    // ── Tests sleep ────────────────────────────────────────────────────────
+
+    @Test
+    fun import_sleep_inserts_rows() = runTest {
+        val csv = sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+            Triple("2026-04-21 23:00:00.000", "2026-04-22 06:45:00.000", "78"),
+        ))
+        val r = service.importSleep(csv)
+        assertEquals(2, r.inserted)
+        assertEquals(0, r.skipped)
+        assertEquals(2, db.sleepDao().countSessions())
+    }
+
+    @Test
+    fun import_sleep_idempotent() = runTest {
+        val csv = sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        ))
+        service.importSleep(csv)
+        val r2 = service.importSleep(csv)
+        assertEquals(0, r2.inserted)
+        assertEquals(1, r2.skipped)
+        assertEquals(1, db.sleepDao().countSessions())
+    }
+
+    @Test
+    fun import_sleep_skips_invalid_dates() = runTest {
+        val csv = sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+            Triple("not-a-date", "2026-04-22 06:45:00.000", "78"),
+        ))
+        val r = service.importSleep(csv)
+        assertEquals(1, r.inserted)
+        assertEquals(1, r.skipped)
+    }
+
+    // ── Tests sleep_stage ──────────────────────────────────────────────────
+
+    @Test
+    fun import_sleep_stage_links_to_existing_session() = runTest {
+        // Pre-condition : 1 session sleep en DB
+        service.importSleep(sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        )))
+        val stagesCsv = sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002), // LIGHT
+            Triple("2026-04-21 00:30:00.000", "2026-04-21 02:00:00.000", 40003), // DEEP
+            Triple("2026-04-21 02:00:00.000", "2026-04-21 03:00:00.000", 40004), // REM
+            Triple("2026-04-21 03:00:00.000", "2026-04-21 07:30:00.000", 40002),
+        ))
+        val r = service.importSleepStages(stagesCsv)
+        assertEquals(4, r.inserted)
+        assertEquals(0, r.skipped)
+        assertEquals(4, db.sleepDao().countStages())
+    }
+
+    @Test
+    fun import_sleep_stage_skips_unknown_code() = runTest {
+        service.importSleep(sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        )))
+        val r = service.importSleepStages(sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002),
+            Triple("2026-04-21 00:30:00.000", "2026-04-21 02:00:00.000", 99999), // unknown
+        )))
+        assertEquals(1, r.inserted)
+        assertEquals(1, r.skipped)
+    }
+
+    @Test
+    fun import_sleep_stage_skips_when_no_parent_session() = runTest {
+        // Pas de session pré-importée
+        val r = service.importSleepStages(sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002),
+        )))
+        assertEquals(0, r.inserted)
+        assertEquals(1, r.skipped)
+    }
+
+    @Test
+    fun import_sleep_stage_idempotent() = runTest {
+        service.importSleep(sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        )))
+        val csv = sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002),
+        ))
+        service.importSleepStages(csv)
+        val r2 = service.importSleepStages(csv)
+        assertEquals(0, r2.inserted)
+        assertEquals(1, r2.skipped)
+    }
+
+    // ── Tests heart_rate ───────────────────────────────────────────────────
+
+    @Test
+    fun import_heart_rate_aggregates_by_hour() = runTest {
+        // 3 samples à 8h, 2 à 9h → 2 enregistrements horaires
+        val csv = heartRateCsv(listOf(
+            Quad("2026-04-20 08:00:00.000", "70", "60", "80"),
+            Quad("2026-04-20 08:15:00.000", "72", "62", "82"),
+            Quad("2026-04-20 08:30:00.000", "74", "64", "84"),
+            Quad("2026-04-20 09:00:00.000", "80", "70", "90"),
+            Quad("2026-04-20 09:30:00.000", "82", "72", "92"),
+        ))
+        val r = service.importHeartRate(csv)
+        assertEquals(2, r.inserted)
+        val all = db.heartRateDao().getAll()
+        assertEquals(2, all.size)
+        val h8 = all.first { it.hour == 8 }
+        assertEquals(72, h8.avgBpm)
+        assertEquals(60, h8.minBpm)
+        assertEquals(84, h8.maxBpm)
+        assertEquals(3, h8.sampleCount)
+    }
+
+    // ── Tests steps ────────────────────────────────────────────────────────
+
+    @Test
+    fun import_steps_uses_day_time_format() = runTest {
+        // day_time est en millis Unix. 2026-04-20 10:00:00 UTC = 1776592800000
+        val csv = stepsCsv(listOf(
+            1776592800000L to 1200,
+            1776596400000L to 800, // 11h
+        ))
+        val r = service.importSteps(csv)
+        assertEquals(2, r.inserted)
+        val all = db.stepsDao().getAll()
+        assertEquals(2, all.size)
+    }
+
+    // ── Tests exercise ─────────────────────────────────────────────────────
+
+    @Test
+    fun import_exercise_maps_known_type() = runTest {
+        val csv = exerciseCsv(listOf(
+            ExRow("2026-04-20 18:00:00.000", "2026-04-20 18:30:00.000", 1001, 1_800_000f),
+        ))
+        val r = service.importExercise(csv)
+        assertEquals(1, r.inserted)
+        val rows = db.exerciseDao().getAll()
+        assertEquals("running", rows.first().exerciseType)
+        assertEquals(30, rows.first().durationMin)
+    }
+
+    @Test
+    fun import_exercise_unknown_type_kept_as_samsung_code() = runTest {
+        val csv = exerciseCsv(listOf(
+            ExRow("2026-04-20 18:00:00.000", "2026-04-20 18:30:00.000", 99999, 1_800_000f),
+        ))
+        service.importExercise(csv)
+        assertEquals("samsung_99999", db.exerciseDao().getAll().first().exerciseType)
+    }
+
+    // ── Tests perf ─────────────────────────────────────────────────────────
+
+    @Test
+    fun import_60k_sleep_stages_under_5_seconds() = runTest {
+        // Crée 1 session qui couvre toute la fenêtre des stages
+        service.importSleep(sleepCsv(listOf(
+            Triple("2023-12-22 00:00:00.000", "2024-12-22 00:00:00.000", "80"),
+        )))
+        // Génère 60k stages contigus d'1 minute chacun
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.health.sleep_stage,12345,7")
+        sb.appendLine("start_time,end_time,stage")
+        val baseSec = java.time.LocalDateTime.parse("2023-12-22T00:00:00").toEpochSecond(java.time.ZoneOffset.UTC)
+        for (i in 0 until 60_000) {
+            val s = java.time.LocalDateTime.ofEpochSecond(baseSec + i * 60L, 0, java.time.ZoneOffset.UTC)
+            val e = java.time.LocalDateTime.ofEpochSecond(baseSec + (i + 1) * 60L, 0, java.time.ZoneOffset.UTC)
+            val code = listOf(40001, 40002, 40003, 40004)[i % 4]
+            sb.appendLine("${s.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))},${e.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))},$code")
+        }
+        val csv = sb.toString().toByteArray(Charsets.UTF_8)
+
+        val t0 = System.currentTimeMillis()
+        val r = service.importSleepStages(csv)
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(60_000, r.inserted)
+        assertTrue("60k stages took ${elapsed}ms (>15s)", elapsed < 15_000)
+    }
+
+    // ── Bisect helper ──────────────────────────────────────────────────────
+
+    @Test
+    fun bisect_right_matches_python_semantics() {
+        // bisect_right([1, 3, 5, 7], 5) == 3 (insère APRÈS le 5 existant)
+        assertEquals(3, LocalImportService.bisectRight(listOf(1L, 3L, 5L, 7L), 5L))
+        assertEquals(0, LocalImportService.bisectRight(listOf(1L, 3L, 5L), 0L))
+        assertEquals(3, LocalImportService.bisectRight(listOf(1L, 3L, 5L), 100L))
+    }
+
+    private data class Quad(val ts: String, val bpm: String, val min: String, val max: String)
+    private data class ExRow(val start: String, val end: String, val code: Int, val durationMs: Float)
+}

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
@@ -1,0 +1,134 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(AndroidJUnit4::class)
+class LocalSleepRepositoryTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var repo: LocalSleepRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        repo = LocalSleepRepository(db.sleepDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun get_all_sessions_when_no_filter() = runTest {
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-21T22:00:00Z", end = "2026-04-22T06:00:00Z")
+
+        val r = repo.getSessions()
+        assertTrue(r.isSuccess)
+        assertEquals(2, r.getOrNull()!!.size)
+    }
+
+    @Test
+    fun get_sessions_in_range_filters_correctly() = runTest {
+        seedSession(start = "2026-04-19T22:00:00Z", end = "2026-04-20T06:00:00Z")
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-25T22:00:00Z", end = "2026-04-26T06:00:00Z")
+
+        // Window [from=2026-04-20, to=2026-04-21] inclus → on attend la session du 20-21
+        // (et celle du 19-20 si son sleep_start tombe dans la fenêtre — non ici)
+        val r = repo.getSessions(from = LocalDate.of(2026, 4, 20), to = LocalDate.of(2026, 4, 21))
+        assertTrue(r.isSuccess)
+        val sessions = r.getOrNull()!!
+        assertEquals(1, sessions.size)
+        assertTrue(sessions.first().sleep_start.startsWith("2026-04-20"))
+    }
+
+    @Test
+    fun stages_are_attached_to_their_session() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:00:00Z", "2026-04-20T23:00:00Z")
+        seedStage(sid, "DEEP", "2026-04-20T23:00:00Z", "2026-04-21T01:00:00Z")
+        seedStage(sid, "REM", "2026-04-21T01:00:00Z", "2026-04-21T03:00:00Z")
+
+        val sessions = repo.getSessions().getOrNull()!!
+        assertEquals(1, sessions.size)
+        val s = sessions.first()
+        assertNotNull(s.stages)
+        assertEquals(3, s.stages!!.size)
+        assertEquals("LIGHT", s.stages.first().stage)
+    }
+
+    @Test
+    fun iso_round_trip_preserves_timestamps() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:30:45Z", end = "2026-04-21T06:15:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:30:45Z", "2026-04-21T00:00:00Z")
+
+        val s = repo.getSessions().getOrNull()!!.first()
+        assertEquals("2026-04-20T22:30:45Z", s.sleep_start)
+        assertEquals("2026-04-21T06:15:00Z", s.sleep_end)
+        val stage = s.stages!!.first()
+        assertEquals("2026-04-20T22:30:45Z", stage.stage_start)
+    }
+
+    @Test
+    fun bulk_load_60k_stages_under_2_seconds() = runTest {
+        // Critère d'acceptation #2 de la spec — Hypnogramme < 200ms en lecture sur device
+        // (Robolectric in-memory ~10x plus lent : seuil large à 5s ici).
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T22:00:00Z")
+        val stages = (0 until 60_000).map { i ->
+            SleepStageEntity(
+                sessionId = sid,
+                stageType = listOf("DEEP", "LIGHT", "REM", "AWAKE")[i % 4],
+                stageStartMs = 1_745_181_600_000L + i * 1_000L,
+                stageEndMs = 1_745_181_600_000L + (i + 1) * 1_000L,
+            )
+        }
+        db.sleepDao().insertStages(stages)
+
+        val t0 = System.currentTimeMillis()
+        val sessions = repo.getSessions().getOrNull()!!
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(1, sessions.size)
+        assertEquals(60_000, sessions.first().stages!!.size)
+        assertTrue("60k stages read took ${elapsed}ms (>5s)", elapsed < 5_000)
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private suspend fun seedSession(start: String, end: String): Long {
+        val s = SleepSessionEntity(sleepStartMs = isoToMs(start), sleepEndMs = isoToMs(end))
+        return db.sleepDao().insertSessions(listOf(s)).first()
+    }
+
+    private suspend fun seedStage(sessionId: Long, type: String, start: String, end: String) {
+        db.sleepDao().insertStages(listOf(
+            SleepStageEntity(
+                sessionId = sessionId,
+                stageType = type,
+                stageStartMs = isoToMs(start),
+                stageEndMs = isoToMs(end),
+            ),
+        ))
+    }
+
+    private fun isoToMs(iso: String): Long = java.time.Instant.parse(iso).toEpochMilli()
+}

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/import_/ImportRepositoryImpl.kt
-git_blob: f78e97d430f86e164fcb8f4462e58c178d5b1eaf
-last_synced: '2026-05-09T08:45:05Z'
-loc: 125
+git_blob: 4b22f61bf73e66d91178597b95525147d3c0fc0d
+last_synced: '2026-05-09T15:32:55Z'
+loc: 121
 annotations: []
 imports: []
 exports: []
@@ -25,14 +25,10 @@ package fr.datasaillance.nightfall.data.import_
 
 import android.content.ContentResolver
 import android.net.Uri
-import fr.datasaillance.nightfall.data.http.CountingRequestBody
-import fr.datasaillance.nightfall.data.http.ImportApiResponse
 import fr.datasaillance.nightfall.data.http.NightfallApi
+import fr.datasaillance.nightfall.data.local.import_.LocalImportService
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
-import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.MultipartBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.zip.ZipInputStream
@@ -40,8 +36,14 @@ import java.util.zip.ZipInputStream
 private const val MAX_UNCOMPRESSED_BYTES = 200_000_000L
 private const val MAX_ZIP_ENTRIES = 100
 
+/**
+ * Phase B local-first : les imports écrivent directement en Room locale via
+ * `LocalImportService`. Plus aucun upload réseau santé. L'API n'est conservée
+ * que pour le ping de connectivité (vérification VPS up).
+ */
 class ImportRepositoryImpl(
     private val api: NightfallApi,
+    private val localImportService: LocalImportService,
 ) : ImportRepository {
 
     override suspend fun pingBackend(): Boolean {
@@ -126,24 +128,18 @@ class ImportRepositoryImpl(
                 contentResolver.openInputStream(uri)?.readBytes()
                     ?: throw IOException("Cannot read file for $type")
             }
-
-        val mediaType = "text/csv".toMediaType()
-        val requestBody = bytes.toRequestBody(mediaType)
-        val countingBody = CountingRequestBody(
-            delegate = requestBody,
-            totalBytes = totalBytes,
-            onProgress = onProgress,
-        )
-        val part = MultipartBody.Part.createFormData("file", "${type.samsungFilenamePrefix}.csv", countingBody)
-
-        val response: ImportApiResponse = when (type) {
-            ImportDataType.SLEEP -> api.importSleep(part)
-            ImportDataType.HEART_RATE -> api.importHeartRate(part)
-            ImportDataType.STEPS -> api.importSteps(part)
-            ImportDataType.EXERCISE -> api.importExercise(part)
-            ImportDataType.SLEEP_STAGE -> api.importSleepStages(part)
+        // Pas de progression réseau ici (parsing local quasi-instantané) — on émet 0
+        // au début et 1 à la fin pour garder le contrat de l'UI.
+        onProgress(0f)
+        val r = when (type) {
+            ImportDataType.SLEEP -> localImportService.importSleep(bytes)
+            ImportDataType.SLEEP_STAGE -> localImportService.importSleepStages(bytes)
+            ImportDataType.HEART_RATE -> localImportService.importHeartRate(bytes)
+            ImportDataType.STEPS -> localImportService.importSteps(bytes)
+            ImportDataType.EXERCISE -> localImportService.importExercise(bytes)
         }
-        return ImportResult(type = type, inserted = response.inserted, skipped = response.skipped)
+        onProgress(1f)
+        return ImportResult(type = type, inserted = r.inserted, skipped = r.skipped)
     }
 }
 ```
@@ -153,8 +149,8 @@ class ImportRepositoryImpl(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportRepositoryImpl` (class) — lines 20-125
-- `pingBackend` (function) — lines 24-31
-- `extractCsvEntries` (function) — lines 35-45
-- `extractFromZip` (function) — lines 47-92
-- `uploadCsv` (function) — lines 94-124
+- `ImportRepositoryImpl` (class) — lines 21-121
+- `pingBackend` (function) — lines 26-33
+- `extractCsvEntries` (function) — lines 37-47
+- `extractFromZip` (function) — lines 49-94
+- `uploadCsv` (function) — lines 96-120

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.md
@@ -1,0 +1,276 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.kt
+git_blob: 5f5f9bf679aaa4db47ff40dea3c689615f9cd23d
+last_synced: '2026-05-09T15:30:15Z'
+loc: 234
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/LocalImportService.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.import_
+
+import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
+import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.dao.StepsDao
+import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Résultat d'un import CSV pour un type donné.
+ * Équivalent du `(inserted, skipped)` retourné par `parse_*_rows` côté serveur.
+ */
+data class LocalImportResult(val inserted: Int, val skipped: Int)
+
+/**
+ * Importe les CSV Samsung Health directement en base Room locale, sans VPS.
+ *
+ * Port Kotlin de `server/services/csv_import.py::parse_sleep_rows / parse_sleep_stage_rows /
+ * parse_heartrate_rows / parse_steps_rows / parse_exercise_rows`.
+ *
+ * Les imports sont idempotents par construction : Room utilise `OnConflictStrategy.IGNORE`
+ * sur les index uniques `(start, end)` ou `(date, hour)`, équivalent fonctionnel du
+ * `ON CONFLICT DO NOTHING` Postgres.
+ */
+class LocalImportService(
+    private val sleepDao: SleepDao,
+    private val heartRateDao: HeartRateDao,
+    private val stepsDao: StepsDao,
+    private val exerciseDao: ExerciseDao,
+) {
+
+    /** Import sleep CSV (`com.samsung.shealth.sleep.*.csv`). */
+    suspend fun importSleep(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val entities = mutableListOf<SleepSessionEntity>()
+        var skipped = 0
+        for (row in rows) {
+            val start = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.sleep.start_time"])
+            val end = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.sleep.end_time"])
+            if (start == null || end == null) {
+                skipped++
+                continue
+            }
+            entities.add(
+                SleepSessionEntity(
+                    sleepStartMs = start,
+                    sleepEndMs = end,
+                    sleepScore = row["sleep_score"]?.toIntOrNullSafe(),
+                    efficiency = row["efficiency"]?.toFloatOrNullSafe(),
+                    sleepDurationMin = row["sleep_duration"]?.toIntOrNullSafe(),
+                    sleepCycle = row["sleep_cycle"]?.toIntOrNullSafe(),
+                    mentalRecovery = row["mental_recovery"]?.toFloatOrNullSafe(),
+                    physicalRecovery = row["physical_recovery"]?.toFloatOrNullSafe(),
+                    sleepType = row["sleep_type"]?.toIntOrNullSafe(),
+                ),
+            )
+        }
+        val ids = sleepDao.insertSessions(entities)
+        val inserted = ids.count { it != -1L }
+        skipped += entities.size - inserted // duplicates ignorés
+        return LocalImportResult(inserted, skipped)
+    }
+
+    /**
+     * Import sleep_stage CSV. Exige que les sessions parentes soient déjà en base
+     * (via `importSleep` précédemment) — chaque stage cherche la session qui le contient
+     * par lookup binary-search sur les `sleep_start` triés.
+     */
+    suspend fun importSleepStages(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val sessions = sleepDao.getAllSessions()
+        if (sessions.isEmpty()) {
+            // Pas de session parente en DB → tous les stages sont orphelins
+            return LocalImportResult(inserted = 0, skipped = rows.size)
+        }
+        val starts = sessions.map { it.sleepStartMs }
+
+        val toInsert = mutableListOf<SleepStageEntity>()
+        var skipped = 0
+        for (row in rows) {
+            val startMs = SamsungCsvParser.parseTimestampToMs(row["start_time"])
+            val endMs = SamsungCsvParser.parseTimestampToMs(row["end_time"])
+            val stageCode = row["stage"]?.toIntOrNullSafe()
+            if (startMs == null || endMs == null || stageCode == null) {
+                skipped++; continue
+            }
+            val stageType = SLEEP_STAGE_MAP[stageCode]
+            if (stageType == null) {
+                skipped++; continue
+            }
+            val sessionIdx = bisectRight(starts, startMs) - 1
+            if (sessionIdx < 0) {
+                skipped++; continue
+            }
+            val parent = sessions[sessionIdx]
+            if (parent.sleepEndMs < endMs) {
+                skipped++; continue
+            }
+            toInsert.add(
+                SleepStageEntity(
+                    sessionId = parent.id,
+                    stageType = stageType,
+                    stageStartMs = startMs,
+                    stageEndMs = endMs,
+                ),
+            )
+        }
+        val ids = sleepDao.insertStages(toInsert)
+        val inserted = ids.count { it != -1L }
+        skipped += toInsert.size - inserted
+        return LocalImportResult(inserted, skipped)
+    }
+
+    /** Import heart_rate CSV avec agrégation horaire (min / max / avg / count par (date, hour) UTC). */
+    suspend fun importHeartRate(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        // Slot par (date, hour) → liste de (bpm, min, max)
+        val slots = HashMap<Pair<String, Int>, MutableList<Triple<Int, Int, Int>>>()
+        for (row in rows) {
+            val tsMs = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.heart_rate.start_time"]) ?: continue
+            val bpm = row["com.samsung.health.heart_rate.heart_rate"]?.toFloatOrNullSafe()?.let { Math.round(it) } ?: continue
+            val mn = row["com.samsung.health.heart_rate.min"]?.toFloatOrNullSafe()?.let { Math.round(it) } ?: continue
+            val mx = row["com.samsung.health.heart_rate.max"]?.toFloatOrNullSafe()?.let { Math.round(it) } ?: continue
+            val (date, hour) = msToDateHour(tsMs)
+            slots.getOrPut(date to hour) { mutableListOf() }.add(Triple(bpm, mn, mx))
+        }
+        val entities = slots.map { (key, samples) ->
+            val (date, hour) = key
+            HeartRateHourlyEntity(
+                date = date,
+                hour = hour,
+                avgBpm = (samples.sumOf { it.first } / samples.size.toDouble()).let { Math.round(it).toInt() },
+                minBpm = samples.minOf { it.second },
+                maxBpm = samples.maxOf { it.third },
+                sampleCount = samples.size,
+            )
+        }
+        val ids = heartRateDao.insertHourly(entities)
+        val inserted = ids.count { it != -1L }
+        return LocalImportResult(inserted, entities.size - inserted)
+    }
+
+    /**
+     * Import steps CSV. Format actuel utilise `day_time` (millis) + `count`.
+     * Fallback supporté : colonnes `com.samsung.health.step_daily_trend.start_time / .count`.
+     */
+    suspend fun importSteps(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val slots = HashMap<Pair<String, Int>, Int>()
+        for (row in rows) {
+            val dayTime = row["day_time"]?.toLongOrNullSafe()
+            val tsMs: Long?
+            val count: Int?
+            if (dayTime != null) {
+                tsMs = dayTime
+                count = row["count"]?.toIntOrNullSafe()
+            } else {
+                tsMs = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.step_daily_trend.start_time"])
+                count = row["com.samsung.health.step_daily_trend.count"]?.toIntOrNullSafe()
+            }
+            if (tsMs == null || count == null) continue
+            val (date, hour) = msToDateHour(tsMs)
+            slots[date to hour] = (slots[date to hour] ?: 0) + count
+        }
+        val entities = slots.map { (key, c) -> StepsHourlyEntity(date = key.first, hour = key.second, stepCount = c) }
+        val ids = stepsDao.insertHourly(entities)
+        val inserted = ids.count { it != -1L }
+        return LocalImportResult(inserted, entities.size - inserted)
+    }
+
+    /** Import exercise CSV. */
+    suspend fun importExercise(csvBytes: ByteArray): LocalImportResult {
+        val rows = SamsungCsvParser.parse(csvBytes)
+        val entities = mutableListOf<ExerciseSessionEntity>()
+        var skipped = 0
+        for (row in rows) {
+            val start = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.exercise.start_time"])
+            val end = SamsungCsvParser.parseTimestampToMs(row["com.samsung.health.exercise.end_time"])
+            val typeCode = row["com.samsung.health.exercise.exercise_type"]?.toIntOrNullSafe()
+            val durationMs = row["com.samsung.health.exercise.duration"]?.toFloatOrNullSafe()
+            if (start == null || end == null || typeCode == null) {
+                skipped++; continue
+            }
+            val type = EXERCISE_TYPE_MAP[typeCode] ?: "samsung_$typeCode"
+            entities.add(
+                ExerciseSessionEntity(
+                    startTimeMs = start,
+                    endTimeMs = end,
+                    exerciseType = type,
+                    durationMin = durationMs?.let { (it / 60_000f).toInt() },
+                    calorie = row["com.samsung.health.exercise.calorie"]?.toFloatOrNullSafe(),
+                    meanHeartRate = row["com.samsung.health.exercise.mean_heart_rate"]?.toFloatOrNullSafe()?.let { Math.round(it) },
+                ),
+            )
+        }
+        val ids = exerciseDao.insertSessions(entities)
+        val inserted = ids.count { it != -1L }
+        skipped += entities.size - inserted
+        return LocalImportResult(inserted, skipped)
+    }
+
+    private fun msToDateHour(ms: Long): Pair<String, Int> {
+        val zdt = Instant.ofEpochMilli(ms).atZone(ZoneOffset.UTC)
+        return zdt.toLocalDate().format(DATE_FMT) to zdt.hour
+    }
+
+    companion object {
+        private val DATE_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+
+        // bisect_right équivalent Python — retourne l'index où insérer `target` pour
+        // garder `list` triée, en plaçant à DROITE des entrées égales.
+        internal fun bisectRight(list: List<Long>, target: Long): Int {
+            var lo = 0
+            var hi = list.size
+            while (lo < hi) {
+                val mid = (lo + hi) ushr 1
+                if (target < list[mid]) hi = mid else lo = mid + 1
+            }
+            return lo
+        }
+    }
+}
+
+// Helpers de parsing tolérants — String?.toIntOrNull() est plus strict (refuse "12.0", " 12 ", etc.)
+private fun String.toIntOrNullSafe(): Int? = trim().takeIf { it.isNotEmpty() }?.toDoubleOrNull()?.toInt()
+private fun String.toFloatOrNullSafe(): Float? = trim().takeIf { it.isNotEmpty() }?.toFloatOrNull()
+private fun String.toLongOrNullSafe(): Long? = trim().takeIf { it.isNotEmpty() }?.toLongOrNull()
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalImportResult` (class) — lines 20-20
+- `LocalImportService` (class) — lines 32-229
+- `importSleep` (function) — lines 40-69
+- `importSleepStages` (function) — lines 76-119
+- `importHeartRate` (function) — lines 122-148
+- `importSteps` (function) — lines 154-176
+- `importExercise` (function) — lines 179-207
+- `msToDateHour` (function) — lines 209-212
+- `bisectRight` (function) — lines 219-227
+- `toIntOrNullSafe` (function) — lines 232-232
+- `toFloatOrNullSafe` (function) — lines 233-233
+- `toLongOrNullSafe` (function) — lines 234-234

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.md
@@ -1,0 +1,142 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.kt
+git_blob: 80721f33a9cf73b4f2dc32a8a6338e320607b148
+last_synced: '2026-05-09T15:30:15Z'
+loc: 109
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/SamsungCsvParser.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.import_
+
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Parser des CSV Samsung Health. Port Kotlin de `server/services/csv_import.py::parse_samsung_csv`.
+ *
+ * Particularités du format Samsung :
+ * - BOM UTF-8 (U+FEFF) en début de fichier — la décode UTF-8 standard ne le mange pas, on doit le strip.
+ * - Lignes commençant par `#` = commentaires/metadata → ignorées.
+ * - Première ligne après les commentaires = ligne metadata `namespace,user_id,version` (le user_id est un entier).
+ * - 2e ligne (ou 1re si pas de metadata) = header CSV.
+ *
+ * Détecte la ligne metadata par la présence d'un entier en 2e champ.
+ */
+object SamsungCsvParser {
+
+    private const val UTF8_BOM = '﻿'
+
+    /**
+     * Parse le contenu binaire d'un CSV Samsung. Retourne une liste de `Map<String, String>`
+     * (équivalent du `list[dict]` Python) — clés = noms de colonnes du header.
+     *
+     * @throws IllegalArgumentException si le contenu est mal formé (ex: lignes incohérentes)
+     */
+    fun parse(rawBytes: ByteArray): List<Map<String, String>> {
+        val text = rawBytes.toString(Charsets.UTF_8).removePrefix(UTF8_BOM.toString())
+        val lines = text.lineSequence()
+            .filter { !it.startsWith("#") }
+            .toList()
+        if (lines.isEmpty()) return emptyList()
+
+        // Détecte la ligne metadata Samsung (`com.samsung.<x>,<userid_int>,<version>`)
+        val firstParts = lines[0].split(",", limit = 3)
+        val withoutMetadata = if (firstParts.size >= 2 && firstParts[1].trim().toIntOrNull() != null) {
+            lines.drop(1)
+        } else {
+            lines
+        }
+        if (withoutMetadata.isEmpty()) return emptyList()
+
+        val header = parseCsvRow(withoutMetadata[0])
+        val rows = mutableListOf<Map<String, String>>()
+        for (i in 1 until withoutMetadata.size) {
+            val raw = withoutMetadata[i]
+            if (raw.isBlank()) continue
+            val cells = parseCsvRow(raw)
+            // Tolérant aux lignes avec extra cellule(s) finale(s) — on ignore les surplus.
+            val map = LinkedHashMap<String, String>(header.size)
+            for ((idx, name) in header.withIndex()) {
+                map[name] = if (idx < cells.size) cells[idx] else ""
+            }
+            rows.add(map)
+        }
+        return rows
+    }
+
+    /**
+     * Parse une ligne CSV avec gestion des champs entre guillemets (RFC 4180 minimal).
+     * Suffisant pour Samsung Health qui n'utilise pas de quoting complexe.
+     */
+    private fun parseCsvRow(line: String): List<String> {
+        val out = mutableListOf<String>()
+        val sb = StringBuilder()
+        var inQuotes = false
+        var i = 0
+        while (i < line.length) {
+            val c = line[i]
+            when {
+                c == '"' && inQuotes && i + 1 < line.length && line[i + 1] == '"' -> {
+                    sb.append('"'); i += 2; continue
+                }
+                c == '"' -> { inQuotes = !inQuotes; i++; continue }
+                c == ',' && !inQuotes -> { out.add(sb.toString()); sb.clear(); i++; continue }
+                else -> { sb.append(c); i++ }
+            }
+        }
+        out.add(sb.toString())
+        return out
+    }
+
+    /**
+     * Parse un timestamp Samsung Health en epoch millis UTC.
+     * Format : `yyyy-MM-dd HH:mm:ss[.SSS]`. Retourne null si invalide.
+     *
+     * Note : Samsung exporte en heure locale "naïve" sans tz, mais sépare le `time_offset`
+     * dans une colonne dédiée. On considère ici la valeur comme UTC pour cohérence avec
+     * l'implémentation serveur (cf. `_parse_ts` en Python).
+     */
+    fun parseTimestampToMs(value: String?): Long? {
+        if (value.isNullOrBlank()) return null
+        val v = value.trim()
+        return try {
+            val dt = if ("." in v) {
+                LocalDateTime.parse(v, FMT_WITH_MS)
+            } else {
+                LocalDateTime.parse(v, FMT_NO_MS)
+            }
+            dt.toInstant(ZoneOffset.UTC).toEpochMilli()
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private val FMT_WITH_MS = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS")
+    private val FMT_NO_MS = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `parse` (function) — lines 28-58
+- `parseCsvRow` (function) — lines 64-82
+- `parseTimestampToMs` (function) — lines 92-105

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.md
@@ -1,0 +1,47 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.kt
+git_blob: 3e04906a8015fbebeda6436c57510e9e15afd7ef
+last_synced: '2026-05-09T15:30:15Z'
+loc: 19
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/import_/StageMaps.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.import_
+
+/** Codes Samsung sleep_stage → libellé canonique (mêmes valeurs que server/services/csv_import.py). */
+internal val SLEEP_STAGE_MAP: Map<Int, String> = mapOf(
+    40001 to "AWAKE",
+    40002 to "LIGHT",
+    40003 to "DEEP",
+    40004 to "REM",
+)
+
+/** Codes Samsung exercise_type → libellé. Codes inconnus stockés comme `samsung_<code>`. */
+internal val EXERCISE_TYPE_MAP: Map<Int, String> = mapOf(
+    1001 to "running",
+    1002 to "cycling",
+    1007 to "walking",
+    1008 to "hiking",
+    3000 to "swimming",
+    90001 to "indoor_cycling",
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.md
@@ -1,0 +1,106 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
+git_blob: 88119451402767cc179160561582bc5d90517c3f
+last_synced: '2026-05-09T15:40:18Z'
+loc: 71
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import timber.log.Timber
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Implémentation locale de `SleepRepository` qui lit les données depuis la base
+ * Room SQLCipher au lieu d'appeler le VPS. Phase C de la migration local-first.
+ *
+ * Garde la même signature et les mêmes shapes (`SleepSessionResponse` /
+ * `SleepStageResponse`) que `SleepRepositoryImpl`, donc ViewModels et UI sont
+ * inchangés. Le parent du chargement saisit `from`/`to` comme avant.
+ */
+class LocalSleepRepository(
+    private val sleepDao: SleepDao,
+) : SleepRepository {
+
+    override suspend fun getSessions(
+        from: LocalDate?,
+        to: LocalDate?,
+    ): Result<List<SleepSessionResponse>> = runCatching {
+        val sessions = if (from != null && to != null) {
+            // [from 00:00 UTC, to+1 00:00 UTC) — `to` est inclusif côté API serveur,
+            // on applique le même offset que server/routers/sleep.py:175 (`to + 1d`).
+            val fromMs = from.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            val toMs = to.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            sleepDao.getSessionsInRange(fromMs, toMs)
+        } else {
+            sleepDao.getAllSessions()
+        }
+        Timber.i("local_sleep_sessions count=${sessions.size} from=$from to=$to")
+        if (sessions.isEmpty()) {
+            return@runCatching emptyList<SleepSessionResponse>()
+        }
+        // Charge tous les stages des sessions retournées en 1 requête
+        val ids = sessions.map { it.id }
+        val allStages = sleepDao.getStagesForSessions(ids).groupBy { it.sessionId }
+        sessions.map { session ->
+            session.toResponse(stages = allStages[session.id].orEmpty())
+        }
+    }
+}
+
+internal fun SleepSessionEntity.toResponse(stages: List<SleepStageEntity>): SleepSessionResponse =
+    SleepSessionResponse(
+        id = this.id.toString(),
+        sleep_start = msToIso(this.sleepStartMs),
+        sleep_end = msToIso(this.sleepEndMs),
+        created_at = msToIso(this.createdAtMs),
+        stages = stages.map { it.toResponse() },
+    )
+
+internal fun SleepStageEntity.toResponse(): SleepStageResponse =
+    SleepStageResponse(
+        id = this.id.toString(),
+        session_id = this.sessionId.toString(),
+        stage = this.stageType,
+        stage_start = msToIso(this.stageStartMs),
+        stage_end = msToIso(this.stageEndMs),
+    )
+
+private val ISO_FMT: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+private fun msToIso(ms: Long): String =
+    Instant.ofEpochMilli(ms).atOffset(ZoneOffset.UTC).format(ISO_FMT)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalSleepRepository` (class) — lines 20-48
+- `getSessions` (function) — lines 24-47
+- `toResponse` (function) — lines 50-57
+- `toResponse` (function) — lines 59-66
+- `msToIso` (function) — lines 70-71

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 746313483e3255e10d40d6204879d3d4fbe09549
-last_synced: '2026-05-09T14:31:04Z'
-loc: 283
+git_blob: b5c61b0e553fa384e12580a1ca86cb747d81511c
+last_synced: '2026-05-09T15:32:55Z'
+loc: 291
 annotations: []
 imports: []
 exports: []
@@ -228,9 +228,17 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Import.route) {
-                val repository: ImportRepository = remember(api) {
+                val context = LocalContext.current
+                val repository: ImportRepository = remember(api, context) {
                     if (api != null) {
-                        ImportRepositoryImpl(api)
+                        val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                        val localService = fr.datasaillance.nightfall.data.local.import_.LocalImportService(
+                            sleepDao = db.sleepDao(),
+                            heartRateDao = db.heartRateDao(),
+                            stepsDao = db.stepsDao(),
+                            exerciseDao = db.exerciseDao(),
+                        )
+                        ImportRepositoryImpl(api, localService)
                     } else {
                         NoOpImportRepository()
                     }
@@ -311,23 +319,23 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 57-229
-- `NoOpSleepRepository` (class) — lines 231-236
-- `getSessions` (function) — lines 232-235
-- `NoOpImportRepository` (class) — lines 238-253
-- `pingBackend` (function) — lines 239-239
-- `extractCsvEntries` (function) — lines 241-244
-- `uploadCsv` (function) — lines 246-252
-- `NoOpNightfallApi` (class) — lines 255-267
-- `health` (function) — lines 256-256
-- `login` (function) — lines 257-257
-- `register` (function) — lines 258-258
-- `requestPasswordReset` (function) — lines 259-259
-- `googleStart` (function) — lines 260-260
-- `getSleepSessions` (function) — lines 261-261
-- `importSleep` (function) — lines 262-262
-- `importHeartRate` (function) — lines 263-263
-- `importSteps` (function) — lines 264-264
-- `importExercise` (function) — lines 265-265
-- `importSleepStages` (function) — lines 266-266
-- `ensureComposeNavigators` (function) — lines 275-283
+- `NavGraph` (function) — lines 57-237
+- `NoOpSleepRepository` (class) — lines 239-244
+- `getSessions` (function) — lines 240-243
+- `NoOpImportRepository` (class) — lines 246-261
+- `pingBackend` (function) — lines 247-247
+- `extractCsvEntries` (function) — lines 249-252
+- `uploadCsv` (function) — lines 254-260
+- `NoOpNightfallApi` (class) — lines 263-275
+- `health` (function) — lines 264-264
+- `login` (function) — lines 265-265
+- `register` (function) — lines 266-266
+- `requestPasswordReset` (function) — lines 267-267
+- `googleStart` (function) — lines 268-268
+- `getSleepSessions` (function) — lines 269-269
+- `importSleep` (function) — lines 270-270
+- `importHeartRate` (function) — lines 271-271
+- `importSteps` (function) — lines 272-272
+- `importExercise` (function) — lines 273-273
+- `importSleepStages` (function) — lines 274-274
+- `ensureComposeNavigators` (function) — lines 283-291

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: b5c61b0e553fa384e12580a1ca86cb747d81511c
-last_synced: '2026-05-09T15:32:55Z'
-loc: 291
+git_blob: ff170b96fa6cb0bdb055869f24961d25422661ff
+last_synced: '2026-05-09T15:40:18Z'
+loc: 283
 annotations: []
 imports: []
 exports: []
@@ -54,6 +54,7 @@ import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.data.sleep.LocalSleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepositoryImpl
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
@@ -155,12 +156,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Sleep.route) {
-                val sleepRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val sleepRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val sleepViewModel = remember(sleepRepository) { SleepViewModel(sleepRepository) }
                 SleepScreen(
@@ -183,12 +181,9 @@ fun NavGraph(
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
                 val dateArg = backStackEntry.arguments?.getString("date")
-                val hypnogramRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val hypnogramRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
                     HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
@@ -199,12 +194,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Timeline.route) {
-                val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val timelineRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
                 TimelineScreen(
@@ -319,23 +311,23 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 57-237
-- `NoOpSleepRepository` (class) — lines 239-244
-- `getSessions` (function) — lines 240-243
-- `NoOpImportRepository` (class) — lines 246-261
-- `pingBackend` (function) — lines 247-247
-- `extractCsvEntries` (function) — lines 249-252
-- `uploadCsv` (function) — lines 254-260
-- `NoOpNightfallApi` (class) — lines 263-275
-- `health` (function) — lines 264-264
-- `login` (function) — lines 265-265
-- `register` (function) — lines 266-266
-- `requestPasswordReset` (function) — lines 267-267
-- `googleStart` (function) — lines 268-268
-- `getSleepSessions` (function) — lines 269-269
-- `importSleep` (function) — lines 270-270
-- `importHeartRate` (function) — lines 271-271
-- `importSteps` (function) — lines 272-272
-- `importExercise` (function) — lines 273-273
-- `importSleepStages` (function) — lines 274-274
-- `ensureComposeNavigators` (function) — lines 283-291
+- `NavGraph` (function) — lines 58-229
+- `NoOpSleepRepository` (class) — lines 231-236
+- `getSessions` (function) — lines 232-235
+- `NoOpImportRepository` (class) — lines 238-253
+- `pingBackend` (function) — lines 239-239
+- `extractCsvEntries` (function) — lines 241-244
+- `uploadCsv` (function) — lines 246-252
+- `NoOpNightfallApi` (class) — lines 255-267
+- `health` (function) — lines 256-256
+- `login` (function) — lines 257-257
+- `register` (function) — lines 258-258
+- `requestPasswordReset` (function) — lines 259-259
+- `googleStart` (function) — lines 260-260
+- `getSleepSessions` (function) — lines 261-261
+- `importSleep` (function) — lines 262-262
+- `importHeartRate` (function) — lines 263-263
+- `importSteps` (function) — lines 264-264
+- `importExercise` (function) — lines 265-265
+- `importSleepStages` (function) — lines 266-266
+- `ensureComposeNavigators` (function) — lines 275-283

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.md
@@ -1,0 +1,345 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.kt
+git_blob: 9fb56f00316c99e79005d109e8f1526d58edff9b
+last_synced: '2026-05-09T15:30:15Z'
+loc: 292
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/import_/LocalImportServiceTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.import_
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LocalImportServiceTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var service: LocalImportService
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        service = LocalImportService(
+            sleepDao = db.sleepDao(),
+            heartRateDao = db.heartRateDao(),
+            stepsDao = db.stepsDao(),
+            exerciseDao = db.exerciseDao(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private fun sleepCsv(rows: List<Triple<String, String, String?>> = emptyList()): ByteArray {
+        // metadata + header + rows. La 1re col=user_id, 2e=valid digit pour déclencher le strip metadata.
+        val header = "com.samsung.health.sleep.start_time,com.samsung.health.sleep.end_time,sleep_score"
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.shealth.sleep,12345,11")
+        sb.appendLine(header)
+        rows.forEach { (s, e, score) ->
+            sb.appendLine("$s,$e,${score ?: ""}")
+        }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun sleepStageCsv(rows: List<Triple<String, String, Int>>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.health.sleep_stage,12345,7")
+        sb.appendLine("start_time,end_time,stage")
+        rows.forEach { (s, e, code) -> sb.appendLine("$s,$e,$code") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun heartRateCsv(rows: List<Quad>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.health.heart_rate,12345,4")
+        sb.appendLine(
+            "com.samsung.health.heart_rate.start_time," +
+                "com.samsung.health.heart_rate.heart_rate," +
+                "com.samsung.health.heart_rate.min," +
+                "com.samsung.health.heart_rate.max",
+        )
+        rows.forEach { sb.appendLine("${it.ts},${it.bpm},${it.min},${it.max}") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun stepsCsv(rows: List<Pair<Long, Int>>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.shealth.tracker.pedometer_day_summary,12345,5")
+        sb.appendLine("day_time,count")
+        rows.forEach { (ts, c) -> sb.appendLine("$ts,$c") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    private fun exerciseCsv(rows: List<ExRow>): ByteArray {
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.shealth.exercise,12345,8")
+        sb.appendLine(
+            "com.samsung.health.exercise.start_time," +
+                "com.samsung.health.exercise.end_time," +
+                "com.samsung.health.exercise.exercise_type," +
+                "com.samsung.health.exercise.duration",
+        )
+        rows.forEach { sb.appendLine("${it.start},${it.end},${it.code},${it.durationMs}") }
+        return sb.toString().toByteArray(Charsets.UTF_8)
+    }
+
+    // ── Tests sleep ────────────────────────────────────────────────────────
+
+    @Test
+    fun import_sleep_inserts_rows() = runTest {
+        val csv = sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+            Triple("2026-04-21 23:00:00.000", "2026-04-22 06:45:00.000", "78"),
+        ))
+        val r = service.importSleep(csv)
+        assertEquals(2, r.inserted)
+        assertEquals(0, r.skipped)
+        assertEquals(2, db.sleepDao().countSessions())
+    }
+
+    @Test
+    fun import_sleep_idempotent() = runTest {
+        val csv = sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        ))
+        service.importSleep(csv)
+        val r2 = service.importSleep(csv)
+        assertEquals(0, r2.inserted)
+        assertEquals(1, r2.skipped)
+        assertEquals(1, db.sleepDao().countSessions())
+    }
+
+    @Test
+    fun import_sleep_skips_invalid_dates() = runTest {
+        val csv = sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+            Triple("not-a-date", "2026-04-22 06:45:00.000", "78"),
+        ))
+        val r = service.importSleep(csv)
+        assertEquals(1, r.inserted)
+        assertEquals(1, r.skipped)
+    }
+
+    // ── Tests sleep_stage ──────────────────────────────────────────────────
+
+    @Test
+    fun import_sleep_stage_links_to_existing_session() = runTest {
+        // Pre-condition : 1 session sleep en DB
+        service.importSleep(sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        )))
+        val stagesCsv = sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002), // LIGHT
+            Triple("2026-04-21 00:30:00.000", "2026-04-21 02:00:00.000", 40003), // DEEP
+            Triple("2026-04-21 02:00:00.000", "2026-04-21 03:00:00.000", 40004), // REM
+            Triple("2026-04-21 03:00:00.000", "2026-04-21 07:30:00.000", 40002),
+        ))
+        val r = service.importSleepStages(stagesCsv)
+        assertEquals(4, r.inserted)
+        assertEquals(0, r.skipped)
+        assertEquals(4, db.sleepDao().countStages())
+    }
+
+    @Test
+    fun import_sleep_stage_skips_unknown_code() = runTest {
+        service.importSleep(sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        )))
+        val r = service.importSleepStages(sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002),
+            Triple("2026-04-21 00:30:00.000", "2026-04-21 02:00:00.000", 99999), // unknown
+        )))
+        assertEquals(1, r.inserted)
+        assertEquals(1, r.skipped)
+    }
+
+    @Test
+    fun import_sleep_stage_skips_when_no_parent_session() = runTest {
+        // Pas de session pré-importée
+        val r = service.importSleepStages(sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002),
+        )))
+        assertEquals(0, r.inserted)
+        assertEquals(1, r.skipped)
+    }
+
+    @Test
+    fun import_sleep_stage_idempotent() = runTest {
+        service.importSleep(sleepCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 07:30:00.000", "85"),
+        )))
+        val csv = sleepStageCsv(listOf(
+            Triple("2026-04-20 23:15:00.000", "2026-04-21 00:30:00.000", 40002),
+        ))
+        service.importSleepStages(csv)
+        val r2 = service.importSleepStages(csv)
+        assertEquals(0, r2.inserted)
+        assertEquals(1, r2.skipped)
+    }
+
+    // ── Tests heart_rate ───────────────────────────────────────────────────
+
+    @Test
+    fun import_heart_rate_aggregates_by_hour() = runTest {
+        // 3 samples à 8h, 2 à 9h → 2 enregistrements horaires
+        val csv = heartRateCsv(listOf(
+            Quad("2026-04-20 08:00:00.000", "70", "60", "80"),
+            Quad("2026-04-20 08:15:00.000", "72", "62", "82"),
+            Quad("2026-04-20 08:30:00.000", "74", "64", "84"),
+            Quad("2026-04-20 09:00:00.000", "80", "70", "90"),
+            Quad("2026-04-20 09:30:00.000", "82", "72", "92"),
+        ))
+        val r = service.importHeartRate(csv)
+        assertEquals(2, r.inserted)
+        val all = db.heartRateDao().getAll()
+        assertEquals(2, all.size)
+        val h8 = all.first { it.hour == 8 }
+        assertEquals(72, h8.avgBpm)
+        assertEquals(60, h8.minBpm)
+        assertEquals(84, h8.maxBpm)
+        assertEquals(3, h8.sampleCount)
+    }
+
+    // ── Tests steps ────────────────────────────────────────────────────────
+
+    @Test
+    fun import_steps_uses_day_time_format() = runTest {
+        // day_time est en millis Unix. 2026-04-20 10:00:00 UTC = 1776592800000
+        val csv = stepsCsv(listOf(
+            1776592800000L to 1200,
+            1776596400000L to 800, // 11h
+        ))
+        val r = service.importSteps(csv)
+        assertEquals(2, r.inserted)
+        val all = db.stepsDao().getAll()
+        assertEquals(2, all.size)
+    }
+
+    // ── Tests exercise ─────────────────────────────────────────────────────
+
+    @Test
+    fun import_exercise_maps_known_type() = runTest {
+        val csv = exerciseCsv(listOf(
+            ExRow("2026-04-20 18:00:00.000", "2026-04-20 18:30:00.000", 1001, 1_800_000f),
+        ))
+        val r = service.importExercise(csv)
+        assertEquals(1, r.inserted)
+        val rows = db.exerciseDao().getAll()
+        assertEquals("running", rows.first().exerciseType)
+        assertEquals(30, rows.first().durationMin)
+    }
+
+    @Test
+    fun import_exercise_unknown_type_kept_as_samsung_code() = runTest {
+        val csv = exerciseCsv(listOf(
+            ExRow("2026-04-20 18:00:00.000", "2026-04-20 18:30:00.000", 99999, 1_800_000f),
+        ))
+        service.importExercise(csv)
+        assertEquals("samsung_99999", db.exerciseDao().getAll().first().exerciseType)
+    }
+
+    // ── Tests perf ─────────────────────────────────────────────────────────
+
+    @Test
+    fun import_60k_sleep_stages_under_5_seconds() = runTest {
+        // Crée 1 session qui couvre toute la fenêtre des stages
+        service.importSleep(sleepCsv(listOf(
+            Triple("2023-12-22 00:00:00.000", "2024-12-22 00:00:00.000", "80"),
+        )))
+        // Génère 60k stages contigus d'1 minute chacun
+        val sb = StringBuilder()
+        sb.appendLine("com.samsung.health.sleep_stage,12345,7")
+        sb.appendLine("start_time,end_time,stage")
+        val baseSec = java.time.LocalDateTime.parse("2023-12-22T00:00:00").toEpochSecond(java.time.ZoneOffset.UTC)
+        for (i in 0 until 60_000) {
+            val s = java.time.LocalDateTime.ofEpochSecond(baseSec + i * 60L, 0, java.time.ZoneOffset.UTC)
+            val e = java.time.LocalDateTime.ofEpochSecond(baseSec + (i + 1) * 60L, 0, java.time.ZoneOffset.UTC)
+            val code = listOf(40001, 40002, 40003, 40004)[i % 4]
+            sb.appendLine("${s.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))},${e.format(java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))},$code")
+        }
+        val csv = sb.toString().toByteArray(Charsets.UTF_8)
+
+        val t0 = System.currentTimeMillis()
+        val r = service.importSleepStages(csv)
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(60_000, r.inserted)
+        assertTrue("60k stages took ${elapsed}ms (>15s)", elapsed < 15_000)
+    }
+
+    // ── Bisect helper ──────────────────────────────────────────────────────
+
+    @Test
+    fun bisect_right_matches_python_semantics() {
+        // bisect_right([1, 3, 5, 7], 5) == 3 (insère APRÈS le 5 existant)
+        assertEquals(3, LocalImportService.bisectRight(listOf(1L, 3L, 5L, 7L), 5L))
+        assertEquals(0, LocalImportService.bisectRight(listOf(1L, 3L, 5L), 0L))
+        assertEquals(3, LocalImportService.bisectRight(listOf(1L, 3L, 5L), 100L))
+    }
+
+    private data class Quad(val ts: String, val bpm: String, val min: String, val max: String)
+    private data class ExRow(val start: String, val end: String, val code: Int, val durationMs: Float)
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalImportServiceTest` (class) — lines 15-292
+- `setUp` (function) — lines 21-33
+- `tearDown` (function) — lines 35-38
+- `sleepCsv` (function) — lines 42-52
+- `sleepStageCsv` (function) — lines 54-60
+- `heartRateCsv` (function) — lines 62-73
+- `stepsCsv` (function) — lines 75-81
+- `exerciseCsv` (function) — lines 83-94
+- `import_sleep_inserts_rows` (function) — lines 98-108
+- `import_sleep_idempotent` (function) — lines 110-120
+- `import_sleep_skips_invalid_dates` (function) — lines 122-131
+- `import_sleep_stage_links_to_existing_session` (function) — lines 135-151
+- `import_sleep_stage_skips_unknown_code` (function) — lines 153-164
+- `import_sleep_stage_skips_when_no_parent_session` (function) — lines 166-174
+- `import_sleep_stage_idempotent` (function) — lines 176-188
+- `import_heart_rate_aggregates_by_hour` (function) — lines 192-211
+- `import_steps_uses_day_time_format` (function) — lines 215-226
+- `import_exercise_maps_known_type` (function) — lines 230-240
+- `import_exercise_unknown_type_kept_as_samsung_code` (function) — lines 242-249
+- `import_60k_sleep_stages_under_5_seconds` (function) — lines 253-278
+- `bisect_right_matches_python_semantics` (function) — lines 282-288
+- `Quad` (class) — lines 290-290
+- `ExRow` (class) — lines 291-291

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.md
@@ -1,0 +1,175 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
+git_blob: 954d125ff5e3a0a500d100ac32011089b186670e
+last_synced: '2026-05-09T15:40:18Z'
+loc: 134
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(AndroidJUnit4::class)
+class LocalSleepRepositoryTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var repo: LocalSleepRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        repo = LocalSleepRepository(db.sleepDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun get_all_sessions_when_no_filter() = runTest {
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-21T22:00:00Z", end = "2026-04-22T06:00:00Z")
+
+        val r = repo.getSessions()
+        assertTrue(r.isSuccess)
+        assertEquals(2, r.getOrNull()!!.size)
+    }
+
+    @Test
+    fun get_sessions_in_range_filters_correctly() = runTest {
+        seedSession(start = "2026-04-19T22:00:00Z", end = "2026-04-20T06:00:00Z")
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-25T22:00:00Z", end = "2026-04-26T06:00:00Z")
+
+        // Window [from=2026-04-20, to=2026-04-21] inclus → on attend la session du 20-21
+        // (et celle du 19-20 si son sleep_start tombe dans la fenêtre — non ici)
+        val r = repo.getSessions(from = LocalDate.of(2026, 4, 20), to = LocalDate.of(2026, 4, 21))
+        assertTrue(r.isSuccess)
+        val sessions = r.getOrNull()!!
+        assertEquals(1, sessions.size)
+        assertTrue(sessions.first().sleep_start.startsWith("2026-04-20"))
+    }
+
+    @Test
+    fun stages_are_attached_to_their_session() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:00:00Z", "2026-04-20T23:00:00Z")
+        seedStage(sid, "DEEP", "2026-04-20T23:00:00Z", "2026-04-21T01:00:00Z")
+        seedStage(sid, "REM", "2026-04-21T01:00:00Z", "2026-04-21T03:00:00Z")
+
+        val sessions = repo.getSessions().getOrNull()!!
+        assertEquals(1, sessions.size)
+        val s = sessions.first()
+        assertNotNull(s.stages)
+        assertEquals(3, s.stages!!.size)
+        assertEquals("LIGHT", s.stages.first().stage)
+    }
+
+    @Test
+    fun iso_round_trip_preserves_timestamps() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:30:45Z", end = "2026-04-21T06:15:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:30:45Z", "2026-04-21T00:00:00Z")
+
+        val s = repo.getSessions().getOrNull()!!.first()
+        assertEquals("2026-04-20T22:30:45Z", s.sleep_start)
+        assertEquals("2026-04-21T06:15:00Z", s.sleep_end)
+        val stage = s.stages!!.first()
+        assertEquals("2026-04-20T22:30:45Z", stage.stage_start)
+    }
+
+    @Test
+    fun bulk_load_60k_stages_under_2_seconds() = runTest {
+        // Critère d'acceptation #2 de la spec — Hypnogramme < 200ms en lecture sur device
+        // (Robolectric in-memory ~10x plus lent : seuil large à 5s ici).
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T22:00:00Z")
+        val stages = (0 until 60_000).map { i ->
+            SleepStageEntity(
+                sessionId = sid,
+                stageType = listOf("DEEP", "LIGHT", "REM", "AWAKE")[i % 4],
+                stageStartMs = 1_745_181_600_000L + i * 1_000L,
+                stageEndMs = 1_745_181_600_000L + (i + 1) * 1_000L,
+            )
+        }
+        db.sleepDao().insertStages(stages)
+
+        val t0 = System.currentTimeMillis()
+        val sessions = repo.getSessions().getOrNull()!!
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(1, sessions.size)
+        assertEquals(60_000, sessions.first().stages!!.size)
+        assertTrue("60k stages read took ${elapsed}ms (>5s)", elapsed < 5_000)
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private suspend fun seedSession(start: String, end: String): Long {
+        val s = SleepSessionEntity(sleepStartMs = isoToMs(start), sleepEndMs = isoToMs(end))
+        return db.sleepDao().insertSessions(listOf(s)).first()
+    }
+
+    private suspend fun seedStage(sessionId: Long, type: String, start: String, end: String) {
+        db.sleepDao().insertStages(listOf(
+            SleepStageEntity(
+                sessionId = sessionId,
+                stageType = type,
+                stageStartMs = isoToMs(start),
+                stageEndMs = isoToMs(end),
+            ),
+        ))
+    }
+
+    private fun isoToMs(iso: String): Long = java.time.Instant.parse(iso).toEpochMilli()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalSleepRepositoryTest` (class) — lines 19-134
+- `setUp` (function) — lines 25-32
+- `tearDown` (function) — lines 34-37
+- `get_all_sessions_when_no_filter` (function) — lines 39-47
+- `get_sessions_in_range_filters_correctly` (function) — lines 49-62
+- `stages_are_attached_to_their_session` (function) — lines 64-77
+- `iso_round_trip_preserves_timestamps` (function) — lines 79-89
+- `bulk_load_60k_stages_under_2_seconds` (function) — lines 91-113
+- `seedSession` (function) — lines 117-120
+- `seedStage` (function) — lines 122-131
+- `isoToMs` (function) — lines 133-133


### PR DESCRIPTION
## Phase B de la migration local-first

Suite de la PR #83 (Phase A). Maintenant les imports Samsung Health s'écrivent directement en base Room locale, **plus aucun upload réseau santé**.

## Livrables

### Parsers Kotlin (port de `server/services/csv_import.py`)
- `SamsungCsvParser` — strip BOM UTF-8, ignore commentaires `#`, détecte ligne metadata (`namespace,user_id_int,version`), parse CSV avec gestion quoting RFC 4180 minimal, parse timestamps `yyyy-MM-dd HH:mm:ss[.SSS]`
- `StageMaps` — codes `40001..40004` (sleep stage) + `1001/1002/1007/1008/3000/90001` (exercise) → libellés
- `LocalImportService` (5 méthodes) :
  - `importSleep` — sessions, fields Art.9 stockés en clair (chiffrés au niveau fichier par SQLCipher)
  - `importSleepStages` — bulk-load sessions une fois, `bisect_right` pour trouver la session parente, batch insert
  - `importHeartRate` — agrégation min/max/avg/count par (date, hour) UTC
  - `importSteps` — supporte `day_time` (millis) + fallback `com.samsung.health.step_daily_trend.*`
  - `importExercise` — codes connus mappés, code inconnu → `samsung_<n>` (cohérent avec le serveur)

Toutes les méthodes sont **idempotentes** par construction : Room `OnConflictStrategy.IGNORE` sur les indexes uniques `(start, end)` ou `(date, hour)`.

### Bypass VPS pour les imports
- `ImportRepositoryImpl` reçoit maintenant `LocalImportService` en plus de l'API
- `uploadCsv` (méthode héritée de `ImportRepository`, gardée pour ne pas casser l'UI) délègue au `LocalImportService` selon le type
- L'API reste utilisée uniquement pour `pingBackend()` (check connectivité VPS)
- Aucun appel `api.importSleep / importHeartRate / importSteps / importExercise / importSleepStages` n'est plus émis

### Wiring
- `NavGraph.kt` : compose `LocalImportService` depuis le singleton `NightfallDatabase.get(context)` et l'injecte dans `ImportRepositoryImpl`

## Tests

`LocalImportServiceTest` (Robolectric in-memory) — **13/13 ✓** :

```
import_sleep_inserts_rows
import_sleep_idempotent
import_sleep_skips_invalid_dates
import_sleep_stage_links_to_existing_session
import_sleep_stage_skips_unknown_code
import_sleep_stage_skips_when_no_parent_session
import_sleep_stage_idempotent
import_heart_rate_aggregates_by_hour
import_steps_uses_day_time_format
import_exercise_maps_known_type
import_exercise_unknown_type_kept_as_samsung_code
import_60k_sleep_stages_under_5_seconds  ← garde-fou perf
bisect_right_matches_python_semantics
```

Le test 60k stages valide le critère #1 de la spec — import lourd < 15s en in-memory (= < 5s sur device réel).

## Comparaison comportement vs serveur

| Aspect | Serveur Python | Kotlin local | Match ? |
|---|---|---|---|
| BOM strip | `decode("utf-8-sig")` | `removePrefix(U+FEFF)` | ✓ |
| Skip lignes `#` | `not ln.startswith("#")` | idem | ✓ |
| Skip ligne metadata | `parts[1].isdigit()` | `toIntOrNull() != null` | ✓ |
| Timestamp parse | `strptime "%Y-%m-%d %H:%M:%S[.f]"` | `LocalDateTime.parse` mêmes patterns | ✓ |
| Sleep stage mapping | `40001..40004` | idem (`SLEEP_STAGE_MAP`) | ✓ |
| Sleep session matching | `bisect_right` puis check `sleep_end >= end` | idem | ✓ |
| Idempotence | `ON CONFLICT DO NOTHING` index `(start, end)` | `OnConflictStrategy.IGNORE` index unique | ✓ |
| HR aggregation | min/max/avg/count par `(date, hour)` UTC | idem | ✓ |
| Exercise unknown type | `samsung_<n>` | idem | ✓ |

## Ce que cette PR ne fait PAS

- ❌ Pas de migration des données déjà sur le VPS vers le local (Phase D / re-import manuel)
- ❌ Pas de bascule des **lectures** (Timeline, Hypnogramme) vers le local — elles continuent à lire le VPS pour l'instant (Phase C)
- ❌ Pas de mode "VPS désactivé" complet (Phase D)

**Conséquence pratique post-merge** : un nouvel import écrit en local → les nouveaux stages/sessions ne seront PAS visibles sur la Timeline/Hypnogramme tant que la Phase C n'est pas en place. C'est attendu — la Phase C bascule les lectures.

Pour valider Phase B en isolation : check `adb shell run-as fr.datasaillance.nightfall.debug ls databases/` post-import → présence de `nightfall.db`.

## Test plan post-merge

- [ ] Install APK → import du ZIP Samsung
- [ ] Import doit terminer **bien plus vite** qu'avant (60k stages en quelques secondes vs 30s+ via VPS)
- [ ] `adb shell run-as fr.datasaillance.nightfall.debug ls -l databases/` → `nightfall.db` présent (chiffré SQLCipher)
- [ ] `adb logcat -s OkHttp:V` pendant l'import → **aucun POST** vers `/api/sleep/import*`, `/api/heartrate/import`, `/api/steps/import`, `/api/exercise/import`
- [ ] Timeline/Hypnogramme continuent à afficher les anciennes données du VPS (comportement inchangé jusqu'à Phase C)