### PR TITLE
feat(local): Phase C — LocalSleepRepository reads from Room (Sleep/Hypnogram/Timeline)

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
@@ -1,0 +1,71 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import timber.log.Timber
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Implémentation locale de `SleepRepository` qui lit les données depuis la base
+ * Room SQLCipher au lieu d'appeler le VPS. Phase C de la migration local-first.
+ *
+ * Garde la même signature et les mêmes shapes (`SleepSessionResponse` /
+ * `SleepStageResponse`) que `SleepRepositoryImpl`, donc ViewModels et UI sont
+ * inchangés. Le parent du chargement saisit `from`/`to` comme avant.
+ */
+class LocalSleepRepository(
+    private val sleepDao: SleepDao,
+) : SleepRepository {
+
+    override suspend fun getSessions(
+        from: LocalDate?,
+        to: LocalDate?,
+    ): Result<List<SleepSessionResponse>> = runCatching {
+        val sessions = if (from != null && to != null) {
+            // [from 00:00 UTC, to+1 00:00 UTC) — `to` est inclusif côté API serveur,
+            // on applique le même offset que server/routers/sleep.py:175 (`to + 1d`).
+            val fromMs = from.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            val toMs = to.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            sleepDao.getSessionsInRange(fromMs, toMs)
+        } else {
+            sleepDao.getAllSessions()
+        }
+        Timber.i("local_sleep_sessions count=${sessions.size} from=$from to=$to")
+        if (sessions.isEmpty()) {
+            return@runCatching emptyList<SleepSessionResponse>()
+        }
+        // Charge tous les stages des sessions retournées en 1 requête
+        val ids = sessions.map { it.id }
+        val allStages = sleepDao.getStagesForSessions(ids).groupBy { it.sessionId }
+        sessions.map { session ->
+            session.toResponse(stages = allStages[session.id].orEmpty())
+        }
+    }
+}
+
+internal fun SleepSessionEntity.toResponse(stages: List<SleepStageEntity>): SleepSessionResponse =
+    SleepSessionResponse(
+        id = this.id.toString(),
+        sleep_start = msToIso(this.sleepStartMs),
+        sleep_end = msToIso(this.sleepEndMs),
+        created_at = msToIso(this.createdAtMs),
+        stages = stages.map { it.toResponse() },
+    )
+
+internal fun SleepStageEntity.toResponse(): SleepStageResponse =
+    SleepStageResponse(
+        id = this.id.toString(),
+        session_id = this.sessionId.toString(),
+        stage = this.stageType,
+        stage_start = msToIso(this.stageStartMs),
+        stage_end = msToIso(this.stageEndMs),
+    )
+
+private val ISO_FMT: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+private fun msToIso(ms: Long): String =
+    Instant.ofEpochMilli(ms).atOffset(ZoneOffset.UTC).format(ISO_FMT)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -31,6 +31,7 @@ import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.data.sleep.LocalSleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepositoryImpl
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
@@ -132,12 +133,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Sleep.route) {
-                val sleepRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val sleepRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val sleepViewModel = remember(sleepRepository) { SleepViewModel(sleepRepository) }
                 SleepScreen(
@@ -160,12 +158,9 @@ fun NavGraph(
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
                 val dateArg = backStackEntry.arguments?.getString("date")
-                val hypnogramRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val hypnogramRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
                     HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
@@ -176,12 +171,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Timeline.route) {
-                val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val timelineRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
                 TimelineScreen(

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
@@ -1,0 +1,134 @@
+package fr.datasaillance.nightfall.data.sleep
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(AndroidJUnit4::class)
+class LocalSleepRepositoryTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var repo: LocalSleepRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        repo = LocalSleepRepository(db.sleepDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun get_all_sessions_when_no_filter() = runTest {
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-21T22:00:00Z", end = "2026-04-22T06:00:00Z")
+
+        val r = repo.getSessions()
+        assertTrue(r.isSuccess)
+        assertEquals(2, r.getOrNull()!!.size)
+    }
+
+    @Test
+    fun get_sessions_in_range_filters_correctly() = runTest {
+        seedSession(start = "2026-04-19T22:00:00Z", end = "2026-04-20T06:00:00Z")
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-25T22:00:00Z", end = "2026-04-26T06:00:00Z")
+
+        // Window [from=2026-04-20, to=2026-04-21] inclus → on attend la session du 20-21
+        // (et celle du 19-20 si son sleep_start tombe dans la fenêtre — non ici)
+        val r = repo.getSessions(from = LocalDate.of(2026, 4, 20), to = LocalDate.of(2026, 4, 21))
+        assertTrue(r.isSuccess)
+        val sessions = r.getOrNull()!!
+        assertEquals(1, sessions.size)
+        assertTrue(sessions.first().sleep_start.startsWith("2026-04-20"))
+    }
+
+    @Test
+    fun stages_are_attached_to_their_session() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:00:00Z", "2026-04-20T23:00:00Z")
+        seedStage(sid, "DEEP", "2026-04-20T23:00:00Z", "2026-04-21T01:00:00Z")
+        seedStage(sid, "REM", "2026-04-21T01:00:00Z", "2026-04-21T03:00:00Z")
+
+        val sessions = repo.getSessions().getOrNull()!!
+        assertEquals(1, sessions.size)
+        val s = sessions.first()
+        assertNotNull(s.stages)
+        assertEquals(3, s.stages!!.size)
+        assertEquals("LIGHT", s.stages.first().stage)
+    }
+
+    @Test
+    fun iso_round_trip_preserves_timestamps() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:30:45Z", end = "2026-04-21T06:15:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:30:45Z", "2026-04-21T00:00:00Z")
+
+        val s = repo.getSessions().getOrNull()!!.first()
+        assertEquals("2026-04-20T22:30:45Z", s.sleep_start)
+        assertEquals("2026-04-21T06:15:00Z", s.sleep_end)
+        val stage = s.stages!!.first()
+        assertEquals("2026-04-20T22:30:45Z", stage.stage_start)
+    }
+
+    @Test
+    fun bulk_load_60k_stages_under_2_seconds() = runTest {
+        // Critère d'acceptation #2 de la spec — Hypnogramme < 200ms en lecture sur device
+        // (Robolectric in-memory ~10x plus lent : seuil large à 5s ici).
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T22:00:00Z")
+        val stages = (0 until 60_000).map { i ->
+            SleepStageEntity(
+                sessionId = sid,
+                stageType = listOf("DEEP", "LIGHT", "REM", "AWAKE")[i % 4],
+                stageStartMs = 1_745_181_600_000L + i * 1_000L,
+                stageEndMs = 1_745_181_600_000L + (i + 1) * 1_000L,
+            )
+        }
+        db.sleepDao().insertStages(stages)
+
+        val t0 = System.currentTimeMillis()
+        val sessions = repo.getSessions().getOrNull()!!
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(1, sessions.size)
+        assertEquals(60_000, sessions.first().stages!!.size)
+        assertTrue("60k stages read took ${elapsed}ms (>5s)", elapsed < 5_000)
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private suspend fun seedSession(start: String, end: String): Long {
+        val s = SleepSessionEntity(sleepStartMs = isoToMs(start), sleepEndMs = isoToMs(end))
+        return db.sleepDao().insertSessions(listOf(s)).first()
+    }
+
+    private suspend fun seedStage(sessionId: Long, type: String, start: String, end: String) {
+        db.sleepDao().insertStages(listOf(
+            SleepStageEntity(
+                sessionId = sessionId,
+                stageType = type,
+                stageStartMs = isoToMs(start),
+                stageEndMs = isoToMs(end),
+            ),
+        ))
+    }
+
+    private fun isoToMs(iso: String): Long = java.time.Instant.parse(iso).toEpochMilli()
+}

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.md
@@ -1,0 +1,106 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
+git_blob: 88119451402767cc179160561582bc5d90517c3f
+last_synced: '2026-05-09T15:40:18Z'
+loc: 71
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepository.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import timber.log.Timber
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+
+/**
+ * Implémentation locale de `SleepRepository` qui lit les données depuis la base
+ * Room SQLCipher au lieu d'appeler le VPS. Phase C de la migration local-first.
+ *
+ * Garde la même signature et les mêmes shapes (`SleepSessionResponse` /
+ * `SleepStageResponse`) que `SleepRepositoryImpl`, donc ViewModels et UI sont
+ * inchangés. Le parent du chargement saisit `from`/`to` comme avant.
+ */
+class LocalSleepRepository(
+    private val sleepDao: SleepDao,
+) : SleepRepository {
+
+    override suspend fun getSessions(
+        from: LocalDate?,
+        to: LocalDate?,
+    ): Result<List<SleepSessionResponse>> = runCatching {
+        val sessions = if (from != null && to != null) {
+            // [from 00:00 UTC, to+1 00:00 UTC) — `to` est inclusif côté API serveur,
+            // on applique le même offset que server/routers/sleep.py:175 (`to + 1d`).
+            val fromMs = from.atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            val toMs = to.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            sleepDao.getSessionsInRange(fromMs, toMs)
+        } else {
+            sleepDao.getAllSessions()
+        }
+        Timber.i("local_sleep_sessions count=${sessions.size} from=$from to=$to")
+        if (sessions.isEmpty()) {
+            return@runCatching emptyList<SleepSessionResponse>()
+        }
+        // Charge tous les stages des sessions retournées en 1 requête
+        val ids = sessions.map { it.id }
+        val allStages = sleepDao.getStagesForSessions(ids).groupBy { it.sessionId }
+        sessions.map { session ->
+            session.toResponse(stages = allStages[session.id].orEmpty())
+        }
+    }
+}
+
+internal fun SleepSessionEntity.toResponse(stages: List<SleepStageEntity>): SleepSessionResponse =
+    SleepSessionResponse(
+        id = this.id.toString(),
+        sleep_start = msToIso(this.sleepStartMs),
+        sleep_end = msToIso(this.sleepEndMs),
+        created_at = msToIso(this.createdAtMs),
+        stages = stages.map { it.toResponse() },
+    )
+
+internal fun SleepStageEntity.toResponse(): SleepStageResponse =
+    SleepStageResponse(
+        id = this.id.toString(),
+        session_id = this.sessionId.toString(),
+        stage = this.stageType,
+        stage_start = msToIso(this.stageStartMs),
+        stage_end = msToIso(this.stageEndMs),
+    )
+
+private val ISO_FMT: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
+
+private fun msToIso(ms: Long): String =
+    Instant.ofEpochMilli(ms).atOffset(ZoneOffset.UTC).format(ISO_FMT)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalSleepRepository` (class) — lines 20-48
+- `getSessions` (function) — lines 24-47
+- `toResponse` (function) — lines 50-57
+- `toResponse` (function) — lines 59-66
+- `msToIso` (function) — lines 70-71

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: b5c61b0e553fa384e12580a1ca86cb747d81511c
-last_synced: '2026-05-09T15:32:55Z'
-loc: 291
+git_blob: ff170b96fa6cb0bdb055869f24961d25422661ff
+last_synced: '2026-05-09T15:40:18Z'
+loc: 283
 annotations: []
 imports: []
 exports: []
@@ -54,6 +54,7 @@ import fr.datasaillance.nightfall.data.http.StatusResponse
 import fr.datasaillance.nightfall.data.import_.CsvEntry
 import fr.datasaillance.nightfall.data.import_.ImportRepository
 import fr.datasaillance.nightfall.data.import_.ImportRepositoryImpl
+import fr.datasaillance.nightfall.data.sleep.LocalSleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepRepositoryImpl
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
@@ -155,12 +156,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Sleep.route) {
-                val sleepRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val sleepRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val sleepViewModel = remember(sleepRepository) { SleepViewModel(sleepRepository) }
                 SleepScreen(
@@ -183,12 +181,9 @@ fun NavGraph(
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
                 val dateArg = backStackEntry.arguments?.getString("date")
-                val hypnogramRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val hypnogramRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
                     HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
@@ -199,12 +194,9 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Timeline.route) {
-                val timelineRepository: SleepRepository = remember(api, tokenDataStore) {
-                    if (api != null && tokenDataStore != null) {
-                        SleepRepositoryImpl(api, tokenDataStore)
-                    } else {
-                        NoOpSleepRepository()
-                    }
+                val timelineRepository: SleepRepository = remember(context) {
+                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                    LocalSleepRepository(db.sleepDao())
                 }
                 val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
                 TimelineScreen(
@@ -319,23 +311,23 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 57-237
-- `NoOpSleepRepository` (class) — lines 239-244
-- `getSessions` (function) — lines 240-243
-- `NoOpImportRepository` (class) — lines 246-261
-- `pingBackend` (function) — lines 247-247
-- `extractCsvEntries` (function) — lines 249-252
-- `uploadCsv` (function) — lines 254-260
-- `NoOpNightfallApi` (class) — lines 263-275
-- `health` (function) — lines 264-264
-- `login` (function) — lines 265-265
-- `register` (function) — lines 266-266
-- `requestPasswordReset` (function) — lines 267-267
-- `googleStart` (function) — lines 268-268
-- `getSleepSessions` (function) — lines 269-269
-- `importSleep` (function) — lines 270-270
-- `importHeartRate` (function) — lines 271-271
-- `importSteps` (function) — lines 272-272
-- `importExercise` (function) — lines 273-273
-- `importSleepStages` (function) — lines 274-274
-- `ensureComposeNavigators` (function) — lines 283-291
+- `NavGraph` (function) — lines 58-229
+- `NoOpSleepRepository` (class) — lines 231-236
+- `getSessions` (function) — lines 232-235
+- `NoOpImportRepository` (class) — lines 238-253
+- `pingBackend` (function) — lines 239-239
+- `extractCsvEntries` (function) — lines 241-244
+- `uploadCsv` (function) — lines 246-252
+- `NoOpNightfallApi` (class) — lines 255-267
+- `health` (function) — lines 256-256
+- `login` (function) — lines 257-257
+- `register` (function) — lines 258-258
+- `requestPasswordReset` (function) — lines 259-259
+- `googleStart` (function) — lines 260-260
+- `getSleepSessions` (function) — lines 261-261
+- `importSleep` (function) — lines 262-262
+- `importHeartRate` (function) — lines 263-263
+- `importSteps` (function) — lines 264-264
+- `importExercise` (function) — lines 265-265
+- `importSleepStages` (function) — lines 266-266
+- `ensureComposeNavigators` (function) — lines 275-283

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.md
@@ -1,0 +1,175 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
+git_blob: 954d125ff5e3a0a500d100ac32011089b186670e
+last_synced: '2026-05-09T15:40:18Z'
+loc: 134
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/sleep/LocalSleepRepositoryTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.sleep
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
+import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(AndroidJUnit4::class)
+class LocalSleepRepositoryTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var repo: LocalSleepRepository
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        repo = LocalSleepRepository(db.sleepDao())
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun get_all_sessions_when_no_filter() = runTest {
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-21T22:00:00Z", end = "2026-04-22T06:00:00Z")
+
+        val r = repo.getSessions()
+        assertTrue(r.isSuccess)
+        assertEquals(2, r.getOrNull()!!.size)
+    }
+
+    @Test
+    fun get_sessions_in_range_filters_correctly() = runTest {
+        seedSession(start = "2026-04-19T22:00:00Z", end = "2026-04-20T06:00:00Z")
+        seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedSession(start = "2026-04-25T22:00:00Z", end = "2026-04-26T06:00:00Z")
+
+        // Window [from=2026-04-20, to=2026-04-21] inclus → on attend la session du 20-21
+        // (et celle du 19-20 si son sleep_start tombe dans la fenêtre — non ici)
+        val r = repo.getSessions(from = LocalDate.of(2026, 4, 20), to = LocalDate.of(2026, 4, 21))
+        assertTrue(r.isSuccess)
+        val sessions = r.getOrNull()!!
+        assertEquals(1, sessions.size)
+        assertTrue(sessions.first().sleep_start.startsWith("2026-04-20"))
+    }
+
+    @Test
+    fun stages_are_attached_to_their_session() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T06:00:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:00:00Z", "2026-04-20T23:00:00Z")
+        seedStage(sid, "DEEP", "2026-04-20T23:00:00Z", "2026-04-21T01:00:00Z")
+        seedStage(sid, "REM", "2026-04-21T01:00:00Z", "2026-04-21T03:00:00Z")
+
+        val sessions = repo.getSessions().getOrNull()!!
+        assertEquals(1, sessions.size)
+        val s = sessions.first()
+        assertNotNull(s.stages)
+        assertEquals(3, s.stages!!.size)
+        assertEquals("LIGHT", s.stages.first().stage)
+    }
+
+    @Test
+    fun iso_round_trip_preserves_timestamps() = runTest {
+        val sid = seedSession(start = "2026-04-20T22:30:45Z", end = "2026-04-21T06:15:00Z")
+        seedStage(sid, "LIGHT", "2026-04-20T22:30:45Z", "2026-04-21T00:00:00Z")
+
+        val s = repo.getSessions().getOrNull()!!.first()
+        assertEquals("2026-04-20T22:30:45Z", s.sleep_start)
+        assertEquals("2026-04-21T06:15:00Z", s.sleep_end)
+        val stage = s.stages!!.first()
+        assertEquals("2026-04-20T22:30:45Z", stage.stage_start)
+    }
+
+    @Test
+    fun bulk_load_60k_stages_under_2_seconds() = runTest {
+        // Critère d'acceptation #2 de la spec — Hypnogramme < 200ms en lecture sur device
+        // (Robolectric in-memory ~10x plus lent : seuil large à 5s ici).
+        val sid = seedSession(start = "2026-04-20T22:00:00Z", end = "2026-04-21T22:00:00Z")
+        val stages = (0 until 60_000).map { i ->
+            SleepStageEntity(
+                sessionId = sid,
+                stageType = listOf("DEEP", "LIGHT", "REM", "AWAKE")[i % 4],
+                stageStartMs = 1_745_181_600_000L + i * 1_000L,
+                stageEndMs = 1_745_181_600_000L + (i + 1) * 1_000L,
+            )
+        }
+        db.sleepDao().insertStages(stages)
+
+        val t0 = System.currentTimeMillis()
+        val sessions = repo.getSessions().getOrNull()!!
+        val elapsed = System.currentTimeMillis() - t0
+
+        assertEquals(1, sessions.size)
+        assertEquals(60_000, sessions.first().stages!!.size)
+        assertTrue("60k stages read took ${elapsed}ms (>5s)", elapsed < 5_000)
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private suspend fun seedSession(start: String, end: String): Long {
+        val s = SleepSessionEntity(sleepStartMs = isoToMs(start), sleepEndMs = isoToMs(end))
+        return db.sleepDao().insertSessions(listOf(s)).first()
+    }
+
+    private suspend fun seedStage(sessionId: Long, type: String, start: String, end: String) {
+        db.sleepDao().insertStages(listOf(
+            SleepStageEntity(
+                sessionId = sessionId,
+                stageType = type,
+                stageStartMs = isoToMs(start),
+                stageEndMs = isoToMs(end),
+            ),
+        ))
+    }
+
+    private fun isoToMs(iso: String): Long = java.time.Instant.parse(iso).toEpochMilli()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalSleepRepositoryTest` (class) — lines 19-134
+- `setUp` (function) — lines 25-32
+- `tearDown` (function) — lines 34-37
+- `get_all_sessions_when_no_filter` (function) — lines 39-47
+- `get_sessions_in_range_filters_correctly` (function) — lines 49-62
+- `stages_are_attached_to_their_session` (function) — lines 64-77
+- `iso_round_trip_preserves_timestamps` (function) — lines 79-89
+- `bulk_load_60k_stages_under_2_seconds` (function) — lines 91-113
+- `seedSession` (function) — lines 117-120
+- `seedStage` (function) — lines 122-131
+- `isoToMs` (function) — lines 133-133


### PR DESCRIPTION
## Phase C de la migration local-first

Empile sur PR #84 (Phase B). À merger **après** B.

À la fin de cette phase, **aucun écran ne lit le VPS pour les données sommeil**. La C1 (« Local-first absolu ») est techniquement atteinte pour le scope sommeil.

## Livrables

### `LocalSleepRepository`
Implémente `SleepRepository` (signature inchangée) en lisant depuis Room :
- `getSessions(from, to)` → `SleepDao.getSessionsInRange(fromMs, toMs)` (semantique `[from 00:00 UTC, to+1 00:00 UTC)` cohérente avec `server/routers/sleep.py:175`)
- `getSessions()` (sans filtre) → `getAllSessions()`
- Charge tous les stages des sessions retournées en **1 seule** requête `getStagesForSessions(ids)` (vs 1 par session côté backend Python avec `selectinload`)
- Mapping entité Room → DTO existant (`SleepSessionResponse` / `SleepStageResponse`) — UI inchangée

### Wiring NavGraph
3 composables bascule sur `LocalSleepRepository` :
- `Sleep` (SleepScreen)
- `Hypnogram` (HypnogramScreen)
- `Timeline` (TimelineScreen)

`SleepRepositoryImpl` (VPS) reste compilé mais n'est plus instancié — supprimable en Phase D.

## Tests

`LocalSleepRepositoryTest` — **5/5 ✓** :
- Lecture all sessions sans filtre
- Filtre `from`/`to` correct (cohérent avec server)
- Stages bien attachés à leur session
- Round-trip ms ↔ ISO 8601 sans perte
- **Garde-fou perf** : 60 000 stages lus en in-memory < 5s (objectif device < 200ms cf. spec)

## Comportement post-merge

- ✅ **Nouveaux imports** (Phase B) → visibles immédiatement dans Sleep/Hypnogram/Timeline (lecture locale)
- ⚠️ **Anciennes données VPS** → invisibles tant qu'elles ne sont pas ré-importées localement. Les sessions du VPS ont des UUIDs alors que Room génère des Long IDs ; pas de migration automatique en Phase C.

**Plan de transition** : l'utilisateur ré-importe son ZIP Samsung Health après upgrade pour repeupler la DB locale. Phase D (à venir) ajoutera optionnellement un mode "désactiver VPS" ou "exporter VPS → import local".

## Test plan post-merge

- [ ] Importer le ZIP Samsung depuis Android (Phase B écrit en local)
- [ ] Ouvrir Timeline → sessions visibles depuis le local
- [ ] Tap sur une nuit → bottom sheet → tap "Hypnogramme" → ouverture en < 1s (vs le 30s d'origine via VPS)
- [ ] `adb logcat -s OkHttp:V` pendant Sleep/Timeline/Hypnogram → **aucun GET** vers `/api/sleep`
- [ ] Hypnogramme du device avec 60k+ stages → fluide

## Diff par fichier
- `data/sleep/LocalSleepRepository.kt` — nouvelle impl (+86 lignes)
- `data/sleep/SleepRepository.kt` — pas touché (interface stable)
- `data/sleep/SleepRepositoryImpl.kt` — pas touché (déprecié de fait, suppression en D)
- `ui/navigation/NavGraph.kt` — 3 wirings remplacés, suppression des refs `SleepRepositoryImpl(api, tokenDataStore)`
- `test/.../LocalSleepRepositoryTest.kt` — 5 tests