### PR TITLE
feat(gps): import Google Takeout + map OSMDroid + badge timeline (DB v3->v4)

### DIFF
--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -113,6 +113,9 @@ dependencies {
     // WorkManager — Phase B_us : collecte UsageStats quotidienne en background
     implementation("androidx.work:work-runtime-ktx:2.10.0")
 
+    // OSMDroid — carte OpenStreetMap embedded (Phase C_gps, raster tiles, no API key)
+    implementation("org.osmdroid:osmdroid-android:6.1.20")
+
     // Test dependencies
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.hamcrest:hamcrest:2.2")

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <!-- Phase A_us — collecte UsageStats local-first.
          Permission appop : doit être activée manuellement par l'utilisateur via

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
@@ -31,6 +31,10 @@ interface LocationDao {
     @Query("SELECT activity_type, COUNT(*) as cnt FROM activity_segments GROUP BY activity_type ORDER BY cnt DESC")
     suspend fun getActivityTypeBreakdown(): List<ActivityTypeCount>
 
+    /** Pour le badge "sorti du domicile" — retourne tous les start_ms d'activities dans la plage. */
+    @Query("SELECT DISTINCT start_ms FROM activity_segments WHERE start_ms >= :fromMs AND start_ms < :toMs")
+    suspend fun getActivityStartTimesInRange(fromMs: Long, toMs: Long): List<Long>
+
     @Query("SELECT COUNT(*) FROM location_visits")
     suspend fun countVisits(): Int
 

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 
 @Dao
@@ -46,6 +47,20 @@ interface LocationDao {
 
     @Query("DELETE FROM activity_segments")
     suspend fun deleteAllSegments()
+
+    // --- Paths GPS (timelinePath du nouveau format Google) ---
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertPaths(rows: List<LocationPathEntity>): List<Long>
+
+    @Query("SELECT * FROM location_paths WHERE start_ms >= :fromMs AND start_ms < :toMs ORDER BY start_ms ASC")
+    suspend fun getPathsInRange(fromMs: Long, toMs: Long): List<LocationPathEntity>
+
+    @Query("SELECT COUNT(*) FROM location_paths")
+    suspend fun countPaths(): Int
+
+    @Query("DELETE FROM location_paths")
+    suspend fun deleteAllPaths()
 }
 
 data class ActivityTypeCount(

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
@@ -1,0 +1,50 @@
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+
+@Dao
+interface LocationDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertVisits(rows: List<LocationVisitEntity>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSegments(rows: List<ActivitySegmentEntity>): List<Long>
+
+    @Query("SELECT * FROM location_visits ORDER BY start_ms ASC")
+    suspend fun getAllVisits(): List<LocationVisitEntity>
+
+    @Query("SELECT * FROM location_visits WHERE start_ms >= :fromMs AND start_ms < :toMs ORDER BY start_ms ASC")
+    suspend fun getVisitsInRange(fromMs: Long, toMs: Long): List<LocationVisitEntity>
+
+    @Query("SELECT * FROM activity_segments ORDER BY start_ms ASC")
+    suspend fun getAllSegments(): List<ActivitySegmentEntity>
+
+    @Query("SELECT * FROM activity_segments WHERE start_ms >= :fromMs AND start_ms < :toMs ORDER BY start_ms ASC")
+    suspend fun getSegmentsInRange(fromMs: Long, toMs: Long): List<ActivitySegmentEntity>
+
+    @Query("SELECT activity_type, COUNT(*) as cnt FROM activity_segments GROUP BY activity_type ORDER BY cnt DESC")
+    suspend fun getActivityTypeBreakdown(): List<ActivityTypeCount>
+
+    @Query("SELECT COUNT(*) FROM location_visits")
+    suspend fun countVisits(): Int
+
+    @Query("SELECT COUNT(*) FROM activity_segments")
+    suspend fun countSegments(): Int
+
+    @Query("DELETE FROM location_visits")
+    suspend fun deleteAllVisits()
+
+    @Query("DELETE FROM activity_segments")
+    suspend fun deleteAllSegments()
+}
+
+data class ActivityTypeCount(
+    @androidx.room.ColumnInfo(name = "activity_type") val activityType: String,
+    val cnt: Int,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
@@ -19,6 +19,7 @@ import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
 import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
 import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
 import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
@@ -33,8 +34,9 @@ import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
         UsageDailyEntity::class,       // v2 — Phase A_us usage stats
         LocationVisitEntity::class,    // v3 — Phase A_gps location visits
         ActivitySegmentEntity::class,  // v3 — Phase A_gps activity segments
+        LocationPathEntity::class,     // v4 — timelinePath waypoints GPS (trajets réalistes)
     ],
-    version = 3,
+    version = 4,
     exportSchema = false,
 )
 abstract class NightfallDatabase : RoomDatabase() {
@@ -72,9 +74,8 @@ abstract class NightfallDatabase : RoomDatabase() {
 
     /**
      * Migration v2 → v3 : ajoute les tables `location_visits` + `activity_segments`
-     * (Phase A_gps). Convergence post-merge des branches feat/usage-stats-collector
-     * et feat/gps-collector — la v2 était usage_daily, on continue avec les tables
-     * location en v3.
+     * (Phase A_gps). Convergence post-merge des 2 branches long-lived — la v2
+     * était usage_daily, on continue avec les tables location en v3.
      */
     object Migration2to3 : Migration(2, 3) {
         override fun migrate(db: SupportSQLiteDatabase) {
@@ -125,6 +126,30 @@ abstract class NightfallDatabase : RoomDatabase() {
         }
     }
 
+    /**
+     * Migration v3 → v4 : ajoute la table `location_paths` pour stocker les waypoints
+     * `timelinePath` du nouveau format Google Takeout (trajets GPS détaillés).
+     */
+    object Migration3to4 : Migration(3, 4) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `location_paths` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `start_ms` INTEGER NOT NULL,
+                    `end_ms` INTEGER NOT NULL,
+                    `points_json` TEXT NOT NULL,
+                    `point_count` INTEGER NOT NULL,
+                    `source` TEXT NOT NULL DEFAULT 'takeout',
+                    `imported_at_ms` INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_location_paths_start_ms_end_ms` ON `location_paths` (`start_ms`, `end_ms`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_location_paths_start_ms` ON `location_paths` (`start_ms`)")
+        }
+    }
+
     companion object {
         private const val DB_NAME = "nightfall.db"
 
@@ -151,7 +176,7 @@ abstract class NightfallDatabase : RoomDatabase() {
                 DB_NAME,
             )
                 .openHelperFactory(factory)
-                .addMigrations(Migration1to2, Migration2to3)
+                .addMigrations(Migration1to2, Migration2to3, Migration3to4)
                 // Fallback safety : si une migration future foire ou si l'utilisateur
                 // a une DB v0 inattendue, on rebuild from scratch plutôt que crasher.
                 .fallbackToDestructiveMigration()

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
@@ -9,6 +9,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
 import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
 import fr.datasaillance.nightfall.data.local.dao.SleepDao
 import fr.datasaillance.nightfall.data.local.dao.StepsDao
 import fr.datasaillance.nightfall.data.local.dao.UsageStatsDao
@@ -17,6 +18,8 @@ import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
 import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
 import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
 import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
 import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
 
@@ -27,9 +30,11 @@ import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
         HeartRateHourlyEntity::class,
         StepsHourlyEntity::class,
         ExerciseSessionEntity::class,
-        UsageDailyEntity::class, // v2 — Phase A_us usage stats
+        UsageDailyEntity::class,       // v2 — Phase A_us usage stats
+        LocationVisitEntity::class,    // v3 — Phase A_gps location visits
+        ActivitySegmentEntity::class,  // v3 — Phase A_gps activity segments
     ],
-    version = 2,
+    version = 3,
     exportSchema = false,
 )
 abstract class NightfallDatabase : RoomDatabase() {
@@ -39,6 +44,7 @@ abstract class NightfallDatabase : RoomDatabase() {
     abstract fun stepsDao(): StepsDao
     abstract fun exerciseDao(): ExerciseDao
     abstract fun usageStatsDao(): UsageStatsDao
+    abstract fun locationDao(): LocationDao
 
     /** Migration v1 → v2 : ajoute la table `usage_daily` (Phase A_us). */
     object Migration1to2 : Migration(1, 2) {
@@ -61,6 +67,61 @@ abstract class NightfallDatabase : RoomDatabase() {
             db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_usage_daily_date_package_name` ON `usage_daily` (`date`, `package_name`)")
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_usage_daily_date` ON `usage_daily` (`date`)")
             db.execSQL("CREATE INDEX IF NOT EXISTS `index_usage_daily_package_name` ON `usage_daily` (`package_name`)")
+        }
+    }
+
+    /**
+     * Migration v2 → v3 : ajoute les tables `location_visits` + `activity_segments`
+     * (Phase A_gps). Convergence post-merge des branches feat/usage-stats-collector
+     * et feat/gps-collector — la v2 était usage_daily, on continue avec les tables
+     * location en v3.
+     */
+    object Migration2to3 : Migration(2, 3) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            // location_visits
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `location_visits` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `start_ms` INTEGER NOT NULL,
+                    `end_ms` INTEGER NOT NULL,
+                    `lat` REAL NOT NULL,
+                    `lng` REAL NOT NULL,
+                    `place_id` TEXT,
+                    `place_name` TEXT,
+                    `address` TEXT,
+                    `confidence` TEXT,
+                    `source` TEXT NOT NULL DEFAULT 'takeout',
+                    `imported_at_ms` INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_location_visits_start_ms_end_ms_lat_lng` ON `location_visits` (`start_ms`, `end_ms`, `lat`, `lng`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_location_visits_start_ms` ON `location_visits` (`start_ms`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_location_visits_place_id` ON `location_visits` (`place_id`)")
+
+            // activity_segments
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `activity_segments` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `start_ms` INTEGER NOT NULL,
+                    `end_ms` INTEGER NOT NULL,
+                    `start_lat` REAL NOT NULL,
+                    `start_lng` REAL NOT NULL,
+                    `end_lat` REAL NOT NULL,
+                    `end_lng` REAL NOT NULL,
+                    `activity_type` TEXT NOT NULL,
+                    `distance_m` INTEGER,
+                    `confidence` TEXT,
+                    `source` TEXT NOT NULL DEFAULT 'takeout',
+                    `imported_at_ms` INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_activity_segments_start_ms_end_ms_activity_type` ON `activity_segments` (`start_ms`, `end_ms`, `activity_type`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_activity_segments_start_ms` ON `activity_segments` (`start_ms`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_activity_segments_activity_type` ON `activity_segments` (`activity_type`)")
         }
     }
 
@@ -90,7 +151,7 @@ abstract class NightfallDatabase : RoomDatabase() {
                 DB_NAME,
             )
                 .openHelperFactory(factory)
-                .addMigrations(Migration1to2)
+                .addMigrations(Migration1to2, Migration2to3)
                 // Fallback safety : si une migration future foire ou si l'utilisateur
                 // a une DB v0 inattendue, on rebuild from scratch plutôt que crasher.
                 .fallbackToDestructiveMigration()

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.kt
@@ -1,0 +1,39 @@
+package fr.datasaillance.nightfall.data.local.entity.location
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Segment d'activité : Google Maps Timeline `activitySegment`. Trajet entre 2 visites
+ * (marche, voiture, vélo, transport en commun, etc.).
+ */
+@Entity(
+    tableName = "activity_segments",
+    indices = [
+        Index(value = ["start_ms", "end_ms", "activity_type"], unique = true),
+        Index("start_ms"),
+        Index("activity_type"),
+    ],
+)
+data class ActivitySegmentEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+
+    @ColumnInfo(name = "start_ms") val startMs: Long,
+    @ColumnInfo(name = "end_ms") val endMs: Long,
+
+    @ColumnInfo(name = "start_lat") val startLat: Double,
+    @ColumnInfo(name = "start_lng") val startLng: Double,
+    @ColumnInfo(name = "end_lat") val endLat: Double,
+    @ColumnInfo(name = "end_lng") val endLng: Double,
+
+    /** Valeurs Google : WALKING, RUNNING, CYCLING, IN_PASSENGER_VEHICLE, IN_BUS, IN_SUBWAY, FLYING, etc. */
+    @ColumnInfo(name = "activity_type") val activityType: String,
+
+    @ColumnInfo(name = "distance_m") val distanceMeters: Int? = null,
+    val confidence: String? = null,
+    val source: String = "takeout",
+    @ColumnInfo(name = "imported_at_ms") val importedAtMs: Long = System.currentTimeMillis(),
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.kt
@@ -1,0 +1,47 @@
+package fr.datasaillance.nightfall.data.local.entity.location
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Chemin GPS détaillé (Google Takeout `timelinePath`). Contient une suite de waypoints
+ * `{lat, lng, t}` qui permet de tracer la trajectoire réelle au lieu d'un trait
+ * vol d'oiseau.
+ *
+ * Volume typique : ~10 waypoints par path, ~1000 paths pour 3 ans d'historique → 10k points
+ * → JSON < 1 MB → OK pour stockage Room.
+ *
+ * `points_json` = `[{"lat":45.527,"lng":4.878,"t":1708347000000}, ...]` (epoch ms).
+ */
+@Entity(
+    tableName = "location_paths",
+    indices = [
+        Index(value = ["start_ms", "end_ms"], unique = true),
+        Index("start_ms"),
+    ],
+)
+data class LocationPathEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+
+    @ColumnInfo(name = "start_ms") val startMs: Long,
+    @ColumnInfo(name = "end_ms") val endMs: Long,
+
+    /** JSON sérialisé des waypoints. Voir [LocationPathPoint] pour le schéma. */
+    @ColumnInfo(name = "points_json") val pointsJson: String,
+
+    /** Nombre de waypoints (dénormalisé pour filtrage rapide sans parser le JSON). */
+    @ColumnInfo(name = "point_count") val pointCount: Int,
+
+    val source: String = "takeout",
+    @ColumnInfo(name = "imported_at_ms") val importedAtMs: Long = System.currentTimeMillis(),
+)
+
+/** Schéma d'un waypoint sérialisé dans `points_json`. */
+data class LocationPathPoint(
+    val lat: Double,
+    val lng: Double,
+    val t: Long,
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.kt
@@ -1,0 +1,44 @@
+package fr.datasaillance.nightfall.data.local.entity.location
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Visite : Google Maps Timeline `placeVisit`. POI ou lieu où l'utilisateur est resté
+ * un temps significatif.
+ *
+ * Coordonnées en degrés décimaux (Google exporte en E7 = degrés × 1e7, on convertit).
+ * Timestamps en epoch millis UTC.
+ */
+@Entity(
+    tableName = "location_visits",
+    indices = [
+        Index(value = ["start_ms", "end_ms", "lat", "lng"], unique = true),
+        Index("start_ms"),
+        Index("place_id"),
+    ],
+)
+data class LocationVisitEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+
+    @ColumnInfo(name = "start_ms") val startMs: Long,
+    @ColumnInfo(name = "end_ms") val endMs: Long,
+
+    val lat: Double,
+    val lng: Double,
+
+    @ColumnInfo(name = "place_id") val placeId: String? = null,
+    @ColumnInfo(name = "place_name") val placeName: String? = null,
+    val address: String? = null,
+
+    /** "HIGH_CONFIDENCE" / "MEDIUM_CONFIDENCE" / "LOW_CONFIDENCE" / null. */
+    val confidence: String? = null,
+
+    /** Source : "takeout" en Phase A_gps, "live" en Phase B_gps. Permet futur cross-check. */
+    val source: String = "takeout",
+
+    @ColumnInfo(name = "imported_at_ms") val importedAtMs: Long = System.currentTimeMillis(),
+)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
@@ -11,6 +11,8 @@ data class LocationImportResult(
     val visitsSkipped: Int,
     val segmentsInserted: Int,
     val segmentsSkipped: Int,
+    val pathsInserted: Int = 0,
+    val pathsSkipped: Int = 0,
     val filesProcessed: Int,
 )
 
@@ -32,13 +34,17 @@ class LocalLocationImportService(
         val parsed = TakeoutTimelineParser.parse(rawJson)
         val visitIds = if (parsed.visits.isNotEmpty()) dao.insertVisits(parsed.visits) else emptyList()
         val segmentIds = if (parsed.segments.isNotEmpty()) dao.insertSegments(parsed.segments) else emptyList()
+        val pathIds = if (parsed.paths.isNotEmpty()) dao.insertPaths(parsed.paths) else emptyList()
         val visitsInserted = visitIds.count { it != -1L }
         val segmentsInserted = segmentIds.count { it != -1L }
+        val pathsInserted = pathIds.count { it != -1L }
         return LocationImportResult(
             visitsInserted = visitsInserted,
             visitsSkipped = parsed.visits.size - visitsInserted,
             segmentsInserted = segmentsInserted,
             segmentsSkipped = parsed.segments.size - segmentsInserted,
+            pathsInserted = pathsInserted,
+            pathsSkipped = parsed.paths.size - pathsInserted,
             filesProcessed = 1,
         )
     }
@@ -54,6 +60,8 @@ class LocalLocationImportService(
         var visitsSkipped = 0
         var segmentsInserted = 0
         var segmentsSkipped = 0
+        var pathsInserted = 0
+        var pathsSkipped = 0
         var filesProcessed = 0
 
         ZipInputStream(input).use { zis ->
@@ -76,6 +84,8 @@ class LocalLocationImportService(
                     visitsSkipped += r.visitsSkipped
                     segmentsInserted += r.segmentsInserted
                     segmentsSkipped += r.segmentsSkipped
+                    pathsInserted += r.pathsInserted
+                    pathsSkipped += r.pathsSkipped
                     filesProcessed++
                 }
                 zis.closeEntry()
@@ -87,6 +97,8 @@ class LocalLocationImportService(
             visitsSkipped = visitsSkipped,
             segmentsInserted = segmentsInserted,
             segmentsSkipped = segmentsSkipped,
+            pathsInserted = pathsInserted,
+            pathsSkipped = pathsSkipped,
             filesProcessed = filesProcessed,
         )
     }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
@@ -1,0 +1,103 @@
+package fr.datasaillance.nightfall.data.local.location
+
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.zip.ZipInputStream
+
+data class LocationImportResult(
+    val visitsInserted: Int,
+    val visitsSkipped: Int,
+    val segmentsInserted: Int,
+    val segmentsSkipped: Int,
+    val filesProcessed: Int,
+)
+
+/**
+ * Importe les fichiers Google Takeout "Semantic Location History" en Room locale.
+ *
+ * Pipeline : `bytes (JSON ou ZIP) → parse → bulk insert Room (idempotent)`.
+ *
+ * - Idempotent par construction : indices uniques `(start_ms, end_ms, lat, lng)` pour
+ *   visits et `(start_ms, end_ms, activity_type)` pour segments + OnConflictStrategy.IGNORE.
+ * - Aucun appel réseau, aucune transmission externe.
+ */
+class LocalLocationImportService(
+    private val dao: LocationDao,
+) {
+
+    /** Import d'un seul fichier JSON Semantic Location History. */
+    suspend fun importJson(rawJson: String): LocationImportResult {
+        val parsed = TakeoutTimelineParser.parse(rawJson)
+        val visitIds = if (parsed.visits.isNotEmpty()) dao.insertVisits(parsed.visits) else emptyList()
+        val segmentIds = if (parsed.segments.isNotEmpty()) dao.insertSegments(parsed.segments) else emptyList()
+        val visitsInserted = visitIds.count { it != -1L }
+        val segmentsInserted = segmentIds.count { it != -1L }
+        return LocationImportResult(
+            visitsInserted = visitsInserted,
+            visitsSkipped = parsed.visits.size - visitsInserted,
+            segmentsInserted = segmentsInserted,
+            segmentsSkipped = parsed.segments.size - segmentsInserted,
+            filesProcessed = 1,
+        )
+    }
+
+    /**
+     * Import d'un ZIP Takeout. Cherche tous les `.json` dans le ZIP qui ressemblent
+     * à du Semantic Location History (chemin contient "Semantic Location History"
+     * ou nom de fichier en `<année>_<mois>.json`).
+     */
+    suspend fun importZip(input: InputStream, maxBytes: Long = 500_000_000L): LocationImportResult {
+        var totalUncompressed = 0L
+        var visitsInserted = 0
+        var visitsSkipped = 0
+        var segmentsInserted = 0
+        var segmentsSkipped = 0
+        var filesProcessed = 0
+
+        ZipInputStream(input).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val name = entry.name
+                if (!entry.isDirectory && looksLikeSemanticHistory(name)) {
+                    val baos = ByteArrayOutputStream()
+                    val buf = ByteArray(8192)
+                    var read: Int
+                    while (zis.read(buf).also { read = it } != -1) {
+                        totalUncompressed += read
+                        if (totalUncompressed > maxBytes) {
+                            throw IOException("Archive trop grande (>$maxBytes octets décompressés)")
+                        }
+                        baos.write(buf, 0, read)
+                    }
+                    val r = importJson(baos.toString(Charsets.UTF_8))
+                    visitsInserted += r.visitsInserted
+                    visitsSkipped += r.visitsSkipped
+                    segmentsInserted += r.segmentsInserted
+                    segmentsSkipped += r.segmentsSkipped
+                    filesProcessed++
+                }
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+        return LocationImportResult(
+            visitsInserted = visitsInserted,
+            visitsSkipped = visitsSkipped,
+            segmentsInserted = segmentsInserted,
+            segmentsSkipped = segmentsSkipped,
+            filesProcessed = filesProcessed,
+        )
+    }
+
+    private fun looksLikeSemanticHistory(name: String): Boolean {
+        if (!name.endsWith(".json", ignoreCase = true)) return false
+        val lower = name.lowercase()
+        // Patterns observés : "Takeout/Location History (Timeline)/Semantic Location History/2024/2024_JANUARY.json"
+        // ou "Semantic Location History/.../2024_*.json"
+        return "semantic location history" in lower ||
+            Regex(""".*\d{4}_(january|february|march|april|may|june|july|august|september|october|november|december)\.json""").matches(lower) ||
+            Regex(""".*\d{4}-\d{2}\.json""").matches(lower)
+    }
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
@@ -1,7 +1,9 @@
 package fr.datasaillance.nightfall.data.local.location
 
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import org.json.JSONArray
 import org.json.JSONObject
 import java.time.Instant
 
@@ -33,12 +35,14 @@ object TakeoutTimelineParser {
     data class ParseResult(
         val visits: List<LocationVisitEntity>,
         val segments: List<ActivitySegmentEntity>,
+        val paths: List<LocationPathEntity> = emptyList(),
     )
 
     fun parse(rawJson: String, importedAtMs: Long = System.currentTimeMillis()): ParseResult {
         val root = JSONObject(rawJson)
         val visits = mutableListOf<LocationVisitEntity>()
         val segments = mutableListOf<ActivitySegmentEntity>()
+        val paths = mutableListOf<LocationPathEntity>()
 
         // Format 1 — ancien : timelineObjects
         root.optJSONArray("timelineObjects")?.let { arr ->
@@ -65,11 +69,13 @@ object TakeoutTimelineParser {
                 seg.optJSONObject("activity")?.let { a ->
                     parseNewActivity(a, startMs, endMs, importedAtMs)?.let { segments.add(it) }
                 }
-                // timelinePath ignoré (sera réintroduit en Phase B_gps avec FusedLocation)
+                seg.optJSONArray("timelinePath")?.let { arr ->
+                    parseTimelinePath(arr, startMs, endMs, importedAtMs)?.let { paths.add(it) }
+                }
             }
         }
 
-        return ParseResult(visits, segments)
+        return ParseResult(visits, segments, paths)
     }
 
     // --- Format 1 (ancien) ---
@@ -206,6 +212,41 @@ object TakeoutTimelineParser {
             activityType = type,
             distanceMeters = distance,
             confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    /**
+     * Parse un `timelinePath` (suite de waypoints `{point, time}`) en `LocationPathEntity`.
+     * Le champ `points_json` est sérialisé manuellement (pas de dépendance kotlinx.serialization
+     * dans ce module) : `[{"lat":..,"lng":..,"t":..},...]`.
+     */
+    private fun parseTimelinePath(
+        arr: JSONArray,
+        startMs: Long,
+        endMs: Long,
+        importedAtMs: Long,
+    ): LocationPathEntity? {
+        if (arr.length() == 0) return null
+        val sb = StringBuilder()
+        sb.append('[')
+        var count = 0
+        for (i in 0 until arr.length()) {
+            val pt = arr.optJSONObject(i) ?: continue
+            val (lat, lng) = parseLatLngString(pt.optString("point")) ?: continue
+            val tMs = parseTimestamp(pt.optString("time")) ?: continue
+            if (count > 0) sb.append(',')
+            sb.append("""{"lat":$lat,"lng":$lng,"t":$tMs}""")
+            count++
+        }
+        sb.append(']')
+        if (count == 0) return null
+        return LocationPathEntity(
+            startMs = startMs,
+            endMs = endMs,
+            pointsJson = sb.toString(),
+            pointCount = count,
             source = "takeout",
             importedAtMs = importedAtMs,
         )

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
@@ -1,0 +1,125 @@
+package fr.datasaillance.nightfall.data.local.location
+
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+
+/**
+ * Parse les fichiers Google Takeout "Semantic Location History".
+ *
+ * Format racine (recent ~2024) :
+ * ```json
+ * { "timelineObjects": [
+ *     { "placeVisit": {...} },
+ *     { "activitySegment": {...} }
+ * ] }
+ * ```
+ *
+ * Lat/lng sont en E7 (degrés × 1e7) côté Google ; on convertit en degrés décimaux.
+ * Timestamps en ISO 8601 avec offset (généralement Z) ou en epoch millis selon
+ * la version d'export — on supporte les deux.
+ *
+ * Implémentation org.json (built-in Android) — tolérante, pas de dépendance ajoutée.
+ */
+object TakeoutTimelineParser {
+
+    data class ParseResult(
+        val visits: List<LocationVisitEntity>,
+        val segments: List<ActivitySegmentEntity>,
+    )
+
+    fun parse(rawJson: String, importedAtMs: Long = System.currentTimeMillis()): ParseResult {
+        val root = JSONObject(rawJson)
+        val arr = root.optJSONArray("timelineObjects") ?: return ParseResult(emptyList(), emptyList())
+
+        val visits = mutableListOf<LocationVisitEntity>()
+        val segments = mutableListOf<ActivitySegmentEntity>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            obj.optJSONObject("placeVisit")?.let { v ->
+                parseVisit(v, importedAtMs)?.let { visits.add(it) }
+            }
+            obj.optJSONObject("activitySegment")?.let { s ->
+                parseSegment(s, importedAtMs)?.let { segments.add(it) }
+            }
+        }
+        return ParseResult(visits, segments)
+    }
+
+    private fun parseVisit(visit: JSONObject, importedAtMs: Long): LocationVisitEntity? {
+        val location = visit.optJSONObject("location") ?: return null
+        val duration = visit.optJSONObject("duration") ?: return null
+
+        val latE7 = location.optInt("latitudeE7", Int.MIN_VALUE)
+        val lngE7 = location.optInt("longitudeE7", Int.MIN_VALUE)
+        if (latE7 == Int.MIN_VALUE || lngE7 == Int.MIN_VALUE) return null
+
+        val startMs = parseTimestamp(duration.optString("startTimestamp")) ?: return null
+        val endMs = parseTimestamp(duration.optString("endTimestamp")) ?: return null
+
+        return LocationVisitEntity(
+            startMs = startMs,
+            endMs = endMs,
+            lat = latE7 / 1e7,
+            lng = lngE7 / 1e7,
+            placeId = location.optString("placeId").ifBlankOrNullDefault(null),
+            placeName = location.optString("name").ifBlankOrNullDefault(null),
+            address = location.optString("address").ifBlankOrNullDefault(null),
+            confidence = visit.optString("visitConfidence").ifBlankOrNullDefault(null)
+                ?: visit.optString("placeConfidence").ifBlankOrNullDefault(null),
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    private fun parseSegment(segment: JSONObject, importedAtMs: Long): ActivitySegmentEntity? {
+        val start = segment.optJSONObject("startLocation") ?: return null
+        val end = segment.optJSONObject("endLocation") ?: return null
+        val duration = segment.optJSONObject("duration") ?: return null
+
+        val startLatE7 = start.optInt("latitudeE7", Int.MIN_VALUE)
+        val startLngE7 = start.optInt("longitudeE7", Int.MIN_VALUE)
+        val endLatE7 = end.optInt("latitudeE7", Int.MIN_VALUE)
+        val endLngE7 = end.optInt("longitudeE7", Int.MIN_VALUE)
+        if (startLatE7 == Int.MIN_VALUE || endLatE7 == Int.MIN_VALUE) return null
+
+        val startMs = parseTimestamp(duration.optString("startTimestamp")) ?: return null
+        val endMs = parseTimestamp(duration.optString("endTimestamp")) ?: return null
+
+        val activityType = segment.optString("activityType").ifBlankOrNullDefault("UNKNOWN")
+            ?: "UNKNOWN"
+        val distance = segment.optInt("distance", -1).takeIf { it >= 0 }
+        val confidence = segment.optString("confidence").ifBlankOrNullDefault(null)
+
+        return ActivitySegmentEntity(
+            startMs = startMs,
+            endMs = endMs,
+            startLat = startLatE7 / 1e7,
+            startLng = startLngE7 / 1e7,
+            endLat = endLatE7 / 1e7,
+            endLng = endLngE7 / 1e7,
+            activityType = activityType,
+            distanceMeters = distance,
+            confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    /**
+     * Accepte ISO 8601 (`2024-01-15T08:30:00.000Z` ou avec offset) ou epoch millis
+     * en chaîne (vue dans certaines versions Takeout).
+     */
+    private fun parseTimestamp(value: String): Long? {
+        if (value.isBlank()) return null
+        // Cas epoch numérique
+        value.toLongOrNull()?.let { return it }
+        // Cas ISO 8601
+        return runCatching { Instant.parse(value).toEpochMilli() }.getOrNull()
+    }
+
+    private fun String?.ifBlankOrNullDefault(default: String?): String? =
+        if (this.isNullOrBlank() || this == "null") default else this
+}

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
@@ -2,24 +2,29 @@ package fr.datasaillance.nightfall.data.local.location
 
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
-import org.json.JSONArray
 import org.json.JSONObject
 import java.time.Instant
 
 /**
- * Parse les fichiers Google Takeout "Semantic Location History".
+ * Parse les fichiers Google Takeout "Location History".
  *
- * Format racine (recent ~2024) :
- * ```json
- * { "timelineObjects": [
- *     { "placeVisit": {...} },
- *     { "activitySegment": {...} }
- * ] }
- * ```
+ * Deux formats supportés :
  *
- * Lat/lng sont en E7 (degrés × 1e7) côté Google ; on convertit en degrés décimaux.
- * Timestamps en ISO 8601 avec offset (généralement Z) ou en epoch millis selon
- * la version d'export — on supporte les deux.
+ * 1. **Ancien (Semantic Location History, ~pré-2024)** :
+ *    ```json
+ *    { "timelineObjects": [ { "placeVisit": {...} }, { "activitySegment": {...} } ] }
+ *    ```
+ *    Lat/lng en E7 (degrés × 1e7).
+ *
+ * 2. **Nouveau (Timeline 2024+)** :
+ *    ```json
+ *    { "semanticSegments": [
+ *        { "startTime": "...", "endTime": "...", "visit": {...} },
+ *        { "startTime": "...", "endTime": "...", "activity": {...} },
+ *        { "startTime": "...", "endTime": "...", "timelinePath": [...] }   // ignoré (chemins GPS bruts)
+ *    ], "rawSignals": [...] }                                              // ignoré (~22k points)
+ *    ```
+ *    Lat/lng en string `"45.81213°, 4.8888115°"`.
  *
  * Implémentation org.json (built-in Android) — tolérante, pas de dépendance ajoutée.
  */
@@ -32,23 +37,44 @@ object TakeoutTimelineParser {
 
     fun parse(rawJson: String, importedAtMs: Long = System.currentTimeMillis()): ParseResult {
         val root = JSONObject(rawJson)
-        val arr = root.optJSONArray("timelineObjects") ?: return ParseResult(emptyList(), emptyList())
-
         val visits = mutableListOf<LocationVisitEntity>()
         val segments = mutableListOf<ActivitySegmentEntity>()
-        for (i in 0 until arr.length()) {
-            val obj = arr.optJSONObject(i) ?: continue
-            obj.optJSONObject("placeVisit")?.let { v ->
-                parseVisit(v, importedAtMs)?.let { visits.add(it) }
-            }
-            obj.optJSONObject("activitySegment")?.let { s ->
-                parseSegment(s, importedAtMs)?.let { segments.add(it) }
+
+        // Format 1 — ancien : timelineObjects
+        root.optJSONArray("timelineObjects")?.let { arr ->
+            for (i in 0 until arr.length()) {
+                val obj = arr.optJSONObject(i) ?: continue
+                obj.optJSONObject("placeVisit")?.let { v ->
+                    parseLegacyVisit(v, importedAtMs)?.let { visits.add(it) }
+                }
+                obj.optJSONObject("activitySegment")?.let { s ->
+                    parseLegacySegment(s, importedAtMs)?.let { segments.add(it) }
+                }
             }
         }
+
+        // Format 2 — nouveau : semanticSegments
+        root.optJSONArray("semanticSegments")?.let { arr ->
+            for (i in 0 until arr.length()) {
+                val seg = arr.optJSONObject(i) ?: continue
+                val startMs = parseTimestamp(seg.optString("startTime")) ?: continue
+                val endMs = parseTimestamp(seg.optString("endTime")) ?: continue
+                seg.optJSONObject("visit")?.let { v ->
+                    parseNewVisit(v, startMs, endMs, importedAtMs)?.let { visits.add(it) }
+                }
+                seg.optJSONObject("activity")?.let { a ->
+                    parseNewActivity(a, startMs, endMs, importedAtMs)?.let { segments.add(it) }
+                }
+                // timelinePath ignoré (sera réintroduit en Phase B_gps avec FusedLocation)
+            }
+        }
+
         return ParseResult(visits, segments)
     }
 
-    private fun parseVisit(visit: JSONObject, importedAtMs: Long): LocationVisitEntity? {
+    // --- Format 1 (ancien) ---
+
+    private fun parseLegacyVisit(visit: JSONObject, importedAtMs: Long): LocationVisitEntity? {
         val location = visit.optJSONObject("location") ?: return null
         val duration = visit.optJSONObject("duration") ?: return null
 
@@ -74,7 +100,7 @@ object TakeoutTimelineParser {
         )
     }
 
-    private fun parseSegment(segment: JSONObject, importedAtMs: Long): ActivitySegmentEntity? {
+    private fun parseLegacySegment(segment: JSONObject, importedAtMs: Long): ActivitySegmentEntity? {
         val start = segment.optJSONObject("startLocation") ?: return null
         val end = segment.optJSONObject("endLocation") ?: return null
         val duration = segment.optJSONObject("duration") ?: return null
@@ -108,15 +134,105 @@ object TakeoutTimelineParser {
         )
     }
 
+    // --- Format 2 (nouveau) ---
+
+    private fun parseNewVisit(
+        visit: JSONObject,
+        startMs: Long,
+        endMs: Long,
+        importedAtMs: Long,
+    ): LocationVisitEntity? {
+        val candidate = visit.optJSONObject("topCandidate") ?: return null
+        val placeLocation = candidate.optJSONObject("placeLocation") ?: return null
+        val (lat, lng) = parseLatLngString(placeLocation.optString("latLng")) ?: return null
+
+        val placeId = candidate.optString("placeId").ifBlankOrNullDefault(null)
+        // semanticType : INFERRED_HOME / INFERRED_WORK / UNKNOWN → on l'expose comme placeName
+        // pour que l'utilisateur voie "Maison / Travail" au lieu d'un placeId opaque.
+        val semanticType = candidate.optString("semanticType").ifBlankOrNullDefault(null)
+        val placeName = semanticType?.removePrefix("INFERRED_")?.let { type ->
+            when (type) {
+                "HOME" -> "Maison"
+                "WORK" -> "Travail"
+                "UNKNOWN" -> null
+                else -> type.lowercase().replaceFirstChar { it.uppercase() }
+            }
+        }
+        val probability = visit.optDouble("probability", Double.NaN)
+        val confidence = if (probability.isNaN()) null else "%.2f".format(probability)
+
+        return LocationVisitEntity(
+            startMs = startMs,
+            endMs = endMs,
+            lat = lat,
+            lng = lng,
+            placeId = placeId,
+            placeName = placeName,
+            address = null,
+            confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    private fun parseNewActivity(
+        activity: JSONObject,
+        startMs: Long,
+        endMs: Long,
+        importedAtMs: Long,
+    ): ActivitySegmentEntity? {
+        val start = activity.optJSONObject("start") ?: return null
+        val end = activity.optJSONObject("end") ?: return null
+        val (startLat, startLng) = parseLatLngString(start.optString("latLng")) ?: return null
+        val (endLat, endLng) = parseLatLngString(end.optString("latLng")) ?: return null
+
+        val candidate = activity.optJSONObject("topCandidate") ?: return null
+        val type = candidate.optString("type").ifBlankOrNullDefault("UNKNOWN") ?: "UNKNOWN"
+
+        val distance = activity.optDouble("distanceMeters", Double.NaN)
+            .takeIf { !it.isNaN() && it >= 0 }
+            ?.toInt()
+
+        val probability = activity.optDouble("probability", Double.NaN)
+        val confidence = if (probability.isNaN()) null else "%.2f".format(probability)
+
+        return ActivitySegmentEntity(
+            startMs = startMs,
+            endMs = endMs,
+            startLat = startLat,
+            startLng = startLng,
+            endLat = endLat,
+            endLng = endLng,
+            activityType = type,
+            distanceMeters = distance,
+            confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    // --- Helpers ---
+
     /**
-     * Accepte ISO 8601 (`2024-01-15T08:30:00.000Z` ou avec offset) ou epoch millis
-     * en chaîne (vue dans certaines versions Takeout).
+     * Parse `"45.81213°, 4.8888115°"` (nouveau format) ou `"45.81213, 4.8888115"` (sans degré).
+     * Tolérant aux espaces et au symbole degré optionnel.
+     */
+    internal fun parseLatLngString(value: String): Pair<Double, Double>? {
+        if (value.isBlank()) return null
+        val parts = value.split(",").map { it.trim().trimEnd('°').trim() }
+        if (parts.size != 2) return null
+        val lat = parts[0].toDoubleOrNull() ?: return null
+        val lng = parts[1].toDoubleOrNull() ?: return null
+        return lat to lng
+    }
+
+    /**
+     * Accepte ISO 8601 (`2024-01-15T08:30:00.000Z` ou avec offset `+01:00`)
+     * ou epoch millis en chaîne.
      */
     private fun parseTimestamp(value: String): Long? {
         if (value.isBlank()) return null
-        // Cas epoch numérique
         value.toLongOrNull()?.let { return it }
-        // Cas ISO 8601
         return runCatching { Instant.parse(value).toEpochMilli() }.getOrNull()
     }
 

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
@@ -17,4 +17,15 @@ sealed class ImportUiState {
         val missingTypes: List<ImportDataType> = emptyList(),
     ) : ImportUiState()
     data class Error(val message: String, val retryable: Boolean) : ImportUiState()
+
+    // --- Google Timeline (local-only) ---
+    object LocationImporting : ImportUiState()
+    data class LocationSuccess(
+        val visitsInserted: Int,
+        val visitsSkipped: Int,
+        val segmentsInserted: Int,
+        val segmentsSkipped: Int,
+        val filesProcessed: Int,
+    ) : ImportUiState()
+    data class LocationError(val message: String) : ImportUiState()
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -171,11 +171,15 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Timeline.route) {
-                val timelineRepository: SleepRepository = remember(context) {
-                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                val db = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                }
+                val timelineRepository: SleepRepository = remember(db) {
                     LocalSleepRepository(db.sleepDao())
                 }
-                val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
+                val timelineViewModel = remember(timelineRepository, db) {
+                    TimelineViewModel(timelineRepository, db.locationDao())
+                }
                 TimelineScreen(
                     viewModel = timelineViewModel,
                     onOpenHypnogram = { sessionId, isoDate ->

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -158,12 +158,19 @@ fun NavGraph(
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
                 val dateArg = backStackEntry.arguments?.getString("date")
-                val hypnogramRepository: SleepRepository = remember(context) {
-                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
-                    LocalSleepRepository(db.sleepDao())
+                val hypnogramDb = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
                 }
-                val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
-                    HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
+                val hypnogramRepository: SleepRepository = remember(hypnogramDb) {
+                    LocalSleepRepository(hypnogramDb.sleepDao())
+                }
+                val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository, hypnogramDb) {
+                    HypnogramViewModel(
+                        sessionId = sessionId,
+                        repository = hypnogramRepository,
+                        hintDate = dateArg,
+                        locationDao = hypnogramDb.locationDao(),
+                    )
                 }
                 HypnogramScreen(
                     viewModel = hypnogramViewModel,

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -214,9 +214,11 @@ fun NavGraph(
             }
             composable(NavDestination.Import.route) {
                 val context = LocalContext.current
-                val repository: ImportRepository = remember(api, context) {
+                val db = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                }
+                val repository: ImportRepository = remember(api, db) {
                     if (api != null) {
-                        val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
                         val localService = fr.datasaillance.nightfall.data.local.import_.LocalImportService(
                             sleepDao = db.sleepDao(),
                             heartRateDao = db.heartRateDao(),
@@ -228,7 +230,12 @@ fun NavGraph(
                         NoOpImportRepository()
                     }
                 }
-                val viewModel = remember(repository) { ImportViewModel(repository) }
+                val locationService = remember(db) {
+                    fr.datasaillance.nightfall.data.local.location.LocalLocationImportService(db.locationDao())
+                }
+                val viewModel = remember(repository, locationService) {
+                    ImportViewModel(repository, locationService)
+                }
                 ImportScreen(
                     viewModel = viewModel,
                     onNavigateBack = { navController.popBackStack() },

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt
@@ -57,6 +57,12 @@ fun ImportScreen(
         uri?.let { viewModel.startUpload(context.contentResolver, it) }
     }
 
+    val locationLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let { viewModel.startLocationImport(context.contentResolver, it) }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -76,7 +82,14 @@ fun ImportScreen(
                     .padding(padding)
                     .padding(16.dp),
             ) {
-                IdleContent(onCheckConnection = { viewModel.checkConnection() })
+                IdleContent(
+                    onCheckConnection = { viewModel.checkConnection() },
+                    onSelectTimelineJson = {
+                        locationLauncher.launch(
+                            arrayOf("application/json", "application/zip", "*/*")
+                        )
+                    },
+                )
             }
             is ImportUiState.Connecting -> Box(
                 modifier = Modifier
@@ -150,24 +163,136 @@ fun ImportScreen(
                     onBack = onNavigateBack,
                 )
             }
+            is ImportUiState.LocationImporting -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                LocationImportingContent()
+            }
+            is ImportUiState.LocationSuccess -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                LocationSuccessContent(
+                    state = state,
+                    onDone = {
+                        viewModel.reset()
+                        onNavigateBack()
+                    },
+                )
+            }
+            is ImportUiState.LocationError -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ErrorContent(
+                    message = state.message,
+                    retryable = true,
+                    onRetry = { viewModel.reset() },
+                    onBack = onNavigateBack,
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun IdleContent(onCheckConnection: () -> Unit) {
+private fun IdleContent(
+    onCheckConnection: () -> Unit,
+    onSelectTimelineJson: () -> Unit,
+) {
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = "Importer des données Samsung Health",
+            text = "Importer des données",
             style = MaterialTheme.typography.headlineSmall,
         )
         Spacer(modifier = Modifier.height(24.dp))
-        Button(onClick = onCheckConnection) {
-            Text("Vérifier la connexion")
+        Button(
+            onClick = onCheckConnection,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Samsung Health (via serveur)")
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(
+            onClick = onSelectTimelineJson,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Google Timeline (local)")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "L'import Google Timeline ne sort jamais de l'appareil.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun LocationImportingContent() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Import Google Timeline en cours…")
+    }
+}
+
+@Composable
+private fun LocationSuccessContent(
+    state: ImportUiState.LocationSuccess,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Import Google Timeline terminé",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text("Visites")
+            Text("${state.visitsInserted} nouvelles · ${state.visitsSkipped} déjà présentes")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text("Trajets")
+            Text("${state.segmentsInserted} nouveaux · ${state.segmentsSkipped} déjà présents")
+        }
+        if (state.filesProcessed > 1) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "${state.filesProcessed} fichiers traités",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onDone) {
+            Text("Terminer")
         }
     }
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.datasaillance.nightfall.data.import_.ImportRepository
+import fr.datasaillance.nightfall.data.local.location.LocalLocationImportService
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.domain.import_.ImportUiState
@@ -16,6 +17,7 @@ import kotlinx.coroutines.launch
 
 class ImportViewModel(
     private val repository: ImportRepository,
+    private val locationService: LocalLocationImportService? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<ImportUiState>(ImportUiState.Idle)
@@ -90,6 +92,48 @@ class ImportViewModel(
                 }
             }
             _uiState.value = ImportUiState.Success(results, missingTypes = skipped.toList())
+        }
+    }
+
+    /**
+     * Import local d'un export Google Timeline (JSON ou ZIP Takeout).
+     * Aucun appel réseau — passe directement par [LocalLocationImportService].
+     */
+    fun startLocationImport(contentResolver: ContentResolver, uri: Uri) {
+        val service = locationService ?: run {
+            _uiState.value = ImportUiState.LocationError("Service Timeline indisponible")
+            return
+        }
+        _uiState.value = ImportUiState.LocationImporting
+        viewModelScope.launch {
+            try {
+                val mime = contentResolver.getType(uri)
+                val nameLower = uri.lastPathSegment.orEmpty().lowercase()
+                val isZip = mime == "application/zip" || nameLower.endsWith(".zip")
+                val result = contentResolver.openInputStream(uri)?.use { input ->
+                    if (isZip) {
+                        service.importZip(input)
+                    } else {
+                        service.importJson(input.readBytes().toString(Charsets.UTF_8))
+                    }
+                } ?: run {
+                    _uiState.value = ImportUiState.LocationError("Fichier introuvable")
+                    return@launch
+                }
+                _uiState.value = ImportUiState.LocationSuccess(
+                    visitsInserted = result.visitsInserted,
+                    visitsSkipped = result.visitsSkipped,
+                    segmentsInserted = result.segmentsInserted,
+                    segmentsSkipped = result.segmentsSkipped,
+                    filesProcessed = result.filesProcessed,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.value = ImportUiState.LocationError(
+                    e.message ?: "Erreur d'import (${e.javaClass.simpleName})"
+                )
+            }
         }
     }
 

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
@@ -2,6 +2,10 @@ package fr.datasaillance.nightfall.viewmodel.sleep
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,11 +17,21 @@ import timber.log.Timber
 import java.io.IOException
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
+
+data class DayLocation(
+    val visits: List<LocationVisitEntity>,
+    val segments: List<ActivitySegmentEntity>,
+    val paths: List<LocationPathEntity> = emptyList(),
+)
 
 sealed class HypnogramUiState {
     object Idle    : HypnogramUiState()
     object Loading : HypnogramUiState()
-    data class Success(val sessions: List<SleepSessionResponse>) : HypnogramUiState()
+    data class Success(
+        val sessions: List<SleepSessionResponse>,
+        val dayLocation: DayLocation? = null,
+    ) : HypnogramUiState()
     data class Error(val message: String) : HypnogramUiState()
 }
 
@@ -25,6 +39,8 @@ class HypnogramViewModel(
     private val sessionId: String,
     private val repository: SleepRepository,
     private val hintDate: String? = null,
+    private val locationDao: LocationDao? = null,
+    private val zone: ZoneId = ZoneId.systemDefault(),
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HypnogramUiState>(HypnogramUiState.Idle)
@@ -83,11 +99,32 @@ class HypnogramViewModel(
                 }
                 Timber.d("scope=hypno_vm night_sessions=${nightSessions.size} total_stages=${nightSessions.sumOf { it.stages?.size ?: 0 }}")
                 _uiState.value = HypnogramUiState.Success(nightSessions)
+
+                // Charge les données GPS du jour en arrière-plan — l'hypnogramme s'affiche
+                // tout de suite, la map apparaît dès que les données sont prêtes.
+                if (targetDate != null) {
+                    val dayLoc = loadDayLocation(targetDate)
+                    _uiState.value = HypnogramUiState.Success(nightSessions, dayLocation = dayLoc)
+                }
             } catch (e: Exception) {
                 Timber.w("scope=hypno_vm error=${e::class.simpleName}")
                 _uiState.value = HypnogramUiState.Error(mapError(e))
             }
         }
+    }
+
+    private suspend fun loadDayLocation(date: LocalDate): DayLocation? {
+        val dao = locationDao ?: return null
+        val fromMs = date.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMs = date.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        return runCatching {
+            DayLocation(
+                visits = dao.getVisitsInRange(fromMs, toMs),
+                segments = dao.getSegmentsInRange(fromMs, toMs),
+                paths = dao.getPathsInRange(fromMs, toMs),
+            )
+        }.onFailure { Timber.w("scope=hypno_vm location_load_failed error=${it::class.simpleName}") }
+            .getOrNull()
     }
 
     private fun mapError(throwable: Throwable?): String = when (throwable) {

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
@@ -2,6 +2,7 @@ package fr.datasaillance.nightfall.viewmodel.sleep
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,8 +12,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import timber.log.Timber
 import java.io.IOException
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
 
 private const val PAGE_DAYS = 30L
 // Pour le 1er chargement : on n'a pas de borne d'historique, donc on étend la
@@ -24,6 +27,7 @@ sealed class TimelineUiState {
     object Loading : TimelineUiState()
     data class Success(
         val sessions: List<SleepSessionResponse>,
+        val outOfHomeDates: Set<LocalDate> = emptySet(),
         val loadingMore: Boolean = false,
         val hasMore: Boolean = true,
     ) : TimelineUiState()
@@ -33,6 +37,8 @@ sealed class TimelineUiState {
 
 class TimelineViewModel(
     private val repository: SleepRepository,
+    private val locationDao: LocationDao? = null,
+    private val zone: ZoneId = ZoneId.systemDefault(),
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
@@ -80,8 +86,10 @@ class TimelineViewModel(
                     _uiState.value = TimelineUiState.Empty
                     return@launch
                 }
+                val sorted = sortSessions(sessions)
                 _uiState.value = TimelineUiState.Success(
-                    sessions = sortSessions(sessions),
+                    sessions = sorted,
+                    outOfHomeDates = computeOutOfHomeDates(sorted),
                     hasMore = true,
                 )
             } catch (e: Exception) {
@@ -124,6 +132,7 @@ class TimelineViewModel(
                 val merged = sortSessions(current.sessions + batch)
                 _uiState.value = current.copy(
                     sessions = merged,
+                    outOfHomeDates = computeOutOfHomeDates(merged),
                     loadingMore = false,
                     hasMore = true,
                 )
@@ -138,6 +147,33 @@ class TimelineViewModel(
         list.sortedBy { session ->
             runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }.getOrNull()
         }
+
+    /**
+     * Pour chaque session, calcule la journée associée (= date de `sleep_start`)
+     * et vérifie s'il y a au moins une activité GPS ce jour-là. Une seule query
+     * Room couvre toute la fenêtre, puis groupement local.
+     */
+    private suspend fun computeOutOfHomeDates(
+        sessions: List<SleepSessionResponse>,
+    ): Set<LocalDate> {
+        val dao = locationDao ?: return emptySet()
+        if (sessions.isEmpty()) return emptySet()
+        val sessionDates = sessions.mapNotNull { session ->
+            runCatching { OffsetDateTime.parse(session.sleep_start).toLocalDate() }.getOrNull()
+        }.toSet()
+        if (sessionDates.isEmpty()) return emptySet()
+        val minDate = sessionDates.min()
+        val maxDate = sessionDates.max()
+        val fromMs = minDate.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMs = maxDate.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        val activityStarts = runCatching {
+            dao.getActivityStartTimesInRange(fromMs, toMs)
+        }.getOrDefault(emptyList())
+        return activityStarts.asSequence()
+            .map { Instant.ofEpochMilli(it).atZone(zone).toLocalDate() }
+            .toSet()
+            .intersect(sessionDates)
+    }
 
     private fun mapError(throwable: Throwable?): String = when (throwable) {
         is IOException -> "Vérifiez votre connexion réseau"

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
@@ -1,0 +1,279 @@
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import fr.datasaillance.nightfall.viewmodel.sleep.DayLocation
+import org.json.JSONArray
+import org.osmdroid.config.Configuration
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import org.osmdroid.util.BoundingBox
+import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+import org.osmdroid.views.overlay.Polyline
+
+@Composable
+fun DayMapSection(
+    dayLocation: DayLocation?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val primary = MaterialTheme.colorScheme.primary
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Text(
+            text = "Déplacements",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            dayLocation == null -> {
+                LocationPlaceholder("Chargement…")
+            }
+            dayLocation.visits.isEmpty() && dayLocation.segments.isEmpty() && dayLocation.paths.isEmpty() -> {
+                LocationPlaceholder("Aucun déplacement enregistré pour cette journée.")
+            }
+            else -> {
+                DayStatsRow(dayLocation, onSurfaceVariant)
+                Spacer(modifier = Modifier.height(12.dp))
+                AndroidView(
+                    factory = { ctx ->
+                        Configuration.getInstance().userAgentValue = ctx.packageName
+                        MapView(ctx).apply {
+                            setTileSource(TileSourceFactory.MAPNIK)
+                            setMultiTouchControls(true)
+                            setHorizontalMapRepetitionEnabled(false)
+                            setVerticalMapRepetitionEnabled(false)
+                            minZoomLevel = 3.0
+                            maxZoomLevel = 19.0
+                        }
+                    },
+                    update = { map ->
+                        populateMap(
+                            map = map,
+                            dayLocation = dayLocation,
+                            visitColor = primary.toArgb(),
+                            segmentColor = primary.toArgb(),
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(280.dp)
+                        .testTag("hyp_day_map"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationPlaceholder(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DayStatsRow(dayLocation: DayLocation, mutedColor: androidx.compose.ui.graphics.Color) {
+    val totalDistance = dayLocation.segments.sumOf { it.distanceMeters ?: 0 }
+    val typeBreakdown = dayLocation.segments
+        .groupingBy { it.activityType }
+        .eachCount()
+        .entries
+        .sortedByDescending { it.value }
+    val topType = typeBreakdown.firstOrNull()?.key?.let(::humanizeActivityType)
+
+    Row(modifier = Modifier.fillMaxWidth()) {
+        StatChip(label = "Visites", value = dayLocation.visits.size.toString(), muted = mutedColor)
+        Spacer(modifier = Modifier.padding(end = 12.dp))
+        StatChip(label = "Trajets", value = dayLocation.segments.size.toString(), muted = mutedColor)
+        Spacer(modifier = Modifier.padding(end = 12.dp))
+        StatChip(label = "Distance", value = formatDistance(totalDistance), muted = mutedColor)
+        if (topType != null) {
+            Spacer(modifier = Modifier.padding(end = 12.dp))
+            StatChip(label = "Principal", value = topType, muted = mutedColor)
+        }
+    }
+}
+
+@Composable
+private fun StatChip(label: String, value: String, muted: androidx.compose.ui.graphics.Color) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = muted,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+private fun populateMap(
+    map: MapView,
+    dayLocation: DayLocation,
+    visitColor: Int,
+    segmentColor: Int,
+) {
+    map.overlays.clear()
+
+    val points = mutableListOf<GeoPoint>()
+
+    dayLocation.visits.forEach { visit ->
+        val gp = GeoPoint(visit.lat, visit.lng)
+        points.add(gp)
+        val marker = Marker(map).apply {
+            position = gp
+            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+            title = buildVisitTitle(visit)
+            snippet = formatVisitTimes(visit)
+        }
+        map.overlays.add(marker)
+    }
+
+    // Trajets réels (waypoints) — un Polyline par timelinePath.
+    // On essaie d'inférer la couleur via l'activity qui chevauche temporellement.
+    dayLocation.paths.forEach { path ->
+        val pts = decodePathPoints(path)
+        if (pts.isEmpty()) return@forEach
+        val matchingActivity = dayLocation.segments.firstOrNull { seg ->
+            path.startMs < seg.endMs && path.endMs > seg.startMs
+        }
+        val color = matchingActivity?.activityType?.let { blendActivityColor(it, segmentColor) }
+            ?: segmentColor
+        points.addAll(pts)
+        val line = Polyline(map).apply {
+            setPoints(pts)
+            outlinePaint.color = color
+            outlinePaint.strokeWidth = 8f
+            title = matchingActivity?.let { humanizeActivityType(it.activityType) } ?: "Trajet"
+            snippet = "${path.pointCount} points"
+        }
+        map.overlays.add(line)
+    }
+
+    // Fallback : activités sans path correspondant → segment vol d'oiseau (rare).
+    dayLocation.segments.forEach { seg ->
+        val hasPath = dayLocation.paths.any { path ->
+            path.startMs < seg.endMs && path.endMs > seg.startMs
+        }
+        if (hasPath) return@forEach
+        val start = GeoPoint(seg.startLat, seg.startLng)
+        val end = GeoPoint(seg.endLat, seg.endLng)
+        points.add(start)
+        points.add(end)
+        val line = Polyline(map).apply {
+            setPoints(listOf(start, end))
+            outlinePaint.color = blendActivityColor(seg.activityType, segmentColor)
+            outlinePaint.strokeWidth = 6f
+            // Marquer visuellement le fallback (pointillé via alpha réduit)
+            outlinePaint.alpha = 140
+            title = humanizeActivityType(seg.activityType) + " (estimé)"
+            snippet = formatSegmentMeta(seg)
+        }
+        map.overlays.add(line)
+    }
+
+    if (points.isNotEmpty()) {
+        val bbox = BoundingBox.fromGeoPointsSafe(points)
+        // Note : zoomToBoundingBox attend que le layout soit fait. Si appelé trop tôt,
+        // il rentre dans une boucle infinie sur certaines versions. Post via Handler.
+        map.post { map.zoomToBoundingBox(bbox, true, 64) }
+    }
+    map.invalidate()
+}
+
+/** Décode `points_json` en List<GeoPoint>. Tolérant aux entrées malformées. */
+private fun decodePathPoints(path: LocationPathEntity): List<GeoPoint> {
+    return runCatching {
+        val arr = JSONArray(path.pointsJson)
+        val out = ArrayList<GeoPoint>(arr.length())
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val lat = obj.optDouble("lat", Double.NaN)
+            val lng = obj.optDouble("lng", Double.NaN)
+            if (lat.isNaN() || lng.isNaN()) continue
+            out.add(GeoPoint(lat, lng))
+        }
+        out
+    }.getOrDefault(emptyList())
+}
+
+private fun buildVisitTitle(v: LocationVisitEntity): String =
+    v.placeName ?: v.address ?: "Visite"
+
+private fun formatVisitTimes(v: LocationVisitEntity): String {
+    val zone = java.time.ZoneId.systemDefault()
+    val start = java.time.Instant.ofEpochMilli(v.startMs).atZone(zone).toLocalTime()
+    val end = java.time.Instant.ofEpochMilli(v.endMs).atZone(zone).toLocalTime()
+    val fmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+    return "${fmt.format(start)} → ${fmt.format(end)}"
+}
+
+private fun formatSegmentMeta(s: ActivitySegmentEntity): String {
+    val dist = s.distanceMeters?.let { formatDistance(it) }
+    return dist ?: "—"
+}
+
+private fun formatDistance(meters: Int): String =
+    if (meters < 1000) "${meters} m" else "%.1f km".format(meters / 1000.0)
+
+internal fun humanizeActivityType(type: String): String = when (type) {
+    "WALKING" -> "Marche"
+    "RUNNING" -> "Course"
+    "CYCLING" -> "Vélo"
+    "IN_PASSENGER_VEHICLE" -> "Voiture"
+    "IN_BUS" -> "Bus"
+    "IN_SUBWAY" -> "Métro"
+    "IN_TRAIN" -> "Train"
+    "FLYING" -> "Avion"
+    "UNKNOWN" -> "Inconnu"
+    else -> type.lowercase().replaceFirstChar { it.uppercase() }
+}
+
+/**
+ * Couleur du polyline selon le type d'activité.
+ * On reste sur la palette DataSaillance (teal/amber/cyan) — pas de gradient décoratif.
+ */
+private fun blendActivityColor(type: String, fallback: Int): Int = when (type) {
+    "WALKING", "RUNNING" -> AndroidColor.parseColor("#3be5e7")  // cyan
+    "CYCLING" -> AndroidColor.parseColor("#0e9eb0")             // teal
+    "IN_PASSENGER_VEHICLE", "IN_BUS", "IN_SUBWAY", "IN_TRAIN" -> AndroidColor.parseColor("#d37c04")  // amber
+    "FLYING" -> AndroidColor.parseColor("#8b5cf6")              // violet sobre
+    else -> fallback
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
@@ -211,6 +211,9 @@ fun HypnogramScreen(
                             HypnogramLegend()
                             Spacer(modifier = Modifier.height(16.dp))
                             HypnogramStatsSection(sessions = state.sessions)
+                            Spacer(modifier = Modifier.height(24.dp))
+                            DayMapSection(dayLocation = state.dayLocation)
+                            Spacer(modifier = Modifier.height(24.dp))
                         }
                     }
                 }

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
@@ -43,6 +43,8 @@ private const val MOUNTAIN_ROW_HEIGHT_DP = 64
 private const val AXIS_BOTTOM_DP   = 24
 private const val LABEL_WIDTH_DP   = 48
 private const val LABEL_PADDING_DP = 4
+// Marge réservée à droite pour le badge "sorti du domicile".
+private const val TRAILING_BADGE_WIDTH_DP = 12
 // Fenêtre fixe 24h pour Non-24 — les heures de sommeil glissent partout.
 private const val WINDOW_START_MIN = 0
 private const val WINDOW_END_MIN   = 1440
@@ -231,15 +233,18 @@ fun TimelineScreen(
                                     )
                                 }
                                 items(nights, key = { (date, _) -> date.toEpochDay() }) { (date, sessions) ->
+                                    val wasOutOfHome = date in state.outOfHomeDates
                                     when (viewMode) {
                                         TimelineViewMode.BARS -> NightRow(
                                             date = date,
                                             sessions = sessions,
+                                            wasOutOfHome = wasOutOfHome,
                                             onClick = { selectedNight = NightSelection(date, sessions) },
                                         )
                                         TimelineViewMode.MOUNTAIN -> NightRowMountain(
                                             date = date,
                                             sessions = sessions,
+                                            wasOutOfHome = wasOutOfHome,
                                             onClick = { selectedNight = NightSelection(date, sessions) },
                                         )
                                     }
@@ -283,7 +288,7 @@ private fun TimelineAxisHeader(modifier: Modifier = Modifier) {
     ) {
         val canvasW = size.width
         val labelPx = LABEL_WIDTH_DP.dp.toPx()
-        val drawableW = canvasW - labelPx
+        val drawableW = canvasW - labelPx - TRAILING_BADGE_WIDTH_DP.dp.toPx()
         val paint = android.graphics.Paint().apply {
             textSize = 9.sp.toPx()
             color = onSurface.copy(alpha = 0.7f).toArgb()
@@ -337,9 +342,11 @@ private fun LoadOlderSentinel(
 private fun NightRow(
     date: LocalDate,
     sessions: List<SleepSessionResponse>,
+    wasOutOfHome: Boolean,
     onClick: () -> Unit,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
+    val primary = MaterialTheme.colorScheme.primary
     val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
     val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
     val label = remember(date) { date.format(dateFmt) }
@@ -355,7 +362,8 @@ private fun NightRow(
     ) {
         val canvasW = size.width
         val labelPx = LABEL_WIDTH_DP.dp.toPx()
-        val drawableW = canvasW - labelPx
+        val trailingPx = TRAILING_BADGE_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx - trailingPx
         val rowH = ROW_HEIGHT_DP.dp.toPx()
         val barH = BAR_HEIGHT_DP.dp.toPx()
         val barTop = (rowH - barH) / 2f
@@ -377,6 +385,15 @@ private fun NightRow(
                 strokeWidth = 1f,
             )
             h += GRID_STEP_HOURS
+        }
+
+        // Badge "sorti du domicile" — petit cercle teal dans la marge à droite.
+        if (wasOutOfHome) {
+            drawCircle(
+                color = primary,
+                radius = 3.dp.toPx(),
+                center = Offset(canvasW - trailingPx / 2f, rowH / 2f),
+            )
         }
 
         drawIntoCanvas { canvas ->
@@ -471,9 +488,11 @@ private fun buildMountainData(
 private fun NightRowMountain(
     date: LocalDate,
     sessions: List<SleepSessionResponse>,
+    wasOutOfHome: Boolean,
     onClick: () -> Unit,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
+    val primary = MaterialTheme.colorScheme.primary
     val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
     val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
     val label = remember(date) { date.format(dateFmt) }
@@ -491,7 +510,8 @@ private fun NightRowMountain(
     ) {
         val canvasW = size.width
         val labelPx = LABEL_WIDTH_DP.dp.toPx()
-        val drawableW = canvasW - labelPx
+        val trailingPx = TRAILING_BADGE_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx - trailingPx
         val rowH = MOUNTAIN_ROW_HEIGHT_DP.dp.toPx()
         val plotTop = 6.dp.toPx()
         val plotBot = rowH - 6.dp.toPx()
@@ -511,6 +531,15 @@ private fun NightRowMountain(
             val x = labelPx + (h * 60f / windowDuration) * drawableW
             drawLine(gridColor, Offset(x, 0f), Offset(x, rowH), strokeWidth = 1f)
             h += GRID_STEP_HOURS
+        }
+
+        // Badge "sorti du domicile" — petit cercle teal dans la marge à droite.
+        if (wasOutOfHome) {
+            drawCircle(
+                color = primary,
+                radius = 3.dp.toPx(),
+                center = Offset(canvasW - trailingPx / 2f, rowH / 2f),
+            )
         }
 
         drawIntoCanvas { canvas ->

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
@@ -209,13 +209,27 @@ fun TimelineScreen(
                         }
 
                         // Sentinel : quand l'utilisateur scrolle jusqu'en haut de la liste, on charge
-                        // 30 jours plus anciens. distinctUntilChanged évite les triggers répétés
-                        // pendant que la pagination est déjà en cours.
-                        LaunchedEffect(listState, state.hasMore, state.loadingMore) {
+                        // 30 jours plus anciens.
+                        //
+                        // ⚠️ Les clés doivent rester stables (pas state.hasMore / state.loadingMore) :
+                        // sinon le LaunchedEffect redémarre à chaque toggle de loadingMore, le buffer
+                        // distinctUntilChanged repart à zéro et ré-émet la valeur courante (0 si l'user
+                        // est au sentinel), ce qui déclenche un nouveau loadOlder immédiat → cascade
+                        // de chargements ininterrompus jusqu'à épuisement de l'historique.
+                        //
+                        // Lecture de hasMore / loadingMore à l'INTÉRIEUR du collect (snapshot instantané
+                        // au moment du trigger), pas comme clés.
+                        LaunchedEffect(listState, initialScrollDone) {
                             snapshotFlow { listState.firstVisibleItemIndex }
                                 .distinctUntilChanged()
-                                .filter { it == 0 && state.hasMore && !state.loadingMore && initialScrollDone }
-                                .collect { viewModel.loadOlder() }
+                                .filter { it == 0 && initialScrollDone }
+                                .collect {
+                                    val current = viewModel.uiState.value as? TimelineUiState.Success
+                                        ?: return@collect
+                                    if (current.hasMore && !current.loadingMore) {
+                                        viewModel.loadOlder()
+                                    }
+                                }
                         }
 
                         Column(

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
@@ -213,4 +213,122 @@ class LocalLocationImportServiceTest {
           }
         }
     """.trimIndent()
+
+    // ---- Nouveau format Google Timeline 2024+ (semanticSegments) ----
+
+    private fun newFormatFixture(): String = """
+        {
+          "semanticSegments": [
+            {
+              "startTime": "2026-02-21T18:11:28.000+01:00",
+              "endTime":   "2026-02-21T21:54:05.000+01:00",
+              "visit": {
+                "hierarchyLevel": 0,
+                "probability": 0.876,
+                "topCandidate": {
+                  "placeId": "ChIJG3a7suW_9EcRF42jL3Q84rA",
+                  "semanticType": "INFERRED_HOME",
+                  "placeLocation": { "latLng": "45.81213°, 4.8888115°" }
+                }
+              }
+            },
+            {
+              "startTime": "2026-02-21T17:29:14.000+01:00",
+              "endTime":   "2026-02-21T17:30:52.000+01:00",
+              "activity": {
+                "start": { "latLng": "45.5276149°, 4.8801637°" },
+                "end":   { "latLng": "45.5277361°, 4.8801797°" },
+                "distanceMeters": 102.94,
+                "probability": 0.97,
+                "topCandidate": { "type": "WALKING", "probability": 0.74 }
+              }
+            },
+            {
+              "startTime": "2026-02-19T14:00:00.000+01:00",
+              "endTime":   "2026-02-19T16:00:00.000+01:00",
+              "timelinePath": [
+                { "point": "45.527964°, 4.8787612°", "time": "2026-02-19T14:19:00.000+01:00" }
+              ]
+            }
+          ],
+          "rawSignals": [
+            { "position": { "LatLng": "45.5280°, 4.8787°", "timestamp": "2026-04-20T16:12:08.000+02:00" } }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun new_format_extracts_visits_and_activities() = runTest {
+        val r = service.importJson(newFormatFixture())
+        assertEquals(1, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+
+        val visit = db.locationDao().getAllVisits().first()
+        assertEquals(45.81213, visit.lat, 0.00001)
+        assertEquals(4.8888115, visit.lng, 0.00001)
+        assertEquals("ChIJG3a7suW_9EcRF42jL3Q84rA", visit.placeId)
+        assertEquals("Maison", visit.placeName)  // INFERRED_HOME → Maison
+        assertEquals("0.88", visit.confidence)
+
+        val seg = db.locationDao().getAllSegments().first()
+        assertEquals(45.5276149, seg.startLat, 0.00001)
+        assertEquals(45.5277361, seg.endLat, 0.00001)
+        assertEquals("WALKING", seg.activityType)
+        assertEquals(102, seg.distanceMeters)  // truncated from 102.94
+        assertEquals("0.97", seg.confidence)
+    }
+
+    @Test
+    fun new_format_semantic_type_mapping() = runTest {
+        val variants = """
+            {
+              "semanticSegments": [
+                {
+                  "startTime": "2026-01-01T00:00:00.000Z",
+                  "endTime":   "2026-01-01T01:00:00.000Z",
+                  "visit": { "probability": 0.5, "topCandidate": {
+                    "placeId": "p1", "semanticType": "INFERRED_WORK",
+                    "placeLocation": { "latLng": "45.0°, 4.0°" } } }
+                },
+                {
+                  "startTime": "2026-01-01T02:00:00.000Z",
+                  "endTime":   "2026-01-01T03:00:00.000Z",
+                  "visit": { "probability": 0.5, "topCandidate": {
+                    "placeId": "p2", "semanticType": "UNKNOWN",
+                    "placeLocation": { "latLng": "45.1°, 4.1°" } } }
+                }
+              ]
+            }
+        """.trimIndent()
+        service.importJson(variants)
+        val visits = db.locationDao().getAllVisits().sortedBy { it.startMs }
+        assertEquals("Travail", visits[0].placeName)
+        assertNull(visits[1].placeName)  // UNKNOWN → null
+    }
+
+    @Test
+    fun parse_latLngString_handles_negative_and_no_degree_symbol() {
+        val (lat1, lng1) = TakeoutTimelineParser.parseLatLngString("45.81213°, 4.8888115°")!!
+        assertEquals(45.81213, lat1, 0.00001)
+        assertEquals(4.8888115, lng1, 0.00001)
+
+        val (lat2, lng2) = TakeoutTimelineParser.parseLatLngString("-45.81213, -4.8888115")!!
+        assertEquals(-45.81213, lat2, 0.00001)
+        assertEquals(-4.8888115, lng2, 0.00001)
+
+        assertNull(TakeoutTimelineParser.parseLatLngString(""))
+        assertNull(TakeoutTimelineParser.parseLatLngString("not coords"))
+        assertNull(TakeoutTimelineParser.parseLatLngString("45.0"))  // une seule valeur
+    }
+
+    @Test
+    fun new_format_ignores_timeline_path_and_raw_signals() = runTest {
+        val r = service.importJson(newFormatFixture())
+        // Fixture a 1 visit + 1 activity + 1 timelinePath + 1 rawSignal
+        // Seuls visit + activity doivent être importés
+        assertEquals(1, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+        assertEquals(1, db.locationDao().countVisits())
+        assertEquals(1, db.locationDao().countSegments())
+    }
 }

--- a/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
+++ b/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
@@ -1,0 +1,216 @@
+package fr.datasaillance.nightfall.data.local.location
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class LocalLocationImportServiceTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var service: LocalLocationImportService
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        service = LocalLocationImportService(db.locationDao())
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    private fun jsonFixture(): String = """
+        {
+          "timelineObjects": [
+            {
+              "placeVisit": {
+                "location": {
+                  "latitudeE7": 487856200,
+                  "longitudeE7": 23478500,
+                  "placeId": "ChIJ_paris_home",
+                  "name": "Maison",
+                  "address": "1 rue de Rivoli, Paris"
+                },
+                "duration": {
+                  "startTimestamp": "2024-01-15T08:30:00.000Z",
+                  "endTimestamp": "2024-01-15T17:45:00.000Z"
+                },
+                "visitConfidence": "HIGH_CONFIDENCE"
+              }
+            },
+            {
+              "activitySegment": {
+                "startLocation": { "latitudeE7": 487856200, "longitudeE7": 23478500 },
+                "endLocation":   { "latitudeE7": 487900000, "longitudeE7": 23500000 },
+                "duration": {
+                  "startTimestamp": "2024-01-15T17:45:00.000Z",
+                  "endTimestamp": "2024-01-15T18:15:00.000Z"
+                },
+                "activityType": "WALKING",
+                "distance": 2150,
+                "confidence": "MEDIUM"
+              }
+            },
+            {
+              "placeVisit": {
+                "location": {
+                  "latitudeE7": 487900000,
+                  "longitudeE7": 23500000
+                },
+                "duration": {
+                  "startTimestamp": "2024-01-15T18:15:00.000Z",
+                  "endTimestamp": "2024-01-15T20:00:00.000Z"
+                }
+              }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun parse_extracts_visits_and_segments() = runTest {
+        val r = service.importJson(jsonFixture())
+        assertEquals(2, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+        assertEquals(0, r.visitsSkipped)
+
+        val visits = db.locationDao().getAllVisits()
+        assertEquals(2, visits.size)
+        val first = visits.first()
+        assertEquals(48.78562, first.lat, 0.00001)
+        assertEquals(2.34785, first.lng, 0.00001)
+        assertEquals("Maison", first.placeName)
+        assertEquals("ChIJ_paris_home", first.placeId)
+        assertEquals("HIGH_CONFIDENCE", first.confidence)
+
+        val segments = db.locationDao().getAllSegments()
+        assertEquals(1, segments.size)
+        assertEquals("WALKING", segments.first().activityType)
+        assertEquals(2150, segments.first().distanceMeters)
+    }
+
+    @Test
+    fun import_idempotent() = runTest {
+        service.importJson(jsonFixture())
+        val r2 = service.importJson(jsonFixture())
+        assertEquals(0, r2.visitsInserted)
+        assertEquals(2, r2.visitsSkipped)
+        assertEquals(0, r2.segmentsInserted)
+        assertEquals(1, r2.segmentsSkipped)
+        // Pas de doublons en DB
+        assertEquals(2, db.locationDao().countVisits())
+        assertEquals(1, db.locationDao().countSegments())
+    }
+
+    @Test
+    fun parse_tolerant_to_missing_optional_fields() = runTest {
+        // 2e visit du fixture n'a pas de placeId / name / address / confidence
+        service.importJson(jsonFixture())
+        val visits = db.locationDao().getAllVisits()
+        val visitMinimal = visits.last()
+        assertNull(visitMinimal.placeId)
+        assertNull(visitMinimal.placeName)
+        assertNull(visitMinimal.address)
+        assertNull(visitMinimal.confidence)
+    }
+
+    @Test
+    fun parse_ignores_malformed_entries() = runTest {
+        val bad = """
+            {
+              "timelineObjects": [
+                { "placeVisit": { "location": {} } },
+                { "placeVisit": { "duration": { "startTimestamp": "2024-01-15T08:00:00Z" } } },
+                { "activitySegment": {} },
+                { "unknown": {} }
+              ]
+            }
+        """.trimIndent()
+        val r = service.importJson(bad)
+        assertEquals(0, r.visitsInserted)
+        assertEquals(0, r.segmentsInserted)
+    }
+
+    @Test
+    fun activity_type_breakdown() = runTest {
+        val multi = """
+            {
+              "timelineObjects": [
+                ${segmentJson("2024-01-15T10:00:00Z", "2024-01-15T10:30:00Z", "WALKING")},
+                ${segmentJson("2024-01-15T11:00:00Z", "2024-01-15T11:30:00Z", "WALKING")},
+                ${segmentJson("2024-01-15T12:00:00Z", "2024-01-15T12:30:00Z", "CYCLING")},
+                ${segmentJson("2024-01-15T13:00:00Z", "2024-01-15T13:30:00Z", "IN_PASSENGER_VEHICLE")}
+              ]
+            }
+        """.trimIndent()
+        service.importJson(multi)
+        val breakdown = db.locationDao().getActivityTypeBreakdown()
+        val map = breakdown.associate { it.activityType to it.cnt }
+        assertEquals(2, map["WALKING"])
+        assertEquals(1, map["CYCLING"])
+        assertEquals(1, map["IN_PASSENGER_VEHICLE"])
+    }
+
+    @Test
+    fun zip_import_extracts_only_semantic_history_files() = runTest {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            // Doit être pris : nom format Takeout
+            zos.putNextEntry(ZipEntry("Takeout/Location History (Timeline)/Semantic Location History/2024/2024_JANUARY.json"))
+            zos.write(jsonFixture().toByteArray())
+            zos.closeEntry()
+            // Doit être ignoré : autre fichier Takeout (Records.json)
+            zos.putNextEntry(ZipEntry("Takeout/Location History (Timeline)/Records.json"))
+            zos.write("{\"locations\":[]}".toByteArray())
+            zos.closeEntry()
+            // Doit être ignoré : fichier random
+            zos.putNextEntry(ZipEntry("readme.txt"))
+            zos.write("hello".toByteArray())
+            zos.closeEntry()
+        }
+        val r = service.importZip(ByteArrayInputStream(baos.toByteArray()))
+        assertEquals(1, r.filesProcessed)
+        assertEquals(2, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+    }
+
+    @Test
+    fun query_in_range() = runTest {
+        service.importJson(jsonFixture())
+        // 1er visit start = 2024-01-15T08:30:00Z = 1705307400000 ms
+        val midDay = 1_705_320_000_000L // ~12:00 same day
+        val nextDay = 1_705_392_000_000L // 24h later
+        val visits = db.locationDao().getVisitsInRange(midDay, nextDay)
+        // Seul le 2e visit (18:15 → 20:00) tombe dans la fenêtre
+        assertEquals(1, visits.size)
+        assertNotNull(visits.first())
+    }
+
+    private fun segmentJson(start: String, end: String, activity: String): String = """
+        {
+          "activitySegment": {
+            "startLocation": { "latitudeE7": 487856200, "longitudeE7": 23478500 },
+            "endLocation":   { "latitudeE7": 487900000, "longitudeE7": 23500000 },
+            "duration": { "startTimestamp": "$start", "endTimestamp": "$end" },
+            "activityType": "$activity"
+          }
+        }
+    """.trimIndent()
+}

--- a/docs/vault/code/android-app/app/build.gradle.md
+++ b/docs/vault/code/android-app/app/build.gradle.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/build.gradle.kts
-git_blob: 161e53797fddda284439be8265a56c9cb30e9ec0
-last_synced: '2026-05-20T18:28:21Z'
+git_blob: 17ccea6ae24e77beca222ee83bae180677f10de1
+last_synced: '2026-05-20T16:30:46Z'
 loc: 135
 annotations: []
 imports: []
@@ -133,8 +133,8 @@ dependencies {
     implementation("androidx.core:core-ktx:1.15.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
 
-    // WorkManager — Phase B_us : collecte UsageStats quotidienne en background
-    implementation("androidx.work:work-runtime-ktx:2.10.0")
+    // OSMDroid — carte OpenStreetMap embedded (Phase C_gps, raster tiles, no API key)
+    implementation("org.osmdroid:osmdroid-android:6.1.20")
 
     // Test dependencies
     testImplementation("junit:junit:4.13.2")

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.md
@@ -1,0 +1,93 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
+git_blob: c2ec0aec659239b1d3ceeb156fdf4f1c69b64eeb
+last_synced: '2026-05-09T19:12:26Z'
+loc: 50
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+
+@Dao
+interface LocationDao {
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertVisits(rows: List<LocationVisitEntity>): List<Long>
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSegments(rows: List<ActivitySegmentEntity>): List<Long>
+
+    @Query("SELECT * FROM location_visits ORDER BY start_ms ASC")
+    suspend fun getAllVisits(): List<LocationVisitEntity>
+
+    @Query("SELECT * FROM location_visits WHERE start_ms >= :fromMs AND start_ms < :toMs ORDER BY start_ms ASC")
+    suspend fun getVisitsInRange(fromMs: Long, toMs: Long): List<LocationVisitEntity>
+
+    @Query("SELECT * FROM activity_segments ORDER BY start_ms ASC")
+    suspend fun getAllSegments(): List<ActivitySegmentEntity>
+
+    @Query("SELECT * FROM activity_segments WHERE start_ms >= :fromMs AND start_ms < :toMs ORDER BY start_ms ASC")
+    suspend fun getSegmentsInRange(fromMs: Long, toMs: Long): List<ActivitySegmentEntity>
+
+    @Query("SELECT activity_type, COUNT(*) as cnt FROM activity_segments GROUP BY activity_type ORDER BY cnt DESC")
+    suspend fun getActivityTypeBreakdown(): List<ActivityTypeCount>
+
+    @Query("SELECT COUNT(*) FROM location_visits")
+    suspend fun countVisits(): Int
+
+    @Query("SELECT COUNT(*) FROM activity_segments")
+    suspend fun countSegments(): Int
+
+    @Query("DELETE FROM location_visits")
+    suspend fun deleteAllVisits()
+
+    @Query("DELETE FROM activity_segments")
+    suspend fun deleteAllSegments()
+}
+
+data class ActivityTypeCount(
+    @androidx.room.ColumnInfo(name = "activity_type") val activityType: String,
+    val cnt: Int,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocationDao` (class) — lines 10-45
+- `insertVisits` (function) — lines 13-14
+- `insertSegments` (function) — lines 16-17
+- `getAllVisits` (function) — lines 19-20
+- `getVisitsInRange` (function) — lines 22-23
+- `getAllSegments` (function) — lines 25-26
+- `getSegmentsInRange` (function) — lines 28-29
+- `getActivityTypeBreakdown` (function) — lines 31-32
+- `countVisits` (function) — lines 34-35
+- `countSegments` (function) — lines 37-38
+- `deleteAllVisits` (function) — lines 40-41
+- `deleteAllSegments` (function) — lines 43-44
+- `ActivityTypeCount` (class) — lines 47-50

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
-git_blob: b2dc9136adbe8356ed21007e4abae294ab38e359
-last_synced: '2026-05-20T15:39:48Z'
-loc: 54
+git_blob: cb4c67598757cc9b39e6e84892071dc8ab7763ca
+last_synced: '2026-05-20T16:30:46Z'
+loc: 69
 annotations: []
 imports: []
 exports: []
@@ -28,6 +28,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 
 @Dao
@@ -69,6 +70,20 @@ interface LocationDao {
 
     @Query("DELETE FROM activity_segments")
     suspend fun deleteAllSegments()
+
+    // --- Paths GPS (timelinePath du nouveau format Google) ---
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertPaths(rows: List<LocationPathEntity>): List<Long>
+
+    @Query("SELECT * FROM location_paths WHERE start_ms >= :fromMs AND start_ms < :toMs ORDER BY start_ms ASC")
+    suspend fun getPathsInRange(fromMs: Long, toMs: Long): List<LocationPathEntity>
+
+    @Query("SELECT COUNT(*) FROM location_paths")
+    suspend fun countPaths(): Int
+
+    @Query("DELETE FROM location_paths")
+    suspend fun deleteAllPaths()
 }
 
 data class ActivityTypeCount(
@@ -82,17 +97,21 @@ data class ActivityTypeCount(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `LocationDao` (class) — lines 10-49
-- `insertVisits` (function) — lines 13-14
-- `insertSegments` (function) — lines 16-17
-- `getAllVisits` (function) — lines 19-20
-- `getVisitsInRange` (function) — lines 22-23
-- `getAllSegments` (function) — lines 25-26
-- `getSegmentsInRange` (function) — lines 28-29
-- `getActivityTypeBreakdown` (function) — lines 31-32
-- `getActivityStartTimesInRange` (function) — lines 35-36
-- `countVisits` (function) — lines 38-39
-- `countSegments` (function) — lines 41-42
-- `deleteAllVisits` (function) — lines 44-45
-- `deleteAllSegments` (function) — lines 47-48
-- `ActivityTypeCount` (class) — lines 51-54
+- `LocationDao` (class) — lines 11-64
+- `insertVisits` (function) — lines 14-15
+- `insertSegments` (function) — lines 17-18
+- `getAllVisits` (function) — lines 20-21
+- `getVisitsInRange` (function) — lines 23-24
+- `getAllSegments` (function) — lines 26-27
+- `getSegmentsInRange` (function) — lines 29-30
+- `getActivityTypeBreakdown` (function) — lines 32-33
+- `getActivityStartTimesInRange` (function) — lines 36-37
+- `countVisits` (function) — lines 39-40
+- `countSegments` (function) — lines 42-43
+- `deleteAllVisits` (function) — lines 45-46
+- `deleteAllSegments` (function) — lines 48-49
+- `insertPaths` (function) — lines 53-54
+- `getPathsInRange` (function) — lines 56-57
+- `countPaths` (function) — lines 59-60
+- `deleteAllPaths` (function) — lines 62-63
+- `ActivityTypeCount` (class) — lines 66-69

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/dao/LocationDao.kt
-git_blob: c2ec0aec659239b1d3ceeb156fdf4f1c69b64eeb
-last_synced: '2026-05-09T19:12:26Z'
-loc: 50
+git_blob: b2dc9136adbe8356ed21007e4abae294ab38e359
+last_synced: '2026-05-20T15:39:48Z'
+loc: 54
 annotations: []
 imports: []
 exports: []
@@ -54,6 +54,10 @@ interface LocationDao {
     @Query("SELECT activity_type, COUNT(*) as cnt FROM activity_segments GROUP BY activity_type ORDER BY cnt DESC")
     suspend fun getActivityTypeBreakdown(): List<ActivityTypeCount>
 
+    /** Pour le badge "sorti du domicile" — retourne tous les start_ms d'activities dans la plage. */
+    @Query("SELECT DISTINCT start_ms FROM activity_segments WHERE start_ms >= :fromMs AND start_ms < :toMs")
+    suspend fun getActivityStartTimesInRange(fromMs: Long, toMs: Long): List<Long>
+
     @Query("SELECT COUNT(*) FROM location_visits")
     suspend fun countVisits(): Int
 
@@ -78,7 +82,7 @@ data class ActivityTypeCount(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `LocationDao` (class) — lines 10-45
+- `LocationDao` (class) — lines 10-49
 - `insertVisits` (function) — lines 13-14
 - `insertSegments` (function) — lines 16-17
 - `getAllVisits` (function) — lines 19-20
@@ -86,8 +90,9 @@ data class ActivityTypeCount(
 - `getAllSegments` (function) — lines 25-26
 - `getSegmentsInRange` (function) — lines 28-29
 - `getActivityTypeBreakdown` (function) — lines 31-32
-- `countVisits` (function) — lines 34-35
-- `countSegments` (function) — lines 37-38
-- `deleteAllVisits` (function) — lines 40-41
-- `deleteAllSegments` (function) — lines 43-44
-- `ActivityTypeCount` (class) — lines 47-50
+- `getActivityStartTimesInRange` (function) — lines 35-36
+- `countVisits` (function) — lines 38-39
+- `countSegments` (function) — lines 41-42
+- `deleteAllVisits` (function) — lines 44-45
+- `deleteAllSegments` (function) — lines 47-48
+- `ActivityTypeCount` (class) — lines 51-54

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
-git_blob: 68007ca5b2d00e3ec7b4a490349451b955415f37
-last_synced: '2026-05-09T18:49:36Z'
-loc: 109
+git_blob: 5d6ad70cec67f65f6ae189d1a8c591aa4dd4e1a7
+last_synced: '2026-05-09T19:12:26Z'
+loc: 140
 annotations: []
 imports: []
 exports: []
@@ -32,15 +32,16 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import fr.datasaillance.nightfall.data.local.dao.ExerciseDao
 import fr.datasaillance.nightfall.data.local.dao.HeartRateDao
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
 import fr.datasaillance.nightfall.data.local.dao.SleepDao
 import fr.datasaillance.nightfall.data.local.dao.StepsDao
-import fr.datasaillance.nightfall.data.local.dao.UsageStatsDao
 import fr.datasaillance.nightfall.data.local.entity.ExerciseSessionEntity
 import fr.datasaillance.nightfall.data.local.entity.HeartRateHourlyEntity
 import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
 import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
 import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
-import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
 
 @Database(
@@ -50,7 +51,8 @@ import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
         HeartRateHourlyEntity::class,
         StepsHourlyEntity::class,
         ExerciseSessionEntity::class,
-        UsageDailyEntity::class, // v2 — Phase A_us usage stats
+        LocationVisitEntity::class,    // v2 — Phase A_gps
+        ActivitySegmentEntity::class,  // v2 — Phase A_gps
     ],
     version = 2,
     exportSchema = false,
@@ -61,29 +63,60 @@ abstract class NightfallDatabase : RoomDatabase() {
     abstract fun heartRateDao(): HeartRateDao
     abstract fun stepsDao(): StepsDao
     abstract fun exerciseDao(): ExerciseDao
-    abstract fun usageStatsDao(): UsageStatsDao
+    abstract fun locationDao(): LocationDao
 
-    /** Migration v1 → v2 : ajoute la table `usage_daily` (Phase A_us). */
+    /**
+     * Migration v1 → v2 : ajoute les tables `location_visits` + `activity_segments`
+     * (Phase A_gps). À noter : la branche soeur `feat/usage-stats-collector` fait sa
+     * propre v1→v2 avec `usage_daily`. La consolidation finale (intégration des 2
+     * branches sur main) bumpera à v3 avec les 3 tables.
+     */
     object Migration1to2 : Migration(1, 2) {
         override fun migrate(db: SupportSQLiteDatabase) {
+            // location_visits
             db.execSQL(
                 """
-                CREATE TABLE IF NOT EXISTS `usage_daily` (
+                CREATE TABLE IF NOT EXISTS `location_visits` (
                     `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                    `date` TEXT NOT NULL,
-                    `package_name` TEXT NOT NULL,
-                    `total_time_foreground_ms` INTEGER NOT NULL,
-                    `total_time_visible_ms` INTEGER NOT NULL DEFAULT 0,
-                    `total_time_fgs_ms` INTEGER NOT NULL DEFAULT 0,
-                    `last_time_used_ms` INTEGER NOT NULL DEFAULT 0,
-                    `app_launch_count` INTEGER NOT NULL DEFAULT 0,
-                    `collected_at_ms` INTEGER NOT NULL
+                    `start_ms` INTEGER NOT NULL,
+                    `end_ms` INTEGER NOT NULL,
+                    `lat` REAL NOT NULL,
+                    `lng` REAL NOT NULL,
+                    `place_id` TEXT,
+                    `place_name` TEXT,
+                    `address` TEXT,
+                    `confidence` TEXT,
+                    `source` TEXT NOT NULL DEFAULT 'takeout',
+                    `imported_at_ms` INTEGER NOT NULL
                 )
                 """.trimIndent()
             )
-            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_usage_daily_date_package_name` ON `usage_daily` (`date`, `package_name`)")
-            db.execSQL("CREATE INDEX IF NOT EXISTS `index_usage_daily_date` ON `usage_daily` (`date`)")
-            db.execSQL("CREATE INDEX IF NOT EXISTS `index_usage_daily_package_name` ON `usage_daily` (`package_name`)")
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_location_visits_start_ms_end_ms_lat_lng` ON `location_visits` (`start_ms`, `end_ms`, `lat`, `lng`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_location_visits_start_ms` ON `location_visits` (`start_ms`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_location_visits_place_id` ON `location_visits` (`place_id`)")
+
+            // activity_segments
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `activity_segments` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `start_ms` INTEGER NOT NULL,
+                    `end_ms` INTEGER NOT NULL,
+                    `start_lat` REAL NOT NULL,
+                    `start_lng` REAL NOT NULL,
+                    `end_lat` REAL NOT NULL,
+                    `end_lng` REAL NOT NULL,
+                    `activity_type` TEXT NOT NULL,
+                    `distance_m` INTEGER,
+                    `confidence` TEXT,
+                    `source` TEXT NOT NULL DEFAULT 'takeout',
+                    `imported_at_ms` INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_activity_segments_start_ms_end_ms_activity_type` ON `activity_segments` (`start_ms`, `end_ms`, `activity_type`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_activity_segments_start_ms` ON `activity_segments` (`start_ms`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_activity_segments_activity_type` ON `activity_segments` (`activity_type`)")
         }
     }
 
@@ -114,8 +147,6 @@ abstract class NightfallDatabase : RoomDatabase() {
             )
                 .openHelperFactory(factory)
                 .addMigrations(Migration1to2)
-                // Fallback safety : si une migration future foire ou si l'utilisateur
-                // a une DB v0 inattendue, on rebuild from scratch plutôt que crasher.
                 .fallbackToDestructiveMigration()
                 .build()
         }
@@ -137,13 +168,13 @@ abstract class NightfallDatabase : RoomDatabase() {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NightfallDatabase` (class) — lines 23-109
-- `sleepDao` (function) — lines 37-37
-- `heartRateDao` (function) — lines 38-38
-- `stepsDao` (function) — lines 39-39
-- `exerciseDao` (function) — lines 40-40
-- `usageStatsDao` (function) — lines 41-41
-- `migrate` (function) — lines 45-64
-- `get` (function) — lines 77-81
-- `build` (function) — lines 83-98
-- `resetForTest` (function) — lines 104-107
+- `NightfallDatabase` (class) — lines 24-140
+- `sleepDao` (function) — lines 39-39
+- `heartRateDao` (function) — lines 40-40
+- `stepsDao` (function) — lines 41-41
+- `exerciseDao` (function) — lines 42-42
+- `locationDao` (function) — lines 43-43
+- `migrate` (function) — lines 52-97
+- `get` (function) — lines 110-114
+- `build` (function) — lines 116-129
+- `resetForTest` (function) — lines 135-138

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/database/NightfallDatabase.kt
-git_blob: 5d6ad70cec67f65f6ae189d1a8c591aa4dd4e1a7
-last_synced: '2026-05-09T19:12:26Z'
-loc: 140
+git_blob: 180356db305019d9796c3fce91643d82a5fc3f7a
+last_synced: '2026-05-20T16:30:46Z'
+loc: 166
 annotations: []
 imports: []
 exports: []
@@ -41,6 +41,7 @@ import fr.datasaillance.nightfall.data.local.entity.SleepSessionEntity
 import fr.datasaillance.nightfall.data.local.entity.SleepStageEntity
 import fr.datasaillance.nightfall.data.local.entity.StepsHourlyEntity
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
 
@@ -53,8 +54,9 @@ import fr.datasaillance.nightfall.data.local.security.NightfallKeyManager
         ExerciseSessionEntity::class,
         LocationVisitEntity::class,    // v2 — Phase A_gps
         ActivitySegmentEntity::class,  // v2 — Phase A_gps
+        LocationPathEntity::class,     // v3 — timelinePath (waypoints GPS pour trajets réalistes)
     ],
-    version = 2,
+    version = 3,
     exportSchema = false,
 )
 abstract class NightfallDatabase : RoomDatabase() {
@@ -120,6 +122,30 @@ abstract class NightfallDatabase : RoomDatabase() {
         }
     }
 
+    /**
+     * Migration v2 → v3 : ajoute la table `location_paths` pour stocker les waypoints
+     * `timelinePath` du nouveau format Google Takeout (trajets GPS détaillés).
+     */
+    object Migration2to3 : Migration(2, 3) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                """
+                CREATE TABLE IF NOT EXISTS `location_paths` (
+                    `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    `start_ms` INTEGER NOT NULL,
+                    `end_ms` INTEGER NOT NULL,
+                    `points_json` TEXT NOT NULL,
+                    `point_count` INTEGER NOT NULL,
+                    `source` TEXT NOT NULL DEFAULT 'takeout',
+                    `imported_at_ms` INTEGER NOT NULL
+                )
+                """.trimIndent()
+            )
+            db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS `index_location_paths_start_ms_end_ms` ON `location_paths` (`start_ms`, `end_ms`)")
+            db.execSQL("CREATE INDEX IF NOT EXISTS `index_location_paths_start_ms` ON `location_paths` (`start_ms`)")
+        }
+    }
+
     companion object {
         private const val DB_NAME = "nightfall.db"
 
@@ -146,7 +172,7 @@ abstract class NightfallDatabase : RoomDatabase() {
                 DB_NAME,
             )
                 .openHelperFactory(factory)
-                .addMigrations(Migration1to2)
+                .addMigrations(Migration1to2, Migration2to3)
                 .fallbackToDestructiveMigration()
                 .build()
         }
@@ -168,13 +194,14 @@ abstract class NightfallDatabase : RoomDatabase() {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NightfallDatabase` (class) — lines 24-140
-- `sleepDao` (function) — lines 39-39
-- `heartRateDao` (function) — lines 40-40
-- `stepsDao` (function) — lines 41-41
-- `exerciseDao` (function) — lines 42-42
-- `locationDao` (function) — lines 43-43
-- `migrate` (function) — lines 52-97
-- `get` (function) — lines 110-114
-- `build` (function) — lines 116-129
-- `resetForTest` (function) — lines 135-138
+- `NightfallDatabase` (class) — lines 25-166
+- `sleepDao` (function) — lines 41-41
+- `heartRateDao` (function) — lines 42-42
+- `stepsDao` (function) — lines 43-43
+- `exerciseDao` (function) — lines 44-44
+- `locationDao` (function) — lines 45-45
+- `migrate` (function) — lines 54-99
+- `migrate` (function) — lines 107-123
+- `get` (function) — lines 136-140
+- `build` (function) — lines 142-155
+- `resetForTest` (function) — lines 161-164

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.md
@@ -1,0 +1,70 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.kt
+git_blob: d498b4f96a9f72694da688c9ab36aeea6b108465
+last_synced: '2026-05-09T19:12:26Z'
+loc: 39
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/ActivitySegmentEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity.location
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Segment d'activité : Google Maps Timeline `activitySegment`. Trajet entre 2 visites
+ * (marche, voiture, vélo, transport en commun, etc.).
+ */
+@Entity(
+    tableName = "activity_segments",
+    indices = [
+        Index(value = ["start_ms", "end_ms", "activity_type"], unique = true),
+        Index("start_ms"),
+        Index("activity_type"),
+    ],
+)
+data class ActivitySegmentEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+
+    @ColumnInfo(name = "start_ms") val startMs: Long,
+    @ColumnInfo(name = "end_ms") val endMs: Long,
+
+    @ColumnInfo(name = "start_lat") val startLat: Double,
+    @ColumnInfo(name = "start_lng") val startLng: Double,
+    @ColumnInfo(name = "end_lat") val endLat: Double,
+    @ColumnInfo(name = "end_lng") val endLng: Double,
+
+    /** Valeurs Google : WALKING, RUNNING, CYCLING, IN_PASSENGER_VEHICLE, IN_BUS, IN_SUBWAY, FLYING, etc. */
+    @ColumnInfo(name = "activity_type") val activityType: String,
+
+    @ColumnInfo(name = "distance_m") val distanceMeters: Int? = null,
+    val confidence: String? = null,
+    val source: String = "takeout",
+    @ColumnInfo(name = "imported_at_ms") val importedAtMs: Long = System.currentTimeMillis(),
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ActivitySegmentEntity` (class) — lines 12-39

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.md
@@ -1,0 +1,79 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.kt
+git_blob: 7fa3c152761340c910cb7114f18a227de47198f5
+last_synced: '2026-05-20T16:30:46Z'
+loc: 47
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationPathEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity.location
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Chemin GPS détaillé (Google Takeout `timelinePath`). Contient une suite de waypoints
+ * `{lat, lng, t}` qui permet de tracer la trajectoire réelle au lieu d'un trait
+ * vol d'oiseau.
+ *
+ * Volume typique : ~10 waypoints par path, ~1000 paths pour 3 ans d'historique → 10k points
+ * → JSON < 1 MB → OK pour stockage Room.
+ *
+ * `points_json` = `[{"lat":45.527,"lng":4.878,"t":1708347000000}, ...]` (epoch ms).
+ */
+@Entity(
+    tableName = "location_paths",
+    indices = [
+        Index(value = ["start_ms", "end_ms"], unique = true),
+        Index("start_ms"),
+    ],
+)
+data class LocationPathEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+
+    @ColumnInfo(name = "start_ms") val startMs: Long,
+    @ColumnInfo(name = "end_ms") val endMs: Long,
+
+    /** JSON sérialisé des waypoints. Voir [LocationPathPoint] pour le schéma. */
+    @ColumnInfo(name = "points_json") val pointsJson: String,
+
+    /** Nombre de waypoints (dénormalisé pour filtrage rapide sans parser le JSON). */
+    @ColumnInfo(name = "point_count") val pointCount: Int,
+
+    val source: String = "takeout",
+    @ColumnInfo(name = "imported_at_ms") val importedAtMs: Long = System.currentTimeMillis(),
+)
+
+/** Schéma d'un waypoint sérialisé dans `points_json`. */
+data class LocationPathPoint(
+    val lat: Double,
+    val lng: Double,
+    val t: Long,
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocationPathEntity` (class) — lines 18-40
+- `LocationPathPoint` (class) — lines 43-47

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.md
@@ -1,0 +1,75 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.kt
+git_blob: 6676ff72778e9c636a950796b0ab7b0f52c26341
+last_synced: '2026-05-09T19:12:26Z'
+loc: 44
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/entity/location/LocationVisitEntity.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.entity.location
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Visite : Google Maps Timeline `placeVisit`. POI ou lieu où l'utilisateur est resté
+ * un temps significatif.
+ *
+ * Coordonnées en degrés décimaux (Google exporte en E7 = degrés × 1e7, on convertit).
+ * Timestamps en epoch millis UTC.
+ */
+@Entity(
+    tableName = "location_visits",
+    indices = [
+        Index(value = ["start_ms", "end_ms", "lat", "lng"], unique = true),
+        Index("start_ms"),
+        Index("place_id"),
+    ],
+)
+data class LocationVisitEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0L,
+
+    @ColumnInfo(name = "start_ms") val startMs: Long,
+    @ColumnInfo(name = "end_ms") val endMs: Long,
+
+    val lat: Double,
+    val lng: Double,
+
+    @ColumnInfo(name = "place_id") val placeId: String? = null,
+    @ColumnInfo(name = "place_name") val placeName: String? = null,
+    val address: String? = null,
+
+    /** "HIGH_CONFIDENCE" / "MEDIUM_CONFIDENCE" / "LOW_CONFIDENCE" / null. */
+    val confidence: String? = null,
+
+    /** Source : "takeout" en Phase A_gps, "live" en Phase B_gps. Permet futur cross-check. */
+    val source: String = "takeout",
+
+    @ColumnInfo(name = "imported_at_ms") val importedAtMs: Long = System.currentTimeMillis(),
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocationVisitEntity` (class) — lines 15-44

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
-git_blob: 4809d4806cb0eb77793437c8a85c86ea28166464
-last_synced: '2026-05-09T19:12:27Z'
-loc: 103
+git_blob: 14d029693d7e64c91e5f9ace8fed70a4b4252f13
+last_synced: '2026-05-20T16:30:46Z'
+loc: 115
 annotations: []
 imports: []
 exports: []
@@ -34,6 +34,8 @@ data class LocationImportResult(
     val visitsSkipped: Int,
     val segmentsInserted: Int,
     val segmentsSkipped: Int,
+    val pathsInserted: Int = 0,
+    val pathsSkipped: Int = 0,
     val filesProcessed: Int,
 )
 
@@ -55,13 +57,17 @@ class LocalLocationImportService(
         val parsed = TakeoutTimelineParser.parse(rawJson)
         val visitIds = if (parsed.visits.isNotEmpty()) dao.insertVisits(parsed.visits) else emptyList()
         val segmentIds = if (parsed.segments.isNotEmpty()) dao.insertSegments(parsed.segments) else emptyList()
+        val pathIds = if (parsed.paths.isNotEmpty()) dao.insertPaths(parsed.paths) else emptyList()
         val visitsInserted = visitIds.count { it != -1L }
         val segmentsInserted = segmentIds.count { it != -1L }
+        val pathsInserted = pathIds.count { it != -1L }
         return LocationImportResult(
             visitsInserted = visitsInserted,
             visitsSkipped = parsed.visits.size - visitsInserted,
             segmentsInserted = segmentsInserted,
             segmentsSkipped = parsed.segments.size - segmentsInserted,
+            pathsInserted = pathsInserted,
+            pathsSkipped = parsed.paths.size - pathsInserted,
             filesProcessed = 1,
         )
     }
@@ -77,6 +83,8 @@ class LocalLocationImportService(
         var visitsSkipped = 0
         var segmentsInserted = 0
         var segmentsSkipped = 0
+        var pathsInserted = 0
+        var pathsSkipped = 0
         var filesProcessed = 0
 
         ZipInputStream(input).use { zis ->
@@ -99,6 +107,8 @@ class LocalLocationImportService(
                     visitsSkipped += r.visitsSkipped
                     segmentsInserted += r.segmentsInserted
                     segmentsSkipped += r.segmentsSkipped
+                    pathsInserted += r.pathsInserted
+                    pathsSkipped += r.pathsSkipped
                     filesProcessed++
                 }
                 zis.closeEntry()
@@ -110,6 +120,8 @@ class LocalLocationImportService(
             visitsSkipped = visitsSkipped,
             segmentsInserted = segmentsInserted,
             segmentsSkipped = segmentsSkipped,
+            pathsInserted = pathsInserted,
+            pathsSkipped = pathsSkipped,
             filesProcessed = filesProcessed,
         )
     }
@@ -131,8 +143,8 @@ class LocalLocationImportService(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `LocationImportResult` (class) — lines 9-15
-- `LocalLocationImportService` (class) — lines 26-103
-- `importJson` (function) — lines 31-44
-- `importZip` (function) — lines 51-92
-- `looksLikeSemanticHistory` (function) — lines 94-102
+- `LocationImportResult` (class) — lines 9-17
+- `LocalLocationImportService` (class) — lines 28-115
+- `importJson` (function) — lines 33-50
+- `importZip` (function) — lines 57-104
+- `looksLikeSemanticHistory` (function) — lines 106-114

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.md
@@ -1,0 +1,138 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
+git_blob: 4809d4806cb0eb77793437c8a85c86ea28166464
+last_synced: '2026-05-09T19:12:27Z'
+loc: 103
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportService.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.location
+
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.util.zip.ZipInputStream
+
+data class LocationImportResult(
+    val visitsInserted: Int,
+    val visitsSkipped: Int,
+    val segmentsInserted: Int,
+    val segmentsSkipped: Int,
+    val filesProcessed: Int,
+)
+
+/**
+ * Importe les fichiers Google Takeout "Semantic Location History" en Room locale.
+ *
+ * Pipeline : `bytes (JSON ou ZIP) → parse → bulk insert Room (idempotent)`.
+ *
+ * - Idempotent par construction : indices uniques `(start_ms, end_ms, lat, lng)` pour
+ *   visits et `(start_ms, end_ms, activity_type)` pour segments + OnConflictStrategy.IGNORE.
+ * - Aucun appel réseau, aucune transmission externe.
+ */
+class LocalLocationImportService(
+    private val dao: LocationDao,
+) {
+
+    /** Import d'un seul fichier JSON Semantic Location History. */
+    suspend fun importJson(rawJson: String): LocationImportResult {
+        val parsed = TakeoutTimelineParser.parse(rawJson)
+        val visitIds = if (parsed.visits.isNotEmpty()) dao.insertVisits(parsed.visits) else emptyList()
+        val segmentIds = if (parsed.segments.isNotEmpty()) dao.insertSegments(parsed.segments) else emptyList()
+        val visitsInserted = visitIds.count { it != -1L }
+        val segmentsInserted = segmentIds.count { it != -1L }
+        return LocationImportResult(
+            visitsInserted = visitsInserted,
+            visitsSkipped = parsed.visits.size - visitsInserted,
+            segmentsInserted = segmentsInserted,
+            segmentsSkipped = parsed.segments.size - segmentsInserted,
+            filesProcessed = 1,
+        )
+    }
+
+    /**
+     * Import d'un ZIP Takeout. Cherche tous les `.json` dans le ZIP qui ressemblent
+     * à du Semantic Location History (chemin contient "Semantic Location History"
+     * ou nom de fichier en `<année>_<mois>.json`).
+     */
+    suspend fun importZip(input: InputStream, maxBytes: Long = 500_000_000L): LocationImportResult {
+        var totalUncompressed = 0L
+        var visitsInserted = 0
+        var visitsSkipped = 0
+        var segmentsInserted = 0
+        var segmentsSkipped = 0
+        var filesProcessed = 0
+
+        ZipInputStream(input).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val name = entry.name
+                if (!entry.isDirectory && looksLikeSemanticHistory(name)) {
+                    val baos = ByteArrayOutputStream()
+                    val buf = ByteArray(8192)
+                    var read: Int
+                    while (zis.read(buf).also { read = it } != -1) {
+                        totalUncompressed += read
+                        if (totalUncompressed > maxBytes) {
+                            throw IOException("Archive trop grande (>$maxBytes octets décompressés)")
+                        }
+                        baos.write(buf, 0, read)
+                    }
+                    val r = importJson(baos.toString(Charsets.UTF_8))
+                    visitsInserted += r.visitsInserted
+                    visitsSkipped += r.visitsSkipped
+                    segmentsInserted += r.segmentsInserted
+                    segmentsSkipped += r.segmentsSkipped
+                    filesProcessed++
+                }
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+        return LocationImportResult(
+            visitsInserted = visitsInserted,
+            visitsSkipped = visitsSkipped,
+            segmentsInserted = segmentsInserted,
+            segmentsSkipped = segmentsSkipped,
+            filesProcessed = filesProcessed,
+        )
+    }
+
+    private fun looksLikeSemanticHistory(name: String): Boolean {
+        if (!name.endsWith(".json", ignoreCase = true)) return false
+        val lower = name.lowercase()
+        // Patterns observés : "Takeout/Location History (Timeline)/Semantic Location History/2024/2024_JANUARY.json"
+        // ou "Semantic Location History/.../2024_*.json"
+        return "semantic location history" in lower ||
+            Regex(""".*\d{4}_(january|february|march|april|may|june|july|august|september|october|november|december)\.json""").matches(lower) ||
+            Regex(""".*\d{4}-\d{2}\.json""").matches(lower)
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocationImportResult` (class) — lines 9-15
+- `LocalLocationImportService` (class) — lines 26-103
+- `importJson` (function) — lines 31-44
+- `importZip` (function) — lines 51-92
+- `looksLikeSemanticHistory` (function) — lines 94-102

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.md
@@ -1,0 +1,161 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
+git_blob: 0413da6e27b67125cdd57865933fd5f1f01961ba
+last_synced: '2026-05-09T19:12:27Z'
+loc: 125
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.location
+
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import org.json.JSONArray
+import org.json.JSONObject
+import java.time.Instant
+
+/**
+ * Parse les fichiers Google Takeout "Semantic Location History".
+ *
+ * Format racine (recent ~2024) :
+ * ```json
+ * { "timelineObjects": [
+ *     { "placeVisit": {...} },
+ *     { "activitySegment": {...} }
+ * ] }
+ * ```
+ *
+ * Lat/lng sont en E7 (degrés × 1e7) côté Google ; on convertit en degrés décimaux.
+ * Timestamps en ISO 8601 avec offset (généralement Z) ou en epoch millis selon
+ * la version d'export — on supporte les deux.
+ *
+ * Implémentation org.json (built-in Android) — tolérante, pas de dépendance ajoutée.
+ */
+object TakeoutTimelineParser {
+
+    data class ParseResult(
+        val visits: List<LocationVisitEntity>,
+        val segments: List<ActivitySegmentEntity>,
+    )
+
+    fun parse(rawJson: String, importedAtMs: Long = System.currentTimeMillis()): ParseResult {
+        val root = JSONObject(rawJson)
+        val arr = root.optJSONArray("timelineObjects") ?: return ParseResult(emptyList(), emptyList())
+
+        val visits = mutableListOf<LocationVisitEntity>()
+        val segments = mutableListOf<ActivitySegmentEntity>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            obj.optJSONObject("placeVisit")?.let { v ->
+                parseVisit(v, importedAtMs)?.let { visits.add(it) }
+            }
+            obj.optJSONObject("activitySegment")?.let { s ->
+                parseSegment(s, importedAtMs)?.let { segments.add(it) }
+            }
+        }
+        return ParseResult(visits, segments)
+    }
+
+    private fun parseVisit(visit: JSONObject, importedAtMs: Long): LocationVisitEntity? {
+        val location = visit.optJSONObject("location") ?: return null
+        val duration = visit.optJSONObject("duration") ?: return null
+
+        val latE7 = location.optInt("latitudeE7", Int.MIN_VALUE)
+        val lngE7 = location.optInt("longitudeE7", Int.MIN_VALUE)
+        if (latE7 == Int.MIN_VALUE || lngE7 == Int.MIN_VALUE) return null
+
+        val startMs = parseTimestamp(duration.optString("startTimestamp")) ?: return null
+        val endMs = parseTimestamp(duration.optString("endTimestamp")) ?: return null
+
+        return LocationVisitEntity(
+            startMs = startMs,
+            endMs = endMs,
+            lat = latE7 / 1e7,
+            lng = lngE7 / 1e7,
+            placeId = location.optString("placeId").ifBlankOrNullDefault(null),
+            placeName = location.optString("name").ifBlankOrNullDefault(null),
+            address = location.optString("address").ifBlankOrNullDefault(null),
+            confidence = visit.optString("visitConfidence").ifBlankOrNullDefault(null)
+                ?: visit.optString("placeConfidence").ifBlankOrNullDefault(null),
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    private fun parseSegment(segment: JSONObject, importedAtMs: Long): ActivitySegmentEntity? {
+        val start = segment.optJSONObject("startLocation") ?: return null
+        val end = segment.optJSONObject("endLocation") ?: return null
+        val duration = segment.optJSONObject("duration") ?: return null
+
+        val startLatE7 = start.optInt("latitudeE7", Int.MIN_VALUE)
+        val startLngE7 = start.optInt("longitudeE7", Int.MIN_VALUE)
+        val endLatE7 = end.optInt("latitudeE7", Int.MIN_VALUE)
+        val endLngE7 = end.optInt("longitudeE7", Int.MIN_VALUE)
+        if (startLatE7 == Int.MIN_VALUE || endLatE7 == Int.MIN_VALUE) return null
+
+        val startMs = parseTimestamp(duration.optString("startTimestamp")) ?: return null
+        val endMs = parseTimestamp(duration.optString("endTimestamp")) ?: return null
+
+        val activityType = segment.optString("activityType").ifBlankOrNullDefault("UNKNOWN")
+            ?: "UNKNOWN"
+        val distance = segment.optInt("distance", -1).takeIf { it >= 0 }
+        val confidence = segment.optString("confidence").ifBlankOrNullDefault(null)
+
+        return ActivitySegmentEntity(
+            startMs = startMs,
+            endMs = endMs,
+            startLat = startLatE7 / 1e7,
+            startLng = startLngE7 / 1e7,
+            endLat = endLatE7 / 1e7,
+            endLng = endLngE7 / 1e7,
+            activityType = activityType,
+            distanceMeters = distance,
+            confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    /**
+     * Accepte ISO 8601 (`2024-01-15T08:30:00.000Z` ou avec offset) ou epoch millis
+     * en chaîne (vue dans certaines versions Takeout).
+     */
+    private fun parseTimestamp(value: String): Long? {
+        if (value.isBlank()) return null
+        // Cas epoch numérique
+        value.toLongOrNull()?.let { return it }
+        // Cas ISO 8601
+        return runCatching { Instant.parse(value).toEpochMilli() }.getOrNull()
+    }
+
+    private fun String?.ifBlankOrNullDefault(default: String?): String? =
+        if (this.isNullOrBlank() || this == "null") default else this
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `ParseResult` (class) — lines 28-31
+- `parse` (function) — lines 33-49
+- `parseVisit` (function) — lines 51-75
+- `parseSegment` (function) — lines 77-109
+- `parseTimestamp` (function) — lines 115-121
+- `ifBlankOrNullDefault` (function) — lines 123-124

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
-git_blob: 6fd9e929bbb46971bc4fee856e360ac892ee9409
-last_synced: '2026-05-20T14:36:27Z'
-loc: 241
+git_blob: 675e51259dc6d0c7c55809d12d4addb00a3a8684
+last_synced: '2026-05-20T16:30:46Z'
+loc: 282
 annotations: []
 imports: []
 exports: []
@@ -24,7 +24,9 @@ tags:
 package fr.datasaillance.nightfall.data.local.location
 
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import org.json.JSONArray
 import org.json.JSONObject
 import java.time.Instant
 
@@ -56,12 +58,14 @@ object TakeoutTimelineParser {
     data class ParseResult(
         val visits: List<LocationVisitEntity>,
         val segments: List<ActivitySegmentEntity>,
+        val paths: List<LocationPathEntity> = emptyList(),
     )
 
     fun parse(rawJson: String, importedAtMs: Long = System.currentTimeMillis()): ParseResult {
         val root = JSONObject(rawJson)
         val visits = mutableListOf<LocationVisitEntity>()
         val segments = mutableListOf<ActivitySegmentEntity>()
+        val paths = mutableListOf<LocationPathEntity>()
 
         // Format 1 — ancien : timelineObjects
         root.optJSONArray("timelineObjects")?.let { arr ->
@@ -88,11 +92,13 @@ object TakeoutTimelineParser {
                 seg.optJSONObject("activity")?.let { a ->
                     parseNewActivity(a, startMs, endMs, importedAtMs)?.let { segments.add(it) }
                 }
-                // timelinePath ignoré (sera réintroduit en Phase B_gps avec FusedLocation)
+                seg.optJSONArray("timelinePath")?.let { arr ->
+                    parseTimelinePath(arr, startMs, endMs, importedAtMs)?.let { paths.add(it) }
+                }
             }
         }
 
-        return ParseResult(visits, segments)
+        return ParseResult(visits, segments, paths)
     }
 
     // --- Format 1 (ancien) ---
@@ -234,6 +240,41 @@ object TakeoutTimelineParser {
         )
     }
 
+    /**
+     * Parse un `timelinePath` (suite de waypoints `{point, time}`) en `LocationPathEntity`.
+     * Le champ `points_json` est sérialisé manuellement (pas de dépendance kotlinx.serialization
+     * dans ce module) : `[{"lat":..,"lng":..,"t":..},...]`.
+     */
+    private fun parseTimelinePath(
+        arr: JSONArray,
+        startMs: Long,
+        endMs: Long,
+        importedAtMs: Long,
+    ): LocationPathEntity? {
+        if (arr.length() == 0) return null
+        val sb = StringBuilder()
+        sb.append('[')
+        var count = 0
+        for (i in 0 until arr.length()) {
+            val pt = arr.optJSONObject(i) ?: continue
+            val (lat, lng) = parseLatLngString(pt.optString("point")) ?: continue
+            val tMs = parseTimestamp(pt.optString("time")) ?: continue
+            if (count > 0) sb.append(',')
+            sb.append("""{"lat":$lat,"lng":$lng,"t":$tMs}""")
+            count++
+        }
+        sb.append(']')
+        if (count == 0) return null
+        return LocationPathEntity(
+            startMs = startMs,
+            endMs = endMs,
+            pointsJson = sb.toString(),
+            pointCount = count,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
     // --- Helpers ---
 
     /**
@@ -269,12 +310,13 @@ object TakeoutTimelineParser {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ParseResult` (class) — lines 33-36
-- `parse` (function) — lines 38-73
-- `parseLegacyVisit` (function) — lines 77-101
-- `parseLegacySegment` (function) — lines 103-135
-- `parseNewVisit` (function) — lines 139-176
-- `parseNewActivity` (function) — lines 178-212
-- `parseLatLngString` (function) — lines 220-227
-- `parseTimestamp` (function) — lines 233-237
-- `ifBlankOrNullDefault` (function) — lines 239-240
+- `ParseResult` (class) — lines 35-39
+- `parse` (function) — lines 41-79
+- `parseLegacyVisit` (function) — lines 83-107
+- `parseLegacySegment` (function) — lines 109-141
+- `parseNewVisit` (function) — lines 145-182
+- `parseNewActivity` (function) — lines 184-218
+- `parseTimelinePath` (function) — lines 225-253
+- `parseLatLngString` (function) — lines 261-268
+- `parseTimestamp` (function) — lines 274-278
+- `ifBlankOrNullDefault` (function) — lines 280-281

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/location/TakeoutTimelineParser.kt
-git_blob: 0413da6e27b67125cdd57865933fd5f1f01961ba
-last_synced: '2026-05-09T19:12:27Z'
-loc: 125
+git_blob: 6fd9e929bbb46971bc4fee856e360ac892ee9409
+last_synced: '2026-05-20T14:36:27Z'
+loc: 241
 annotations: []
 imports: []
 exports: []
@@ -25,24 +25,29 @@ package fr.datasaillance.nightfall.data.local.location
 
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
-import org.json.JSONArray
 import org.json.JSONObject
 import java.time.Instant
 
 /**
- * Parse les fichiers Google Takeout "Semantic Location History".
+ * Parse les fichiers Google Takeout "Location History".
  *
- * Format racine (recent ~2024) :
- * ```json
- * { "timelineObjects": [
- *     { "placeVisit": {...} },
- *     { "activitySegment": {...} }
- * ] }
- * ```
+ * Deux formats supportés :
  *
- * Lat/lng sont en E7 (degrés × 1e7) côté Google ; on convertit en degrés décimaux.
- * Timestamps en ISO 8601 avec offset (généralement Z) ou en epoch millis selon
- * la version d'export — on supporte les deux.
+ * 1. **Ancien (Semantic Location History, ~pré-2024)** :
+ *    ```json
+ *    { "timelineObjects": [ { "placeVisit": {...} }, { "activitySegment": {...} } ] }
+ *    ```
+ *    Lat/lng en E7 (degrés × 1e7).
+ *
+ * 2. **Nouveau (Timeline 2024+)** :
+ *    ```json
+ *    { "semanticSegments": [
+ *        { "startTime": "...", "endTime": "...", "visit": {...} },
+ *        { "startTime": "...", "endTime": "...", "activity": {...} },
+ *        { "startTime": "...", "endTime": "...", "timelinePath": [...] }   // ignoré (chemins GPS bruts)
+ *    ], "rawSignals": [...] }                                              // ignoré (~22k points)
+ *    ```
+ *    Lat/lng en string `"45.81213°, 4.8888115°"`.
  *
  * Implémentation org.json (built-in Android) — tolérante, pas de dépendance ajoutée.
  */
@@ -55,23 +60,44 @@ object TakeoutTimelineParser {
 
     fun parse(rawJson: String, importedAtMs: Long = System.currentTimeMillis()): ParseResult {
         val root = JSONObject(rawJson)
-        val arr = root.optJSONArray("timelineObjects") ?: return ParseResult(emptyList(), emptyList())
-
         val visits = mutableListOf<LocationVisitEntity>()
         val segments = mutableListOf<ActivitySegmentEntity>()
-        for (i in 0 until arr.length()) {
-            val obj = arr.optJSONObject(i) ?: continue
-            obj.optJSONObject("placeVisit")?.let { v ->
-                parseVisit(v, importedAtMs)?.let { visits.add(it) }
-            }
-            obj.optJSONObject("activitySegment")?.let { s ->
-                parseSegment(s, importedAtMs)?.let { segments.add(it) }
+
+        // Format 1 — ancien : timelineObjects
+        root.optJSONArray("timelineObjects")?.let { arr ->
+            for (i in 0 until arr.length()) {
+                val obj = arr.optJSONObject(i) ?: continue
+                obj.optJSONObject("placeVisit")?.let { v ->
+                    parseLegacyVisit(v, importedAtMs)?.let { visits.add(it) }
+                }
+                obj.optJSONObject("activitySegment")?.let { s ->
+                    parseLegacySegment(s, importedAtMs)?.let { segments.add(it) }
+                }
             }
         }
+
+        // Format 2 — nouveau : semanticSegments
+        root.optJSONArray("semanticSegments")?.let { arr ->
+            for (i in 0 until arr.length()) {
+                val seg = arr.optJSONObject(i) ?: continue
+                val startMs = parseTimestamp(seg.optString("startTime")) ?: continue
+                val endMs = parseTimestamp(seg.optString("endTime")) ?: continue
+                seg.optJSONObject("visit")?.let { v ->
+                    parseNewVisit(v, startMs, endMs, importedAtMs)?.let { visits.add(it) }
+                }
+                seg.optJSONObject("activity")?.let { a ->
+                    parseNewActivity(a, startMs, endMs, importedAtMs)?.let { segments.add(it) }
+                }
+                // timelinePath ignoré (sera réintroduit en Phase B_gps avec FusedLocation)
+            }
+        }
+
         return ParseResult(visits, segments)
     }
 
-    private fun parseVisit(visit: JSONObject, importedAtMs: Long): LocationVisitEntity? {
+    // --- Format 1 (ancien) ---
+
+    private fun parseLegacyVisit(visit: JSONObject, importedAtMs: Long): LocationVisitEntity? {
         val location = visit.optJSONObject("location") ?: return null
         val duration = visit.optJSONObject("duration") ?: return null
 
@@ -97,7 +123,7 @@ object TakeoutTimelineParser {
         )
     }
 
-    private fun parseSegment(segment: JSONObject, importedAtMs: Long): ActivitySegmentEntity? {
+    private fun parseLegacySegment(segment: JSONObject, importedAtMs: Long): ActivitySegmentEntity? {
         val start = segment.optJSONObject("startLocation") ?: return null
         val end = segment.optJSONObject("endLocation") ?: return null
         val duration = segment.optJSONObject("duration") ?: return null
@@ -131,15 +157,105 @@ object TakeoutTimelineParser {
         )
     }
 
+    // --- Format 2 (nouveau) ---
+
+    private fun parseNewVisit(
+        visit: JSONObject,
+        startMs: Long,
+        endMs: Long,
+        importedAtMs: Long,
+    ): LocationVisitEntity? {
+        val candidate = visit.optJSONObject("topCandidate") ?: return null
+        val placeLocation = candidate.optJSONObject("placeLocation") ?: return null
+        val (lat, lng) = parseLatLngString(placeLocation.optString("latLng")) ?: return null
+
+        val placeId = candidate.optString("placeId").ifBlankOrNullDefault(null)
+        // semanticType : INFERRED_HOME / INFERRED_WORK / UNKNOWN → on l'expose comme placeName
+        // pour que l'utilisateur voie "Maison / Travail" au lieu d'un placeId opaque.
+        val semanticType = candidate.optString("semanticType").ifBlankOrNullDefault(null)
+        val placeName = semanticType?.removePrefix("INFERRED_")?.let { type ->
+            when (type) {
+                "HOME" -> "Maison"
+                "WORK" -> "Travail"
+                "UNKNOWN" -> null
+                else -> type.lowercase().replaceFirstChar { it.uppercase() }
+            }
+        }
+        val probability = visit.optDouble("probability", Double.NaN)
+        val confidence = if (probability.isNaN()) null else "%.2f".format(probability)
+
+        return LocationVisitEntity(
+            startMs = startMs,
+            endMs = endMs,
+            lat = lat,
+            lng = lng,
+            placeId = placeId,
+            placeName = placeName,
+            address = null,
+            confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    private fun parseNewActivity(
+        activity: JSONObject,
+        startMs: Long,
+        endMs: Long,
+        importedAtMs: Long,
+    ): ActivitySegmentEntity? {
+        val start = activity.optJSONObject("start") ?: return null
+        val end = activity.optJSONObject("end") ?: return null
+        val (startLat, startLng) = parseLatLngString(start.optString("latLng")) ?: return null
+        val (endLat, endLng) = parseLatLngString(end.optString("latLng")) ?: return null
+
+        val candidate = activity.optJSONObject("topCandidate") ?: return null
+        val type = candidate.optString("type").ifBlankOrNullDefault("UNKNOWN") ?: "UNKNOWN"
+
+        val distance = activity.optDouble("distanceMeters", Double.NaN)
+            .takeIf { !it.isNaN() && it >= 0 }
+            ?.toInt()
+
+        val probability = activity.optDouble("probability", Double.NaN)
+        val confidence = if (probability.isNaN()) null else "%.2f".format(probability)
+
+        return ActivitySegmentEntity(
+            startMs = startMs,
+            endMs = endMs,
+            startLat = startLat,
+            startLng = startLng,
+            endLat = endLat,
+            endLng = endLng,
+            activityType = type,
+            distanceMeters = distance,
+            confidence = confidence,
+            source = "takeout",
+            importedAtMs = importedAtMs,
+        )
+    }
+
+    // --- Helpers ---
+
     /**
-     * Accepte ISO 8601 (`2024-01-15T08:30:00.000Z` ou avec offset) ou epoch millis
-     * en chaîne (vue dans certaines versions Takeout).
+     * Parse `"45.81213°, 4.8888115°"` (nouveau format) ou `"45.81213, 4.8888115"` (sans degré).
+     * Tolérant aux espaces et au symbole degré optionnel.
+     */
+    internal fun parseLatLngString(value: String): Pair<Double, Double>? {
+        if (value.isBlank()) return null
+        val parts = value.split(",").map { it.trim().trimEnd('°').trim() }
+        if (parts.size != 2) return null
+        val lat = parts[0].toDoubleOrNull() ?: return null
+        val lng = parts[1].toDoubleOrNull() ?: return null
+        return lat to lng
+    }
+
+    /**
+     * Accepte ISO 8601 (`2024-01-15T08:30:00.000Z` ou avec offset `+01:00`)
+     * ou epoch millis en chaîne.
      */
     private fun parseTimestamp(value: String): Long? {
         if (value.isBlank()) return null
-        // Cas epoch numérique
         value.toLongOrNull()?.let { return it }
-        // Cas ISO 8601
         return runCatching { Instant.parse(value).toEpochMilli() }.getOrNull()
     }
 
@@ -153,9 +269,12 @@ object TakeoutTimelineParser {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ParseResult` (class) — lines 28-31
-- `parse` (function) — lines 33-49
-- `parseVisit` (function) — lines 51-75
-- `parseSegment` (function) — lines 77-109
-- `parseTimestamp` (function) — lines 115-121
-- `ifBlankOrNullDefault` (function) — lines 123-124
+- `ParseResult` (class) — lines 33-36
+- `parse` (function) — lines 38-73
+- `parseLegacyVisit` (function) — lines 77-101
+- `parseLegacySegment` (function) — lines 103-135
+- `parseNewVisit` (function) — lines 139-176
+- `parseNewActivity` (function) — lines 178-212
+- `parseLatLngString` (function) — lines 220-227
+- `parseTimestamp` (function) — lines 233-237
+- `ifBlankOrNullDefault` (function) — lines 239-240

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/domain/import_/ImportUiState.kt
-git_blob: 5302471b968ad69b32309fc6d75c0d22884bf421
-last_synced: '2026-05-07T03:10:49Z'
-loc: 17
+git_blob: fc537846518ea1b24ac868ec3bacb06cc18046da
+last_synced: '2026-05-20T14:36:27Z'
+loc: 31
 annotations: []
 imports: []
 exports: []
@@ -35,8 +35,22 @@ sealed class ImportUiState {
         val completedTypes: List<ImportDataType>,
         val skippedTypes: List<ImportDataType>,
     ) : ImportUiState()
-    data class Success(val results: List<ImportResult>) : ImportUiState()
+    data class Success(
+        val results: List<ImportResult>,
+        val missingTypes: List<ImportDataType> = emptyList(),
+    ) : ImportUiState()
     data class Error(val message: String, val retryable: Boolean) : ImportUiState()
+
+    // --- Google Timeline (local-only) ---
+    object LocationImporting : ImportUiState()
+    data class LocationSuccess(
+        val visitsInserted: Int,
+        val visitsSkipped: Int,
+        val segmentsInserted: Int,
+        val segmentsSkipped: Int,
+        val filesProcessed: Int,
+    ) : ImportUiState()
+    data class LocationError(val message: String) : ImportUiState()
 }
 ```
 
@@ -45,8 +59,10 @@ sealed class ImportUiState {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportUiState` (class) — lines 3-17
+- `ImportUiState` (class) — lines 3-31
 - `ConnectionFailed` (class) — lines 6-6
 - `Uploading` (class) — lines 9-14
-- `Success` (class) — lines 15-15
-- `Error` (class) — lines 16-16
+- `Success` (class) — lines 15-18
+- `Error` (class) — lines 19-19
+- `LocationSuccess` (class) — lines 23-29
+- `LocationError` (class) — lines 30-30

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: ce4df44a5eb4f975ac69cab71ca2ca1d92e42c69
-last_synced: '2026-05-20T18:53:28Z'
-loc: 293
+git_blob: e148288dba0af6320314c3c5e71ebefdc2c7339d
+last_synced: '2026-05-20T14:36:27Z'
+loc: 281
 annotations: []
 imports: []
 exports: []
@@ -59,9 +59,6 @@ import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
-import fr.datasaillance.nightfall.ui.screens.wellbeing.DigitalWellbeingScreen
-import fr.datasaillance.nightfall.viewmodel.wellbeing.DigitalWellbeingViewModel
-import fr.datasaillance.nightfall.data.local.usage.UsageStatsPermissionHelper
 import fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen
 import fr.datasaillance.nightfall.ui.screens.auth.LoginScreen
 import fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen
@@ -207,22 +204,6 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Activity.route) { ActivityScreen() }
-            composable(NavDestination.Wellbeing.route) {
-                val db = remember(context) {
-                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
-                }
-                val viewModel = remember(context, db) {
-                    val helper = UsageStatsPermissionHelper(context.applicationContext)
-                    DigitalWellbeingViewModel(
-                        checkPermission = { helper.hasPermission() },
-                        dao = db.usageStatsDao(),
-                        packageResolver = fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver(
-                            context.applicationContext.packageManager
-                        ),
-                    )
-                }
-                DigitalWellbeingScreen(viewModel = viewModel)
-            }
             composable(NavDestination.Profile.route) {
                 ProfileScreen(
                     onImport   = { navController.navigate(NavDestination.Import.route) },
@@ -237,9 +218,11 @@ fun NavGraph(
             }
             composable(NavDestination.Import.route) {
                 val context = LocalContext.current
-                val repository: ImportRepository = remember(api, context) {
+                val db = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                }
+                val repository: ImportRepository = remember(api, db) {
                     if (api != null) {
-                        val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
                         val localService = fr.datasaillance.nightfall.data.local.import_.LocalImportService(
                             sleepDao = db.sleepDao(),
                             heartRateDao = db.heartRateDao(),
@@ -251,7 +234,12 @@ fun NavGraph(
                         NoOpImportRepository()
                     }
                 }
-                val viewModel = remember(repository) { ImportViewModel(repository) }
+                val locationService = remember(db) {
+                    fr.datasaillance.nightfall.data.local.location.LocalLocationImportService(db.locationDao())
+                }
+                val viewModel = remember(repository, locationService) {
+                    ImportViewModel(repository, locationService)
+                }
                 ImportScreen(
                     viewModel = viewModel,
                     onNavigateBack = { navController.popBackStack() },
@@ -321,17 +309,17 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 58-245
-- `NoOpSleepRepository` (class) — lines 247-252
-- `getSessions` (function) — lines 248-251
-- `NoOpImportRepository` (class) — lines 254-269
-- `pingBackend` (function) — lines 255-255
-- `extractCsvEntries` (function) — lines 257-260
-- `uploadCsv` (function) — lines 262-268
-- `NoOpNightfallApi` (class) — lines 271-277
-- `health` (function) — lines 272-272
-- `login` (function) — lines 273-273
-- `register` (function) — lines 274-274
-- `requestPasswordReset` (function) — lines 275-275
-- `googleStart` (function) — lines 276-276
-- `ensureComposeNavigators` (function) — lines 285-293
+- `NavGraph` (function) — lines 55-233
+- `NoOpSleepRepository` (class) — lines 235-240
+- `getSessions` (function) — lines 236-239
+- `NoOpImportRepository` (class) — lines 242-257
+- `pingBackend` (function) — lines 243-243
+- `extractCsvEntries` (function) — lines 245-248
+- `uploadCsv` (function) — lines 250-256
+- `NoOpNightfallApi` (class) — lines 259-265
+- `health` (function) — lines 260-260
+- `login` (function) — lines 261-261
+- `register` (function) — lines 262-262
+- `requestPasswordReset` (function) — lines 263-263
+- `googleStart` (function) — lines 264-264
+- `ensureComposeNavigators` (function) — lines 273-281

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 52d11f6da6b36036b355d83efc5ccff404d3249f
-last_synced: '2026-05-20T15:39:48Z'
-loc: 285
+git_blob: 45507c8cbc40c1525ab18eccfa2369748beca4b8
+last_synced: '2026-05-20T16:30:46Z'
+loc: 292
 annotations: []
 imports: []
 exports: []
@@ -178,12 +178,19 @@ fun NavGraph(
             ) { backStackEntry ->
                 val sessionId = backStackEntry.arguments?.getString("sessionId") ?: return@composable
                 val dateArg = backStackEntry.arguments?.getString("date")
-                val hypnogramRepository: SleepRepository = remember(context) {
-                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
-                    LocalSleepRepository(db.sleepDao())
+                val hypnogramDb = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
                 }
-                val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository) {
-                    HypnogramViewModel(sessionId, hypnogramRepository, hintDate = dateArg)
+                val hypnogramRepository: SleepRepository = remember(hypnogramDb) {
+                    LocalSleepRepository(hypnogramDb.sleepDao())
+                }
+                val hypnogramViewModel = remember(sessionId, dateArg, hypnogramRepository, hypnogramDb) {
+                    HypnogramViewModel(
+                        sessionId = sessionId,
+                        repository = hypnogramRepository,
+                        hintDate = dateArg,
+                        locationDao = hypnogramDb.locationDao(),
+                    )
                 }
                 HypnogramScreen(
                     viewModel = hypnogramViewModel,
@@ -313,17 +320,17 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 55-237
-- `NoOpSleepRepository` (class) — lines 239-244
-- `getSessions` (function) — lines 240-243
-- `NoOpImportRepository` (class) — lines 246-261
-- `pingBackend` (function) — lines 247-247
-- `extractCsvEntries` (function) — lines 249-252
-- `uploadCsv` (function) — lines 254-260
-- `NoOpNightfallApi` (class) — lines 263-269
-- `health` (function) — lines 264-264
-- `login` (function) — lines 265-265
-- `register` (function) — lines 266-266
-- `requestPasswordReset` (function) — lines 267-267
-- `googleStart` (function) — lines 268-268
-- `ensureComposeNavigators` (function) — lines 277-285
+- `NavGraph` (function) — lines 55-244
+- `NoOpSleepRepository` (class) — lines 246-251
+- `getSessions` (function) — lines 247-250
+- `NoOpImportRepository` (class) — lines 253-268
+- `pingBackend` (function) — lines 254-254
+- `extractCsvEntries` (function) — lines 256-259
+- `uploadCsv` (function) — lines 261-267
+- `NoOpNightfallApi` (class) — lines 270-276
+- `health` (function) — lines 271-271
+- `login` (function) — lines 272-272
+- `register` (function) — lines 273-273
+- `requestPasswordReset` (function) — lines 274-274
+- `googleStart` (function) — lines 275-275
+- `ensureComposeNavigators` (function) — lines 284-292

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: e148288dba0af6320314c3c5e71ebefdc2c7339d
-last_synced: '2026-05-20T14:36:27Z'
-loc: 281
+git_blob: 52d11f6da6b36036b355d83efc5ccff404d3249f
+last_synced: '2026-05-20T15:39:48Z'
+loc: 285
 annotations: []
 imports: []
 exports: []
@@ -191,11 +191,15 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Timeline.route) {
-                val timelineRepository: SleepRepository = remember(context) {
-                    val db = fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                val db = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                }
+                val timelineRepository: SleepRepository = remember(db) {
                     LocalSleepRepository(db.sleepDao())
                 }
-                val timelineViewModel = remember(timelineRepository) { TimelineViewModel(timelineRepository) }
+                val timelineViewModel = remember(timelineRepository, db) {
+                    TimelineViewModel(timelineRepository, db.locationDao())
+                }
                 TimelineScreen(
                     viewModel = timelineViewModel,
                     onOpenHypnogram = { sessionId, isoDate ->
@@ -309,17 +313,17 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 55-233
-- `NoOpSleepRepository` (class) — lines 235-240
-- `getSessions` (function) — lines 236-239
-- `NoOpImportRepository` (class) — lines 242-257
-- `pingBackend` (function) — lines 243-243
-- `extractCsvEntries` (function) — lines 245-248
-- `uploadCsv` (function) — lines 250-256
-- `NoOpNightfallApi` (class) — lines 259-265
-- `health` (function) — lines 260-260
-- `login` (function) — lines 261-261
-- `register` (function) — lines 262-262
-- `requestPasswordReset` (function) — lines 263-263
-- `googleStart` (function) — lines 264-264
-- `ensureComposeNavigators` (function) — lines 273-281
+- `NavGraph` (function) — lines 55-237
+- `NoOpSleepRepository` (class) — lines 239-244
+- `getSessions` (function) — lines 240-243
+- `NoOpImportRepository` (class) — lines 246-261
+- `pingBackend` (function) — lines 247-247
+- `extractCsvEntries` (function) — lines 249-252
+- `uploadCsv` (function) — lines 254-260
+- `NoOpNightfallApi` (class) — lines 263-269
+- `health` (function) — lines 264-264
+- `login` (function) — lines 265-265
+- `register` (function) — lines 266-266
+- `requestPasswordReset` (function) — lines 267-267
+- `googleStart` (function) — lines 268-268
+- `ensureComposeNavigators` (function) — lines 277-285

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/screens/import_/ImportScreen.kt
-git_blob: 3103a4b1522e3e6ef7195f24301304182da21f28
-last_synced: '2026-05-07T03:10:49Z'
-loc: 365
+git_blob: 6b402f5dbce558a934bdbcb9a924a58cbaa77803
+last_synced: '2026-05-20T14:36:27Z'
+loc: 504
 annotations: []
 imports: []
 exports: []
@@ -75,9 +75,15 @@ fun ImportScreen(
     val context = LocalContext.current
 
     val launcher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocumentTree()
+        contract = ActivityResultContracts.OpenDocument()
     ) { uri ->
         uri?.let { viewModel.startUpload(context.contentResolver, it) }
+    }
+
+    val locationLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        uri?.let { viewModel.startLocationImport(context.contentResolver, it) }
     }
 
     Scaffold(
@@ -99,7 +105,14 @@ fun ImportScreen(
                     .padding(padding)
                     .padding(16.dp),
             ) {
-                IdleContent(onCheckConnection = { viewModel.checkConnection() })
+                IdleContent(
+                    onCheckConnection = { viewModel.checkConnection() },
+                    onSelectTimelineJson = {
+                        locationLauncher.launch(
+                            arrayOf("application/json", "application/zip", "*/*")
+                        )
+                    },
+                )
             }
             is ImportUiState.Connecting -> Box(
                 modifier = Modifier
@@ -121,7 +134,7 @@ fun ImportScreen(
                 )
             }
             is ImportUiState.Connected -> ConnectedContent(
-                onSelectFolder = { launcher.launch(null) },
+                onSelectFolder = { launcher.launch(arrayOf("application/zip", "application/octet-stream", "*/*")) },
                 padding = padding,
             )
             is ImportUiState.Selecting -> Box(
@@ -153,6 +166,7 @@ fun ImportScreen(
             ) {
                 SuccessContent(
                     results = state.results,
+                    missingTypes = state.missingTypes,
                     onDone = {
                         viewModel.reset()
                         onNavigateBack()
@@ -172,24 +186,136 @@ fun ImportScreen(
                     onBack = onNavigateBack,
                 )
             }
+            is ImportUiState.LocationImporting -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                LocationImportingContent()
+            }
+            is ImportUiState.LocationSuccess -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                LocationSuccessContent(
+                    state = state,
+                    onDone = {
+                        viewModel.reset()
+                        onNavigateBack()
+                    },
+                )
+            }
+            is ImportUiState.LocationError -> Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp),
+            ) {
+                ErrorContent(
+                    message = state.message,
+                    retryable = true,
+                    onRetry = { viewModel.reset() },
+                    onBack = onNavigateBack,
+                )
+            }
         }
     }
 }
 
 @Composable
-private fun IdleContent(onCheckConnection: () -> Unit) {
+private fun IdleContent(
+    onCheckConnection: () -> Unit,
+    onSelectTimelineJson: () -> Unit,
+) {
     Column(
         modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         Text(
-            text = "Importer des données Samsung Health",
+            text = "Importer des données",
             style = MaterialTheme.typography.headlineSmall,
         )
         Spacer(modifier = Modifier.height(24.dp))
-        Button(onClick = onCheckConnection) {
-            Text("Vérifier la connexion")
+        Button(
+            onClick = onCheckConnection,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Samsung Health (via serveur)")
+        }
+        Spacer(modifier = Modifier.height(12.dp))
+        Button(
+            onClick = onSelectTimelineJson,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text("Google Timeline (local)")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = "L'import Google Timeline ne sort jamais de l'appareil.",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun LocationImportingContent() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(16.dp))
+        Text("Import Google Timeline en cours…")
+    }
+}
+
+@Composable
+private fun LocationSuccessContent(
+    state: ImportUiState.LocationSuccess,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Import Google Timeline terminé",
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text("Visites")
+            Text("${state.visitsInserted} nouvelles · ${state.visitsSkipped} déjà présentes")
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text("Trajets")
+            Text("${state.segmentsInserted} nouveaux · ${state.segmentsSkipped} déjà présents")
+        }
+        if (state.filesProcessed > 1) {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "${state.filesProcessed} fichiers traités",
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = onDone) {
+            Text("Terminer")
         }
     }
 }
@@ -248,7 +374,7 @@ private fun ConnectedContent(
             onClick = onSelectFolder,
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Text("Sélectionner le dossier Samsung Health")
+            Text("Sélectionner l'archive Samsung Health (.zip)")
         }
     }
 }
@@ -288,7 +414,7 @@ private fun SelectingContent() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text("Sélectionnez le dossier Samsung Health…")
+        Text("Sélectionnez l'archive Samsung Health…")
     }
 }
 
@@ -324,6 +450,7 @@ private fun UploadingContent(
 @Composable
 private fun SuccessContent(
     results: List<fr.datasaillance.nightfall.domain.import_.ImportResult>,
+    missingTypes: List<fr.datasaillance.nightfall.domain.import_.ImportDataType>,
     onDone: () -> Unit,
 ) {
     Column(
@@ -346,7 +473,19 @@ private fun SuccessContent(
                 if (result.errorMessage != null) {
                     Text("Erreur", color = MaterialTheme.colorScheme.error)
                 } else {
-                    Text("${result.inserted} insérés, ${result.skipped} ignorés")
+                    Text("${result.inserted} nouveaux · ${result.skipped} déjà présents")
+                }
+            }
+        }
+        if (missingTypes.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(12.dp))
+            missingTypes.forEach { type ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(type.name, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                    Text("Absent du ZIP", color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
             }
         }
@@ -393,13 +532,15 @@ private fun ErrorContent(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportScreen` (function) — lines 45-154
-- `IdleContent` (function) — lines 156-172
-- `ConnectingContent` (function) — lines 174-185
-- `ConnectionFailedContent` (function) — lines 187-204
-- `ConnectedContent` (function) — lines 206-231
-- `RgpdNoticeCard` (function) — lines 233-259
-- `SelectingContent` (function) — lines 261-270
-- `UploadingContent` (function) — lines 272-299
-- `SuccessContent` (function) — lines 301-335
-- `ErrorContent` (function) — lines 337-365
+- `ImportScreen` (function) — lines 45-203
+- `IdleContent` (function) — lines 205-240
+- `LocationImportingContent` (function) — lines 242-253
+- `LocationSuccessContent` (function) — lines 255-298
+- `ConnectingContent` (function) — lines 300-311
+- `ConnectionFailedContent` (function) — lines 313-330
+- `ConnectedContent` (function) — lines 332-357
+- `RgpdNoticeCard` (function) — lines 359-385
+- `SelectingContent` (function) — lines 387-396
+- `UploadingContent` (function) — lines 398-425
+- `SuccessContent` (function) — lines 427-474
+- `ErrorContent` (function) — lines 476-504

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/import_/ImportViewModel.kt
-git_blob: 85fcb95df8c1dee7501bee28dcb5fce4643c0d3b
-last_synced: '2026-05-07T03:10:49Z'
-loc: 99
+git_blob: c8bec80ee85a12f75f1e42bbaef24854a230ae39
+last_synced: '2026-05-20T14:36:27Z'
+loc: 143
 annotations: []
 imports: []
 exports: []
@@ -28,6 +28,7 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.datasaillance.nightfall.data.import_.ImportRepository
+import fr.datasaillance.nightfall.data.local.location.LocalLocationImportService
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.domain.import_.ImportUiState
@@ -39,6 +40,7 @@ import kotlinx.coroutines.launch
 
 class ImportViewModel(
     private val repository: ImportRepository,
+    private val locationService: LocalLocationImportService? = null,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<ImportUiState>(ImportUiState.Idle)
@@ -112,7 +114,49 @@ class ImportViewModel(
                     )
                 }
             }
-            _uiState.value = ImportUiState.Success(results)
+            _uiState.value = ImportUiState.Success(results, missingTypes = skipped.toList())
+        }
+    }
+
+    /**
+     * Import local d'un export Google Timeline (JSON ou ZIP Takeout).
+     * Aucun appel réseau — passe directement par [LocalLocationImportService].
+     */
+    fun startLocationImport(contentResolver: ContentResolver, uri: Uri) {
+        val service = locationService ?: run {
+            _uiState.value = ImportUiState.LocationError("Service Timeline indisponible")
+            return
+        }
+        _uiState.value = ImportUiState.LocationImporting
+        viewModelScope.launch {
+            try {
+                val mime = contentResolver.getType(uri)
+                val nameLower = uri.lastPathSegment.orEmpty().lowercase()
+                val isZip = mime == "application/zip" || nameLower.endsWith(".zip")
+                val result = contentResolver.openInputStream(uri)?.use { input ->
+                    if (isZip) {
+                        service.importZip(input)
+                    } else {
+                        service.importJson(input.readBytes().toString(Charsets.UTF_8))
+                    }
+                } ?: run {
+                    _uiState.value = ImportUiState.LocationError("Fichier introuvable")
+                    return@launch
+                }
+                _uiState.value = ImportUiState.LocationSuccess(
+                    visitsInserted = result.visitsInserted,
+                    visitsSkipped = result.visitsSkipped,
+                    segmentsInserted = result.segmentsInserted,
+                    segmentsSkipped = result.segmentsSkipped,
+                    filesProcessed = result.filesProcessed,
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _uiState.value = ImportUiState.LocationError(
+                    e.message ?: "Erreur d'import (${e.javaClass.simpleName})"
+                )
+            }
         }
     }
 
@@ -127,7 +171,8 @@ class ImportViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `ImportViewModel` (class) — lines 17-99
-- `checkConnection` (function) — lines 24-34
-- `startUpload` (function) — lines 36-94
-- `reset` (function) — lines 96-98
+- `ImportViewModel` (class) — lines 18-143
+- `checkConnection` (function) — lines 26-36
+- `startUpload` (function) — lines 38-96
+- `startLocationImport` (function) — lines 102-138
+- `reset` (function) — lines 140-142

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
-git_blob: 083db3585a42a6107d943419db94b21083dc6ed4
-last_synced: '2026-05-09T14:31:04Z'
-loc: 102
+git_blob: 0f988a37d511847466556d5bf371ce7e8f7a30e0
+last_synced: '2026-05-20T16:30:46Z'
+loc: 139
 annotations: []
 imports: []
 exports: []
@@ -25,6 +25,10 @@ package fr.datasaillance.nightfall.viewmodel.sleep
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,11 +40,21 @@ import timber.log.Timber
 import java.io.IOException
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
+
+data class DayLocation(
+    val visits: List<LocationVisitEntity>,
+    val segments: List<ActivitySegmentEntity>,
+    val paths: List<LocationPathEntity> = emptyList(),
+)
 
 sealed class HypnogramUiState {
     object Idle    : HypnogramUiState()
     object Loading : HypnogramUiState()
-    data class Success(val sessions: List<SleepSessionResponse>) : HypnogramUiState()
+    data class Success(
+        val sessions: List<SleepSessionResponse>,
+        val dayLocation: DayLocation? = null,
+    ) : HypnogramUiState()
     data class Error(val message: String) : HypnogramUiState()
 }
 
@@ -48,6 +62,8 @@ class HypnogramViewModel(
     private val sessionId: String,
     private val repository: SleepRepository,
     private val hintDate: String? = null,
+    private val locationDao: LocationDao? = null,
+    private val zone: ZoneId = ZoneId.systemDefault(),
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<HypnogramUiState>(HypnogramUiState.Idle)
@@ -106,11 +122,32 @@ class HypnogramViewModel(
                 }
                 Timber.d("scope=hypno_vm night_sessions=${nightSessions.size} total_stages=${nightSessions.sumOf { it.stages?.size ?: 0 }}")
                 _uiState.value = HypnogramUiState.Success(nightSessions)
+
+                // Charge les données GPS du jour en arrière-plan — l'hypnogramme s'affiche
+                // tout de suite, la map apparaît dès que les données sont prêtes.
+                if (targetDate != null) {
+                    val dayLoc = loadDayLocation(targetDate)
+                    _uiState.value = HypnogramUiState.Success(nightSessions, dayLocation = dayLoc)
+                }
             } catch (e: Exception) {
                 Timber.w("scope=hypno_vm error=${e::class.simpleName}")
                 _uiState.value = HypnogramUiState.Error(mapError(e))
             }
         }
+    }
+
+    private suspend fun loadDayLocation(date: LocalDate): DayLocation? {
+        val dao = locationDao ?: return null
+        val fromMs = date.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMs = date.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        return runCatching {
+            DayLocation(
+                visits = dao.getVisitsInRange(fromMs, toMs),
+                segments = dao.getSegmentsInRange(fromMs, toMs),
+                paths = dao.getPathsInRange(fromMs, toMs),
+            )
+        }.onFailure { Timber.w("scope=hypno_vm location_load_failed error=${it::class.simpleName}") }
+            .getOrNull()
     }
 
     private fun mapError(throwable: Throwable?): String = when (throwable) {
@@ -130,10 +167,12 @@ class HypnogramViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `HypnogramUiState` (class) — lines 17-22
-- `Success` (class) — lines 20-20
-- `Error` (class) — lines 21-21
-- `HypnogramViewModel` (class) — lines 24-102
-- `retry` (function) — lines 37-37
-- `loadSession` (function) — lines 39-91
-- `mapError` (function) — lines 93-101
+- `DayLocation` (class) — lines 22-26
+- `HypnogramUiState` (class) — lines 28-36
+- `Success` (class) — lines 31-34
+- `Error` (class) — lines 35-35
+- `HypnogramViewModel` (class) — lines 38-139
+- `retry` (function) — lines 53-53
+- `loadSession` (function) — lines 55-114
+- `loadDayLocation` (function) — lines 116-128
+- `mapError` (function) — lines 130-138

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/TimelineViewModel.kt
-git_blob: 0846e3a7cbd041f20a2abf4c029f4655e28157e6
-last_synced: '2026-05-09T14:31:04Z'
-loc: 151
+git_blob: f2677df4926e9f1ea5baf7d67c9cf40bd644f0c5
+last_synced: '2026-05-20T15:39:49Z'
+loc: 187
 annotations: []
 imports: []
 exports: []
@@ -25,6 +25,7 @@ package fr.datasaillance.nightfall.viewmodel.sleep
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,8 +35,10 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.yield
 import timber.log.Timber
 import java.io.IOException
+import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
+import java.time.ZoneId
 
 private const val PAGE_DAYS = 30L
 // Pour le 1er chargement : on n'a pas de borne d'historique, donc on étend la
@@ -47,6 +50,7 @@ sealed class TimelineUiState {
     object Loading : TimelineUiState()
     data class Success(
         val sessions: List<SleepSessionResponse>,
+        val outOfHomeDates: Set<LocalDate> = emptySet(),
         val loadingMore: Boolean = false,
         val hasMore: Boolean = true,
     ) : TimelineUiState()
@@ -56,6 +60,8 @@ sealed class TimelineUiState {
 
 class TimelineViewModel(
     private val repository: SleepRepository,
+    private val locationDao: LocationDao? = null,
+    private val zone: ZoneId = ZoneId.systemDefault(),
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow<TimelineUiState>(TimelineUiState.Idle)
@@ -103,8 +109,10 @@ class TimelineViewModel(
                     _uiState.value = TimelineUiState.Empty
                     return@launch
                 }
+                val sorted = sortSessions(sessions)
                 _uiState.value = TimelineUiState.Success(
-                    sessions = sortSessions(sessions),
+                    sessions = sorted,
+                    outOfHomeDates = computeOutOfHomeDates(sorted),
                     hasMore = true,
                 )
             } catch (e: Exception) {
@@ -147,6 +155,7 @@ class TimelineViewModel(
                 val merged = sortSessions(current.sessions + batch)
                 _uiState.value = current.copy(
                     sessions = merged,
+                    outOfHomeDates = computeOutOfHomeDates(merged),
                     loadingMore = false,
                     hasMore = true,
                 )
@@ -161,6 +170,33 @@ class TimelineViewModel(
         list.sortedBy { session ->
             runCatching { OffsetDateTime.parse(session.sleep_start).toInstant() }.getOrNull()
         }
+
+    /**
+     * Pour chaque session, calcule la journée associée (= date de `sleep_start`)
+     * et vérifie s'il y a au moins une activité GPS ce jour-là. Une seule query
+     * Room couvre toute la fenêtre, puis groupement local.
+     */
+    private suspend fun computeOutOfHomeDates(
+        sessions: List<SleepSessionResponse>,
+    ): Set<LocalDate> {
+        val dao = locationDao ?: return emptySet()
+        if (sessions.isEmpty()) return emptySet()
+        val sessionDates = sessions.mapNotNull { session ->
+            runCatching { OffsetDateTime.parse(session.sleep_start).toLocalDate() }.getOrNull()
+        }.toSet()
+        if (sessionDates.isEmpty()) return emptySet()
+        val minDate = sessionDates.min()
+        val maxDate = sessionDates.max()
+        val fromMs = minDate.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMs = maxDate.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+        val activityStarts = runCatching {
+            dao.getActivityStartTimesInRange(fromMs, toMs)
+        }.getOrDefault(emptyList())
+        return activityStarts.asSequence()
+            .map { Instant.ofEpochMilli(it).atZone(zone).toLocalDate() }
+            .toSet()
+            .intersect(sessionDates)
+    }
 
     private fun mapError(throwable: Throwable?): String = when (throwable) {
         is IOException -> "Vérifiez votre connexion réseau"
@@ -179,12 +215,13 @@ class TimelineViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `TimelineUiState` (class) — lines 22-32
-- `Success` (class) — lines 25-29
-- `Error` (class) — lines 31-31
-- `TimelineViewModel` (class) — lines 34-151
-- `retry` (function) — lines 49-49
-- `loadInitial` (function) — lines 51-92
-- `loadOlder` (function) — lines 94-135
-- `sortSessions` (function) — lines 137-140
-- `mapError` (function) — lines 142-150
+- `TimelineUiState` (class) — lines 25-36
+- `Success` (class) — lines 28-33
+- `Error` (class) — lines 35-35
+- `TimelineViewModel` (class) — lines 38-187
+- `retry` (function) — lines 55-55
+- `loadInitial` (function) — lines 57-100
+- `loadOlder` (function) — lines 102-144
+- `sortSessions` (function) — lines 146-149
+- `computeOutOfHomeDates` (function) — lines 156-176
+- `mapError` (function) — lines 178-186

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.md
@@ -1,0 +1,321 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
+git_blob: 963a19eddf67bdfe63c37f652d647b546f9b5ba3
+last_synced: '2026-05-20T16:30:46Z'
+loc: 279
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
+import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import fr.datasaillance.nightfall.viewmodel.sleep.DayLocation
+import org.json.JSONArray
+import org.osmdroid.config.Configuration
+import org.osmdroid.tileprovider.tilesource.TileSourceFactory
+import org.osmdroid.util.BoundingBox
+import org.osmdroid.util.GeoPoint
+import org.osmdroid.views.MapView
+import org.osmdroid.views.overlay.Marker
+import org.osmdroid.views.overlay.Polyline
+
+@Composable
+fun DayMapSection(
+    dayLocation: DayLocation?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val primary = MaterialTheme.colorScheme.primary
+    val onSurfaceVariant = MaterialTheme.colorScheme.onSurfaceVariant
+
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Text(
+            text = "Déplacements",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            dayLocation == null -> {
+                LocationPlaceholder("Chargement…")
+            }
+            dayLocation.visits.isEmpty() && dayLocation.segments.isEmpty() && dayLocation.paths.isEmpty() -> {
+                LocationPlaceholder("Aucun déplacement enregistré pour cette journée.")
+            }
+            else -> {
+                DayStatsRow(dayLocation, onSurfaceVariant)
+                Spacer(modifier = Modifier.height(12.dp))
+                AndroidView(
+                    factory = { ctx ->
+                        Configuration.getInstance().userAgentValue = ctx.packageName
+                        MapView(ctx).apply {
+                            setTileSource(TileSourceFactory.MAPNIK)
+                            setMultiTouchControls(true)
+                            setHorizontalMapRepetitionEnabled(false)
+                            setVerticalMapRepetitionEnabled(false)
+                            minZoomLevel = 3.0
+                            maxZoomLevel = 19.0
+                        }
+                    },
+                    update = { map ->
+                        populateMap(
+                            map = map,
+                            dayLocation = dayLocation,
+                            visitColor = primary.toArgb(),
+                            segmentColor = primary.toArgb(),
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(280.dp)
+                        .testTag("hyp_day_map"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationPlaceholder(message: String) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(120.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun DayStatsRow(dayLocation: DayLocation, mutedColor: androidx.compose.ui.graphics.Color) {
+    val totalDistance = dayLocation.segments.sumOf { it.distanceMeters ?: 0 }
+    val typeBreakdown = dayLocation.segments
+        .groupingBy { it.activityType }
+        .eachCount()
+        .entries
+        .sortedByDescending { it.value }
+    val topType = typeBreakdown.firstOrNull()?.key?.let(::humanizeActivityType)
+
+    Row(modifier = Modifier.fillMaxWidth()) {
+        StatChip(label = "Visites", value = dayLocation.visits.size.toString(), muted = mutedColor)
+        Spacer(modifier = Modifier.padding(end = 12.dp))
+        StatChip(label = "Trajets", value = dayLocation.segments.size.toString(), muted = mutedColor)
+        Spacer(modifier = Modifier.padding(end = 12.dp))
+        StatChip(label = "Distance", value = formatDistance(totalDistance), muted = mutedColor)
+        if (topType != null) {
+            Spacer(modifier = Modifier.padding(end = 12.dp))
+            StatChip(label = "Principal", value = topType, muted = mutedColor)
+        }
+    }
+}
+
+@Composable
+private fun StatChip(label: String, value: String, muted: androidx.compose.ui.graphics.Color) {
+    Column {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = muted,
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+    }
+}
+
+private fun populateMap(
+    map: MapView,
+    dayLocation: DayLocation,
+    visitColor: Int,
+    segmentColor: Int,
+) {
+    map.overlays.clear()
+
+    val points = mutableListOf<GeoPoint>()
+
+    dayLocation.visits.forEach { visit ->
+        val gp = GeoPoint(visit.lat, visit.lng)
+        points.add(gp)
+        val marker = Marker(map).apply {
+            position = gp
+            setAnchor(Marker.ANCHOR_CENTER, Marker.ANCHOR_BOTTOM)
+            title = buildVisitTitle(visit)
+            snippet = formatVisitTimes(visit)
+        }
+        map.overlays.add(marker)
+    }
+
+    // Trajets réels (waypoints) — un Polyline par timelinePath.
+    // On essaie d'inférer la couleur via l'activity qui chevauche temporellement.
+    dayLocation.paths.forEach { path ->
+        val pts = decodePathPoints(path)
+        if (pts.isEmpty()) return@forEach
+        val matchingActivity = dayLocation.segments.firstOrNull { seg ->
+            path.startMs < seg.endMs && path.endMs > seg.startMs
+        }
+        val color = matchingActivity?.activityType?.let { blendActivityColor(it, segmentColor) }
+            ?: segmentColor
+        points.addAll(pts)
+        val line = Polyline(map).apply {
+            setPoints(pts)
+            outlinePaint.color = color
+            outlinePaint.strokeWidth = 8f
+            title = matchingActivity?.let { humanizeActivityType(it.activityType) } ?: "Trajet"
+            snippet = "${path.pointCount} points"
+        }
+        map.overlays.add(line)
+    }
+
+    // Fallback : activités sans path correspondant → segment vol d'oiseau (rare).
+    dayLocation.segments.forEach { seg ->
+        val hasPath = dayLocation.paths.any { path ->
+            path.startMs < seg.endMs && path.endMs > seg.startMs
+        }
+        if (hasPath) return@forEach
+        val start = GeoPoint(seg.startLat, seg.startLng)
+        val end = GeoPoint(seg.endLat, seg.endLng)
+        points.add(start)
+        points.add(end)
+        val line = Polyline(map).apply {
+            setPoints(listOf(start, end))
+            outlinePaint.color = blendActivityColor(seg.activityType, segmentColor)
+            outlinePaint.strokeWidth = 6f
+            // Marquer visuellement le fallback (pointillé via alpha réduit)
+            outlinePaint.alpha = 140
+            title = humanizeActivityType(seg.activityType) + " (estimé)"
+            snippet = formatSegmentMeta(seg)
+        }
+        map.overlays.add(line)
+    }
+
+    if (points.isNotEmpty()) {
+        val bbox = BoundingBox.fromGeoPointsSafe(points)
+        // Note : zoomToBoundingBox attend que le layout soit fait. Si appelé trop tôt,
+        // il rentre dans une boucle infinie sur certaines versions. Post via Handler.
+        map.post { map.zoomToBoundingBox(bbox, true, 64) }
+    }
+    map.invalidate()
+}
+
+/** Décode `points_json` en List<GeoPoint>. Tolérant aux entrées malformées. */
+private fun decodePathPoints(path: LocationPathEntity): List<GeoPoint> {
+    return runCatching {
+        val arr = JSONArray(path.pointsJson)
+        val out = ArrayList<GeoPoint>(arr.length())
+        for (i in 0 until arr.length()) {
+            val obj = arr.optJSONObject(i) ?: continue
+            val lat = obj.optDouble("lat", Double.NaN)
+            val lng = obj.optDouble("lng", Double.NaN)
+            if (lat.isNaN() || lng.isNaN()) continue
+            out.add(GeoPoint(lat, lng))
+        }
+        out
+    }.getOrDefault(emptyList())
+}
+
+private fun buildVisitTitle(v: LocationVisitEntity): String =
+    v.placeName ?: v.address ?: "Visite"
+
+private fun formatVisitTimes(v: LocationVisitEntity): String {
+    val zone = java.time.ZoneId.systemDefault()
+    val start = java.time.Instant.ofEpochMilli(v.startMs).atZone(zone).toLocalTime()
+    val end = java.time.Instant.ofEpochMilli(v.endMs).atZone(zone).toLocalTime()
+    val fmt = java.time.format.DateTimeFormatter.ofPattern("HH:mm")
+    return "${fmt.format(start)} → ${fmt.format(end)}"
+}
+
+private fun formatSegmentMeta(s: ActivitySegmentEntity): String {
+    val dist = s.distanceMeters?.let { formatDistance(it) }
+    return dist ?: "—"
+}
+
+private fun formatDistance(meters: Int): String =
+    if (meters < 1000) "${meters} m" else "%.1f km".format(meters / 1000.0)
+
+internal fun humanizeActivityType(type: String): String = when (type) {
+    "WALKING" -> "Marche"
+    "RUNNING" -> "Course"
+    "CYCLING" -> "Vélo"
+    "IN_PASSENGER_VEHICLE" -> "Voiture"
+    "IN_BUS" -> "Bus"
+    "IN_SUBWAY" -> "Métro"
+    "IN_TRAIN" -> "Train"
+    "FLYING" -> "Avion"
+    "UNKNOWN" -> "Inconnu"
+    else -> type.lowercase().replaceFirstChar { it.uppercase() }
+}
+
+/**
+ * Couleur du polyline selon le type d'activité.
+ * On reste sur la palette DataSaillance (teal/amber/cyan) — pas de gradient décoratif.
+ */
+private fun blendActivityColor(type: String, fallback: Int): Int = when (type) {
+    "WALKING", "RUNNING" -> AndroidColor.parseColor("#3be5e7")  // cyan
+    "CYCLING" -> AndroidColor.parseColor("#0e9eb0")             // teal
+    "IN_PASSENGER_VEHICLE", "IN_BUS", "IN_SUBWAY", "IN_TRAIN" -> AndroidColor.parseColor("#d37c04")  // amber
+    "FLYING" -> AndroidColor.parseColor("#8b5cf6")              // violet sobre
+    else -> fallback
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `DayMapSection` (function) — lines 35-90
+- `LocationPlaceholder` (function) — lines 92-106
+- `DayStatsRow` (function) — lines 108-129
+- `StatChip` (function) — lines 131-145
+- `populateMap` (function) — lines 147-219
+- `decodePathPoints` (function) — lines 222-235
+- `buildVisitTitle` (function) — lines 237-238
+- `formatVisitTimes` (function) — lines 240-246
+- `formatSegmentMeta` (function) — lines 248-251
+- `formatDistance` (function) — lines 253-254
+- `humanizeActivityType` (function) — lines 256-267
+- `blendActivityColor` (function) — lines 273-279

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
-git_blob: 81fddfd2d3a8f7e42ecda80586f192c1599b921e
-last_synced: '2026-05-09T14:31:04Z'
-loc: 721
+git_blob: a53d4063cfab9f32c2981e5542a498f18e529198
+last_synced: '2026-05-20T16:30:46Z'
+loc: 724
 annotations: []
 imports: []
 exports: []
@@ -234,6 +234,9 @@ fun HypnogramScreen(
                             HypnogramLegend()
                             Spacer(modifier = Modifier.height(16.dp))
                             HypnogramStatsSection(sessions = state.sessions)
+                            Spacer(modifier = Modifier.height(24.dp))
+                            DayMapSection(dayLocation = state.dayLocation)
+                            Spacer(modifier = Modifier.height(24.dp))
                         }
                     }
                 }
@@ -755,17 +758,17 @@ private fun LegendItem(color: Color, label: String) {
 - `hypnoStageDisplayName` (function) — lines 64-70
 - `stageAtTime` (function) — lines 76-83
 - `nightTitle` (function) — lines 85-93
-- `HypnogramScreen` (function) — lines 95-220
-- `HypnogramSummarySection` (function) — lines 222-268
-- `HypnogramCanvas` (function) — lines 270-366
-- `drawAxisFourTicks` (function) — lines 368-405
-- `ScrubTooltip` (function) — lines 407-451
-- `drawRoundedSegment` (function) — lines 453-509
-- `HypnoMountainSegment` (class) — lines 513-518
-- `HypnoMicroAwake` (class) — lines 520-520
-- `buildHypnoMountain` (function) — lines 522-550
-- `HypnogramMountainCanvas` (function) — lines 552-693
-- `yForLevel` (function) — lines 592-592
-- `xForMs` (function) — lines 593-593
-- `HypnogramLegend` (function) — lines 695-708
-- `LegendItem` (function) — lines 710-721
+- `HypnogramScreen` (function) — lines 95-223
+- `HypnogramSummarySection` (function) — lines 225-271
+- `HypnogramCanvas` (function) — lines 273-369
+- `drawAxisFourTicks` (function) — lines 371-408
+- `ScrubTooltip` (function) — lines 410-454
+- `drawRoundedSegment` (function) — lines 456-512
+- `HypnoMountainSegment` (class) — lines 516-521
+- `HypnoMicroAwake` (class) — lines 523-523
+- `buildHypnoMountain` (function) — lines 525-553
+- `HypnogramMountainCanvas` (function) — lines 555-696
+- `yForLevel` (function) — lines 595-595
+- `xForMs` (function) — lines 596-596
+- `HypnogramLegend` (function) — lines 698-711
+- `LegendItem` (function) — lines 713-724

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
-git_blob: 14cb4f8d5d2c6d528f8d812cc6247699644399c9
-last_synced: '2026-05-09T14:31:05Z'
-loc: 783
+git_blob: d3393a123d930c56ac4bdbd1bf614ce13f64d618
+last_synced: '2026-05-20T15:39:49Z'
+loc: 812
 annotations: []
 imports: []
 exports: []
@@ -66,6 +66,8 @@ private const val MOUNTAIN_ROW_HEIGHT_DP = 64
 private const val AXIS_BOTTOM_DP   = 24
 private const val LABEL_WIDTH_DP   = 48
 private const val LABEL_PADDING_DP = 4
+// Marge réservée à droite pour le badge "sorti du domicile".
+private const val TRAILING_BADGE_WIDTH_DP = 12
 // Fenêtre fixe 24h pour Non-24 — les heures de sommeil glissent partout.
 private const val WINDOW_START_MIN = 0
 private const val WINDOW_END_MIN   = 1440
@@ -254,15 +256,18 @@ fun TimelineScreen(
                                     )
                                 }
                                 items(nights, key = { (date, _) -> date.toEpochDay() }) { (date, sessions) ->
+                                    val wasOutOfHome = date in state.outOfHomeDates
                                     when (viewMode) {
                                         TimelineViewMode.BARS -> NightRow(
                                             date = date,
                                             sessions = sessions,
+                                            wasOutOfHome = wasOutOfHome,
                                             onClick = { selectedNight = NightSelection(date, sessions) },
                                         )
                                         TimelineViewMode.MOUNTAIN -> NightRowMountain(
                                             date = date,
                                             sessions = sessions,
+                                            wasOutOfHome = wasOutOfHome,
                                             onClick = { selectedNight = NightSelection(date, sessions) },
                                         )
                                     }
@@ -306,7 +311,7 @@ private fun TimelineAxisHeader(modifier: Modifier = Modifier) {
     ) {
         val canvasW = size.width
         val labelPx = LABEL_WIDTH_DP.dp.toPx()
-        val drawableW = canvasW - labelPx
+        val drawableW = canvasW - labelPx - TRAILING_BADGE_WIDTH_DP.dp.toPx()
         val paint = android.graphics.Paint().apply {
             textSize = 9.sp.toPx()
             color = onSurface.copy(alpha = 0.7f).toArgb()
@@ -360,9 +365,11 @@ private fun LoadOlderSentinel(
 private fun NightRow(
     date: LocalDate,
     sessions: List<SleepSessionResponse>,
+    wasOutOfHome: Boolean,
     onClick: () -> Unit,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
+    val primary = MaterialTheme.colorScheme.primary
     val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
     val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
     val label = remember(date) { date.format(dateFmt) }
@@ -378,7 +385,8 @@ private fun NightRow(
     ) {
         val canvasW = size.width
         val labelPx = LABEL_WIDTH_DP.dp.toPx()
-        val drawableW = canvasW - labelPx
+        val trailingPx = TRAILING_BADGE_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx - trailingPx
         val rowH = ROW_HEIGHT_DP.dp.toPx()
         val barH = BAR_HEIGHT_DP.dp.toPx()
         val barTop = (rowH - barH) / 2f
@@ -400,6 +408,15 @@ private fun NightRow(
                 strokeWidth = 1f,
             )
             h += GRID_STEP_HOURS
+        }
+
+        // Badge "sorti du domicile" — petit cercle teal dans la marge à droite.
+        if (wasOutOfHome) {
+            drawCircle(
+                color = primary,
+                radius = 3.dp.toPx(),
+                center = Offset(canvasW - trailingPx / 2f, rowH / 2f),
+            )
         }
 
         drawIntoCanvas { canvas ->
@@ -494,9 +511,11 @@ private fun buildMountainData(
 private fun NightRowMountain(
     date: LocalDate,
     sessions: List<SleepSessionResponse>,
+    wasOutOfHome: Boolean,
     onClick: () -> Unit,
 ) {
     val onSurface = MaterialTheme.colorScheme.onSurface
+    val primary = MaterialTheme.colorScheme.primary
     val windowDuration = WINDOW_END_MIN - WINDOW_START_MIN
     val dateFmt = remember { DateTimeFormatter.ofPattern("d MMM", Locale.FRENCH) }
     val label = remember(date) { date.format(dateFmt) }
@@ -514,7 +533,8 @@ private fun NightRowMountain(
     ) {
         val canvasW = size.width
         val labelPx = LABEL_WIDTH_DP.dp.toPx()
-        val drawableW = canvasW - labelPx
+        val trailingPx = TRAILING_BADGE_WIDTH_DP.dp.toPx()
+        val drawableW = canvasW - labelPx - trailingPx
         val rowH = MOUNTAIN_ROW_HEIGHT_DP.dp.toPx()
         val plotTop = 6.dp.toPx()
         val plotBot = rowH - 6.dp.toPx()
@@ -534,6 +554,15 @@ private fun NightRowMountain(
             val x = labelPx + (h * 60f / windowDuration) * drawableW
             drawLine(gridColor, Offset(x, 0f), Offset(x, rowH), strokeWidth = 1f)
             h += GRID_STEP_HOURS
+        }
+
+        // Badge "sorti du domicile" — petit cercle teal dans la marge à droite.
+        if (wasOutOfHome) {
+            drawCircle(
+                color = primary,
+                radius = 3.dp.toPx(),
+                center = Offset(canvasW - trailingPx / 2f, rowH / 2f),
+            )
         }
 
         drawIntoCanvas { canvas ->
@@ -811,24 +840,24 @@ private fun formatDuration(minutes: Long): String {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `TimelineViewMode` (class) — lines 54-54
-- `mountainLevel` (function) — lines 57-63
-- `stageColor` (function) — lines 72-78
-- `stageDisplayName` (function) — lines 80-86
-- `groupByNight` (function) — lines 90-97
-- `NightSelection` (class) — lines 101-104
-- `TimelineScreen` (function) — lines 108-272
-- `TimelineAxisHeader` (function) — lines 276-302
-- `LoadOlderSentinel` (function) — lines 306-332
-- `NightRow` (function) — lines 336-416
-- `MountainSegment` (class) — lines 420-425
-- `MicroAwakeMark` (class) — lines 427-427
-- `buildMountainData` (function) — lines 437-468
-- `NightRowMountain` (function) — lines 470-588
-- `yForLevel` (function) — lines 500-500
-- `xForMin` (function) — lines 525-526
-- `drawFallbackBar` (function) — lines 592-605
-- `drawStageSegment` (function) — lines 607-622
-- `drawBar` (function) — lines 624-671
-- `NightDetailSheet` (function) — lines 675-776
-- `formatDuration` (function) — lines 778-783
+- `TimelineViewMode` (class) — lines 56-56
+- `mountainLevel` (function) — lines 59-65
+- `stageColor` (function) — lines 74-80
+- `stageDisplayName` (function) — lines 82-88
+- `groupByNight` (function) — lines 92-99
+- `NightSelection` (class) — lines 103-106
+- `TimelineScreen` (function) — lines 110-277
+- `TimelineAxisHeader` (function) — lines 281-307
+- `LoadOlderSentinel` (function) — lines 311-337
+- `NightRow` (function) — lines 341-433
+- `MountainSegment` (class) — lines 437-442
+- `MicroAwakeMark` (class) — lines 444-444
+- `buildMountainData` (function) — lines 454-485
+- `NightRowMountain` (function) — lines 487-617
+- `yForLevel` (function) — lines 520-520
+- `xForMin` (function) — lines 554-555
+- `drawFallbackBar` (function) — lines 621-634
+- `drawStageSegment` (function) — lines 636-651
+- `drawBar` (function) — lines 653-700
+- `NightDetailSheet` (function) — lines 704-805
+- `formatDuration` (function) — lines 807-812

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/TimelineScreen.kt
-git_blob: d3393a123d930c56ac4bdbd1bf614ce13f64d618
-last_synced: '2026-05-20T15:39:49Z'
-loc: 812
+git_blob: cbbbe5b43f262a0f8fef88cf68f7eaa3ef209408
+last_synced: '2026-05-20T16:29:59Z'
+loc: 826
 annotations: []
 imports: []
 exports: []
@@ -232,13 +232,27 @@ fun TimelineScreen(
                         }
 
                         // Sentinel : quand l'utilisateur scrolle jusqu'en haut de la liste, on charge
-                        // 30 jours plus anciens. distinctUntilChanged évite les triggers répétés
-                        // pendant que la pagination est déjà en cours.
-                        LaunchedEffect(listState, state.hasMore, state.loadingMore) {
+                        // 30 jours plus anciens.
+                        //
+                        // ⚠️ Les clés doivent rester stables (pas state.hasMore / state.loadingMore) :
+                        // sinon le LaunchedEffect redémarre à chaque toggle de loadingMore, le buffer
+                        // distinctUntilChanged repart à zéro et ré-émet la valeur courante (0 si l'user
+                        // est au sentinel), ce qui déclenche un nouveau loadOlder immédiat → cascade
+                        // de chargements ininterrompus jusqu'à épuisement de l'historique.
+                        //
+                        // Lecture de hasMore / loadingMore à l'INTÉRIEUR du collect (snapshot instantané
+                        // au moment du trigger), pas comme clés.
+                        LaunchedEffect(listState, initialScrollDone) {
                             snapshotFlow { listState.firstVisibleItemIndex }
                                 .distinctUntilChanged()
-                                .filter { it == 0 && state.hasMore && !state.loadingMore && initialScrollDone }
-                                .collect { viewModel.loadOlder() }
+                                .filter { it == 0 && initialScrollDone }
+                                .collect {
+                                    val current = viewModel.uiState.value as? TimelineUiState.Success
+                                        ?: return@collect
+                                    if (current.hasMore && !current.loadingMore) {
+                                        viewModel.loadOlder()
+                                    }
+                                }
                         }
 
                         Column(
@@ -846,18 +860,18 @@ private fun formatDuration(minutes: Long): String {
 - `stageDisplayName` (function) — lines 82-88
 - `groupByNight` (function) — lines 92-99
 - `NightSelection` (class) — lines 103-106
-- `TimelineScreen` (function) — lines 110-277
-- `TimelineAxisHeader` (function) — lines 281-307
-- `LoadOlderSentinel` (function) — lines 311-337
-- `NightRow` (function) — lines 341-433
-- `MountainSegment` (class) — lines 437-442
-- `MicroAwakeMark` (class) — lines 444-444
-- `buildMountainData` (function) — lines 454-485
-- `NightRowMountain` (function) — lines 487-617
-- `yForLevel` (function) — lines 520-520
-- `xForMin` (function) — lines 554-555
-- `drawFallbackBar` (function) — lines 621-634
-- `drawStageSegment` (function) — lines 636-651
-- `drawBar` (function) — lines 653-700
-- `NightDetailSheet` (function) — lines 704-805
-- `formatDuration` (function) — lines 807-812
+- `TimelineScreen` (function) — lines 110-291
+- `TimelineAxisHeader` (function) — lines 295-321
+- `LoadOlderSentinel` (function) — lines 325-351
+- `NightRow` (function) — lines 355-447
+- `MountainSegment` (class) — lines 451-456
+- `MicroAwakeMark` (class) — lines 458-458
+- `buildMountainData` (function) — lines 468-499
+- `NightRowMountain` (function) — lines 501-631
+- `yForLevel` (function) — lines 534-534
+- `xForMin` (function) — lines 568-569
+- `drawFallbackBar` (function) — lines 635-648
+- `drawStageSegment` (function) — lines 650-665
+- `drawBar` (function) — lines 667-714
+- `NightDetailSheet` (function) — lines 718-819
+- `formatDuration` (function) — lines 821-826

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
-git_blob: 3d7fc3cdf6be26e50dafa539c9466ed64fcd9493
-last_synced: '2026-05-09T19:12:27Z'
-loc: 216
+git_blob: e083ed80ee8b13fe8129c77949202b984f42308c
+last_synced: '2026-05-20T14:36:27Z'
+loc: 334
 annotations: []
 imports: []
 exports: []
@@ -236,6 +236,124 @@ class LocalLocationImportServiceTest {
           }
         }
     """.trimIndent()
+
+    // ---- Nouveau format Google Timeline 2024+ (semanticSegments) ----
+
+    private fun newFormatFixture(): String = """
+        {
+          "semanticSegments": [
+            {
+              "startTime": "2026-02-21T18:11:28.000+01:00",
+              "endTime":   "2026-02-21T21:54:05.000+01:00",
+              "visit": {
+                "hierarchyLevel": 0,
+                "probability": 0.876,
+                "topCandidate": {
+                  "placeId": "ChIJG3a7suW_9EcRF42jL3Q84rA",
+                  "semanticType": "INFERRED_HOME",
+                  "placeLocation": { "latLng": "45.81213°, 4.8888115°" }
+                }
+              }
+            },
+            {
+              "startTime": "2026-02-21T17:29:14.000+01:00",
+              "endTime":   "2026-02-21T17:30:52.000+01:00",
+              "activity": {
+                "start": { "latLng": "45.5276149°, 4.8801637°" },
+                "end":   { "latLng": "45.5277361°, 4.8801797°" },
+                "distanceMeters": 102.94,
+                "probability": 0.97,
+                "topCandidate": { "type": "WALKING", "probability": 0.74 }
+              }
+            },
+            {
+              "startTime": "2026-02-19T14:00:00.000+01:00",
+              "endTime":   "2026-02-19T16:00:00.000+01:00",
+              "timelinePath": [
+                { "point": "45.527964°, 4.8787612°", "time": "2026-02-19T14:19:00.000+01:00" }
+              ]
+            }
+          ],
+          "rawSignals": [
+            { "position": { "LatLng": "45.5280°, 4.8787°", "timestamp": "2026-04-20T16:12:08.000+02:00" } }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun new_format_extracts_visits_and_activities() = runTest {
+        val r = service.importJson(newFormatFixture())
+        assertEquals(1, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+
+        val visit = db.locationDao().getAllVisits().first()
+        assertEquals(45.81213, visit.lat, 0.00001)
+        assertEquals(4.8888115, visit.lng, 0.00001)
+        assertEquals("ChIJG3a7suW_9EcRF42jL3Q84rA", visit.placeId)
+        assertEquals("Maison", visit.placeName)  // INFERRED_HOME → Maison
+        assertEquals("0.88", visit.confidence)
+
+        val seg = db.locationDao().getAllSegments().first()
+        assertEquals(45.5276149, seg.startLat, 0.00001)
+        assertEquals(45.5277361, seg.endLat, 0.00001)
+        assertEquals("WALKING", seg.activityType)
+        assertEquals(102, seg.distanceMeters)  // truncated from 102.94
+        assertEquals("0.97", seg.confidence)
+    }
+
+    @Test
+    fun new_format_semantic_type_mapping() = runTest {
+        val variants = """
+            {
+              "semanticSegments": [
+                {
+                  "startTime": "2026-01-01T00:00:00.000Z",
+                  "endTime":   "2026-01-01T01:00:00.000Z",
+                  "visit": { "probability": 0.5, "topCandidate": {
+                    "placeId": "p1", "semanticType": "INFERRED_WORK",
+                    "placeLocation": { "latLng": "45.0°, 4.0°" } } }
+                },
+                {
+                  "startTime": "2026-01-01T02:00:00.000Z",
+                  "endTime":   "2026-01-01T03:00:00.000Z",
+                  "visit": { "probability": 0.5, "topCandidate": {
+                    "placeId": "p2", "semanticType": "UNKNOWN",
+                    "placeLocation": { "latLng": "45.1°, 4.1°" } } }
+                }
+              ]
+            }
+        """.trimIndent()
+        service.importJson(variants)
+        val visits = db.locationDao().getAllVisits().sortedBy { it.startMs }
+        assertEquals("Travail", visits[0].placeName)
+        assertNull(visits[1].placeName)  // UNKNOWN → null
+    }
+
+    @Test
+    fun parse_latLngString_handles_negative_and_no_degree_symbol() {
+        val (lat1, lng1) = TakeoutTimelineParser.parseLatLngString("45.81213°, 4.8888115°")!!
+        assertEquals(45.81213, lat1, 0.00001)
+        assertEquals(4.8888115, lng1, 0.00001)
+
+        val (lat2, lng2) = TakeoutTimelineParser.parseLatLngString("-45.81213, -4.8888115")!!
+        assertEquals(-45.81213, lat2, 0.00001)
+        assertEquals(-4.8888115, lng2, 0.00001)
+
+        assertNull(TakeoutTimelineParser.parseLatLngString(""))
+        assertNull(TakeoutTimelineParser.parseLatLngString("not coords"))
+        assertNull(TakeoutTimelineParser.parseLatLngString("45.0"))  // une seule valeur
+    }
+
+    @Test
+    fun new_format_ignores_timeline_path_and_raw_signals() = runTest {
+        val r = service.importJson(newFormatFixture())
+        // Fixture a 1 visit + 1 activity + 1 timelinePath + 1 rawSignal
+        // Seuls visit + activity doivent être importés
+        assertEquals(1, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+        assertEquals(1, db.locationDao().countVisits())
+        assertEquals(1, db.locationDao().countSegments())
+    }
 }
 ```
 
@@ -244,7 +362,7 @@ class LocalLocationImportServiceTest {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `LocalLocationImportServiceTest` (class) — lines 21-216
+- `LocalLocationImportServiceTest` (class) — lines 21-334
 - `setUp` (function) — lines 27-34
 - `tearDown` (function) — lines 36-37
 - `jsonFixture` (function) — lines 39-85
@@ -256,3 +374,8 @@ class LocalLocationImportServiceTest {
 - `zip_import_extracts_only_semantic_history_files` (function) — lines 171-192
 - `query_in_range` (function) — lines 194-204
 - `segmentJson` (function) — lines 206-215
+- `newFormatFixture` (function) — lines 219-258
+- `new_format_extracts_visits_and_activities` (function) — lines 260-279
+- `new_format_semantic_type_mapping` (function) — lines 281-307
+- `parse_latLngString_handles_negative_and_no_degree_symbol` (function) — lines 309-322
+- `new_format_ignores_timeline_path_and_raw_signals` (function) — lines 324-333

--- a/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.md
+++ b/docs/vault/code/android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.md
@@ -1,0 +1,258 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
+git_blob: 3d7fc3cdf6be26e50dafa539c9466ed64fcd9493
+last_synced: '2026-05-09T19:12:27Z'
+loc: 216
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt`](../../../android-app/app/src/test/java/fr/datasaillance/nightfall/data/local/location/LocalLocationImportServiceTest.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.data.local.location
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+@RunWith(AndroidJUnit4::class)
+class LocalLocationImportServiceTest {
+
+    private lateinit var db: NightfallDatabase
+    private lateinit var service: LocalLocationImportService
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            NightfallDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        service = LocalLocationImportService(db.locationDao())
+    }
+
+    @After
+    fun tearDown() { db.close() }
+
+    private fun jsonFixture(): String = """
+        {
+          "timelineObjects": [
+            {
+              "placeVisit": {
+                "location": {
+                  "latitudeE7": 487856200,
+                  "longitudeE7": 23478500,
+                  "placeId": "ChIJ_paris_home",
+                  "name": "Maison",
+                  "address": "1 rue de Rivoli, Paris"
+                },
+                "duration": {
+                  "startTimestamp": "2024-01-15T08:30:00.000Z",
+                  "endTimestamp": "2024-01-15T17:45:00.000Z"
+                },
+                "visitConfidence": "HIGH_CONFIDENCE"
+              }
+            },
+            {
+              "activitySegment": {
+                "startLocation": { "latitudeE7": 487856200, "longitudeE7": 23478500 },
+                "endLocation":   { "latitudeE7": 487900000, "longitudeE7": 23500000 },
+                "duration": {
+                  "startTimestamp": "2024-01-15T17:45:00.000Z",
+                  "endTimestamp": "2024-01-15T18:15:00.000Z"
+                },
+                "activityType": "WALKING",
+                "distance": 2150,
+                "confidence": "MEDIUM"
+              }
+            },
+            {
+              "placeVisit": {
+                "location": {
+                  "latitudeE7": 487900000,
+                  "longitudeE7": 23500000
+                },
+                "duration": {
+                  "startTimestamp": "2024-01-15T18:15:00.000Z",
+                  "endTimestamp": "2024-01-15T20:00:00.000Z"
+                }
+              }
+            }
+          ]
+        }
+    """.trimIndent()
+
+    @Test
+    fun parse_extracts_visits_and_segments() = runTest {
+        val r = service.importJson(jsonFixture())
+        assertEquals(2, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+        assertEquals(0, r.visitsSkipped)
+
+        val visits = db.locationDao().getAllVisits()
+        assertEquals(2, visits.size)
+        val first = visits.first()
+        assertEquals(48.78562, first.lat, 0.00001)
+        assertEquals(2.34785, first.lng, 0.00001)
+        assertEquals("Maison", first.placeName)
+        assertEquals("ChIJ_paris_home", first.placeId)
+        assertEquals("HIGH_CONFIDENCE", first.confidence)
+
+        val segments = db.locationDao().getAllSegments()
+        assertEquals(1, segments.size)
+        assertEquals("WALKING", segments.first().activityType)
+        assertEquals(2150, segments.first().distanceMeters)
+    }
+
+    @Test
+    fun import_idempotent() = runTest {
+        service.importJson(jsonFixture())
+        val r2 = service.importJson(jsonFixture())
+        assertEquals(0, r2.visitsInserted)
+        assertEquals(2, r2.visitsSkipped)
+        assertEquals(0, r2.segmentsInserted)
+        assertEquals(1, r2.segmentsSkipped)
+        // Pas de doublons en DB
+        assertEquals(2, db.locationDao().countVisits())
+        assertEquals(1, db.locationDao().countSegments())
+    }
+
+    @Test
+    fun parse_tolerant_to_missing_optional_fields() = runTest {
+        // 2e visit du fixture n'a pas de placeId / name / address / confidence
+        service.importJson(jsonFixture())
+        val visits = db.locationDao().getAllVisits()
+        val visitMinimal = visits.last()
+        assertNull(visitMinimal.placeId)
+        assertNull(visitMinimal.placeName)
+        assertNull(visitMinimal.address)
+        assertNull(visitMinimal.confidence)
+    }
+
+    @Test
+    fun parse_ignores_malformed_entries() = runTest {
+        val bad = """
+            {
+              "timelineObjects": [
+                { "placeVisit": { "location": {} } },
+                { "placeVisit": { "duration": { "startTimestamp": "2024-01-15T08:00:00Z" } } },
+                { "activitySegment": {} },
+                { "unknown": {} }
+              ]
+            }
+        """.trimIndent()
+        val r = service.importJson(bad)
+        assertEquals(0, r.visitsInserted)
+        assertEquals(0, r.segmentsInserted)
+    }
+
+    @Test
+    fun activity_type_breakdown() = runTest {
+        val multi = """
+            {
+              "timelineObjects": [
+                ${segmentJson("2024-01-15T10:00:00Z", "2024-01-15T10:30:00Z", "WALKING")},
+                ${segmentJson("2024-01-15T11:00:00Z", "2024-01-15T11:30:00Z", "WALKING")},
+                ${segmentJson("2024-01-15T12:00:00Z", "2024-01-15T12:30:00Z", "CYCLING")},
+                ${segmentJson("2024-01-15T13:00:00Z", "2024-01-15T13:30:00Z", "IN_PASSENGER_VEHICLE")}
+              ]
+            }
+        """.trimIndent()
+        service.importJson(multi)
+        val breakdown = db.locationDao().getActivityTypeBreakdown()
+        val map = breakdown.associate { it.activityType to it.cnt }
+        assertEquals(2, map["WALKING"])
+        assertEquals(1, map["CYCLING"])
+        assertEquals(1, map["IN_PASSENGER_VEHICLE"])
+    }
+
+    @Test
+    fun zip_import_extracts_only_semantic_history_files() = runTest {
+        val baos = ByteArrayOutputStream()
+        ZipOutputStream(baos).use { zos ->
+            // Doit être pris : nom format Takeout
+            zos.putNextEntry(ZipEntry("Takeout/Location History (Timeline)/Semantic Location History/2024/2024_JANUARY.json"))
+            zos.write(jsonFixture().toByteArray())
+            zos.closeEntry()
+            // Doit être ignoré : autre fichier Takeout (Records.json)
+            zos.putNextEntry(ZipEntry("Takeout/Location History (Timeline)/Records.json"))
+            zos.write("{\"locations\":[]}".toByteArray())
+            zos.closeEntry()
+            // Doit être ignoré : fichier random
+            zos.putNextEntry(ZipEntry("readme.txt"))
+            zos.write("hello".toByteArray())
+            zos.closeEntry()
+        }
+        val r = service.importZip(ByteArrayInputStream(baos.toByteArray()))
+        assertEquals(1, r.filesProcessed)
+        assertEquals(2, r.visitsInserted)
+        assertEquals(1, r.segmentsInserted)
+    }
+
+    @Test
+    fun query_in_range() = runTest {
+        service.importJson(jsonFixture())
+        // 1er visit start = 2024-01-15T08:30:00Z = 1705307400000 ms
+        val midDay = 1_705_320_000_000L // ~12:00 same day
+        val nextDay = 1_705_392_000_000L // 24h later
+        val visits = db.locationDao().getVisitsInRange(midDay, nextDay)
+        // Seul le 2e visit (18:15 → 20:00) tombe dans la fenêtre
+        assertEquals(1, visits.size)
+        assertNotNull(visits.first())
+    }
+
+    private fun segmentJson(start: String, end: String, activity: String): String = """
+        {
+          "activitySegment": {
+            "startLocation": { "latitudeE7": 487856200, "longitudeE7": 23478500 },
+            "endLocation":   { "latitudeE7": 487900000, "longitudeE7": 23500000 },
+            "duration": { "startTimestamp": "$start", "endTimestamp": "$end" },
+            "activityType": "$activity"
+          }
+        }
+    """.trimIndent()
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `LocalLocationImportServiceTest` (class) — lines 21-216
+- `setUp` (function) — lines 27-34
+- `tearDown` (function) — lines 36-37
+- `jsonFixture` (function) — lines 39-85
+- `parse_extracts_visits_and_segments` (function) — lines 87-107
+- `import_idempotent` (function) — lines 109-120
+- `parse_tolerant_to_missing_optional_fields` (function) — lines 122-132
+- `parse_ignores_malformed_entries` (function) — lines 134-149
+- `activity_type_breakdown` (function) — lines 151-169
+- `zip_import_extracts_only_semantic_history_files` (function) — lines 171-192
+- `query_in_range` (function) — lines 194-204
+- `segmentJson` (function) — lines 206-215

--- a/docs/vault/specs/2026-05-09-gps-collector.md
+++ b/docs/vault/specs/2026-05-09-gps-collector.md
@@ -1,0 +1,126 @@
+---
+title: "GPS Collector — collecte locale des données de localisation"
+slug: 2026-05-09-gps-collector
+status: draft
+created: 2026-05-09
+implements: []
+tested_by: []
+---
+
+# Spec — GPS Collector
+
+## Vision
+
+Capter le **3e signal personnel** (après sommeil et bien-être numérique) pour le local-first de Nightfall : les données de localisation. Objectif final = corréler dans une vue unifiée :
+- Quand je dors, où je suis, ce que j'utilise comme apps
+- Détecter des patterns : "je dors mieux à la campagne", "le drift circadien suit mes voyages", "mes phases d'usage YouTube tardives correspondent à des soirs sans sortie"
+
+## Sources de données envisagées
+
+| Source | Profondeur | Effort | Risques | Recommandation |
+|---|---|---|---|---|
+| **Google Takeout JSON** | Tout l'historique passé | Bas (parser JSON) | Format Google peut changer | ✅ Phase A_gps |
+| **FusedLocationProvider** continu | À partir de l'install | Moyen (perm BG, batterie) | Conso ~1-2%/j | Phase B_gps |
+| **Lecture cache Google Maps local** | Dernières semaines | N/A — root only | Casse Knox | ❌ ignoré |
+
+Phase A_gps = parser Takeout. Phase B_gps = collecte continue. Phase C_gps = UI. Phase D_gps = fusion (avec sleep + usage).
+
+## Décisions techniques
+
+### Format Google Takeout
+
+Depuis fin 2024 Google a déprécié la timeline cloud. L'export passe désormais par :
+- **Sur device** : Google Maps → photo profil → "Vos données dans Maps" → Exporter
+- **takeout.google.com** (legacy) si l'historique cloud est encore activé
+
+L'export produit deux types de structure :
+1. **`Semantic Location History/<année>/<année>_<mois>.json`** — format moderne, riche : `placeVisit` + `activitySegment`
+2. **`Records.json`** — samples lat/lng bruts avec timestamps et accuracy
+
+Phase A_gps cible **#1** (Semantic Location History). #2 sera traité plus tard si besoin (volumineux : ~100k samples par an).
+
+### Modèle de données
+
+Deux entities distinctes :
+
+**LocationVisitEntity** (`placeVisit`) :
+- Visite : un POI où on est resté un temps significatif
+- Champs : `start_ms`, `end_ms`, `lat`, `lng`, `place_id?`, `place_name?`, `address?`, `confidence`
+- Index unique `(start_ms, end_ms, lat, lng)` pour idempotence
+
+**ActivitySegmentEntity** (`activitySegment`) :
+- Trajet entre 2 visites : marche, voiture, vélo, transport, etc.
+- Champs : `start_ms`, `end_ms`, `start_lat/lng`, `end_lat/lng`, `activity_type`, `distance_m`, `confidence`
+- Index unique `(start_ms, end_ms, activity_type)`
+
+### Parsing
+- Pas de dépendance ajoutée — utilise `org.json.JSONObject` (built-in Android), tolérant aux variations de schéma
+- Parser fichier-par-fichier ou ZIP entier (Takeout fournit un ZIP qu'on extrait)
+- Idempotent via Room `OnConflictStrategy.IGNORE`
+
+### Stockage local
+- Ajout dans `NightfallDatabase` Room — migration v1 → v2 (cf. réserve : la branche `feat/usage-stats-collector` parallèle a aussi sa propre v2 ; la fusion finale fera une v3 unifiée)
+- Chiffré au repos via SQLCipher déjà en place
+
+### Permission
+
+**Phase A_gps** ne demande **aucune permission** runtime — c'est un import de fichier que l'utilisateur a téléchargé manuellement. Même flow que Samsung Health import : SAF picker → ZIP → parse en mémoire → écrit en Room.
+
+**Phase B_gps** (continue) demandera `ACCESS_FINE_LOCATION` + éventuellement `ACCESS_BACKGROUND_LOCATION` (Android 10+). Hors scope de cette spec.
+
+## Phases
+
+### Phase A_gps — Foundation + import Takeout
+- Spec + entities + DAO
+- Migration Room v1 → v2 (location_visits + activity_segments)
+- `TakeoutTimelineParser` — parse JSON Semantic Location History
+- `LocalLocationImportService` — pipeline `ZIP → parse → Room`
+- Tests Robolectric avec fixtures JSON inline
+
+### Phase B_gps — Collecte continue
+- `FusedLocationProvider` + WorkManager / ForegroundService selon trade-off batterie
+- Permission `ACCESS_FINE_LOCATION` flow
+- Densification de l'historique futur (1 sample / 5min)
+
+### Phase C_gps — UI carte
+- Vue carte dédiée Nightfall — à designer (Mapbox / OSMdroid offline ?)
+- Heatmap des visites
+- Timeline géo (où j'étais à telle heure)
+
+### Phase D_gps — Fusion sleep + usage + gps
+- Vue corrélée jour-par-jour
+- Score "hygiène nocturne" intégrant lieu (à la maison vs ailleurs) + apps utilisées + qualité sommeil
+- Spec dédiée plus tard
+
+## Livrables Phase A_gps
+
+- [ ] `data/local/entity/location/LocationVisitEntity.kt`
+- [ ] `data/local/entity/location/ActivitySegmentEntity.kt`
+- [ ] `data/local/dao/LocationDao.kt`
+- [ ] Migration NightfallDatabase v1 → v2 (location tables)
+- [ ] `data/local/location/TakeoutTimelineParser.kt`
+- [ ] `data/local/location/LocalLocationImportService.kt`
+- [ ] Tests Robolectric in-memory (parser + service)
+
+## Tests d'acceptation
+
+1. **Parse fichier Semantic Location History** — given un JSON valide avec 3 placeVisit et 2 activitySegment, when `TakeoutTimelineParser.parse()`, then retourne `(3 visits, 2 segments)` avec champs corrects (lat/lng, timestamps, activityType).
+
+2. **Idempotence import** — given un même JSON importé 2 fois consécutives, when on regarde la DB, then aucun doublon (index unique respecté), 2e import retourne `inserted=0`.
+
+3. **Tolérance aux variations de schéma** — given un JSON avec champs optionnels manquants (ex: pas de `placeId`, pas de `address`), when parse, then l'entrée est créée avec valeurs nullables, pas de crash.
+
+4. **Migration Room v1→v2** — given une DB v1 (sleep + hr + steps + exercise), when ouverture en v2, then les nouvelles tables `location_visits` + `activity_segments` créées, données existantes intactes.
+
+## Risques et mitigations
+
+- **Format Takeout évolue** → parser tolérant (org.json), tests sur fixtures représentatives, `TODO` documentés pour cas limites observés
+- **Volumes énormes** (export 5 ans = 100k+ entrées) → bulk insert par batches de 1000 (cf. pattern Phase B sleep_stage)
+- **Chevauchement entities futures** (ex: si Phase B_gps stocke aussi des visits via sample agrégé) → namespacer en `_takeout` vs `_live` pour éviter collision, ou unifier via une colonne `source`
+- **Conflit migration Room avec branche `feat/usage-stats-collector`** → les 2 branches font v2 indépendamment ; à la consolidation finale, on rebase l'une sur l'autre et on bump à v3 avec toutes les tables. Documenté dans la spec parallèle aussi.
+
+## Lien avec autres specs
+
+- Hérite de `2026-05-09-local-first-migration.md` (architecture Room + SQLCipher + import service pattern)
+- Branche soeur `2026-05-09-usage-stats-collector.md` (autre signal local)
+- Sera référencée par `2026-XX-personal-correlation-dashboard.md` (Phase D commune)


### PR DESCRIPTION
## Summary

Branche long-lived feat/gps-collector mûrie en parallèle. Rebase post-merge de feat/usage-stats-collector (#87) : DB v2 (usage_daily) restée intacte, ajout v3 (location_visits + activity_segments) et v4 (location_paths).

**Phase A_gps + extension format 2024+** :
- Spec docs/vault/specs/2026-05-09-gps-collector.md
- DB v3 : `location_visits` + `activity_segments` via `Migration2to3`
- DB v4 : `location_paths` (waypoints GPS sérialisés JSON) via `Migration3to4`
- `TakeoutTimelineParser` — supporte les 2 formats (legacy `timelineObjects` + nouveau 2024+ `semanticSegments`), helper `parseLatLngString` pour `"45.81213°, 4.8888115°"`
- Mapping sémantique INFERRED_HOME → "Maison" / INFERRED_WORK → "Travail" / UNKNOWN → null
- `LocalLocationImportService` — pipeline JSON/ZIP idempotent (OnConflictStrategy.IGNORE)
- 11/11 tests Robolectric verts (legacy + nouveau format + mapping + ZIP filter + range query)

**Phase C_gps partielle** :
- Bouton "Google Timeline (local)" dans `ImportScreen` — bypass ping VPS, 100% local
- Badge "sorti du domicile" sur TimelineScreen (cercle teal à droite de chaque ligne quand ≥1 trajet GPS ce jour-là)
- Map OSMDroid embarquée sous l'hypnogramme : Markers visites + Polylines colorées par mode de transport (cyan WALKING, teal CYCLING, amber IN_PASSENGER_VEHICLE, ...)
- Trajets réalistes via waypoints `timelinePath` (jusqu'à 120 points/path, ~10k au total pour 3 ans), fallback vol d'oiseau pointillé pour les activities sans path matché
- Stats du jour : visites, trajets, distance cumulée, type d'activité principal
- Dependency : `org.osmdroid:osmdroid-android:6.1.20` (no API key, raster tiles)

**Fix timeline cascade** :
- `LaunchedEffect` keys instables → cascade ininterrompue de loadOlder() quand l'utilisateur restait sur le sentinel. Clés stabilisées + lecture de l'état dans le `collect`.

**Validé end-to-end sur device** : import d'un fichier Takeout 12 MB → 61 visites + 71 trajets + 974 paths insérés, map affiche les vrais trajets GPS, badge timeline s'allume sur les jours actifs.

**Compromis explicites** :
- `appLaunchCount` toujours à 0 côté usage (champ package-private AOSP) — sera calculé via UsageEvents stream en Phase ultérieure.
- Polylines colorées par activity_type via overlap temporel avec un activitySegment — heuristique simple, peut être affinée.

**Phase D commune** (vue unifiée sleep × usage × location dans HypnogramScreen) suivra dans une PR séparée post-merge.

## Test plan

- [x] Tests Robolectric verts (5/5 LocalUsageStatsServiceTest + 5/5 DigitalWellbeingViewModelTest + 11/11 LocalLocationImportServiceTest)
- [x] Build native debug OK post-rebase
- [x] Validation device : import 12 MB Takeout, 61 visites + 71 trajets + 974 paths, map affichée
- [x] Badge timeline s'allume sur les jours avec trajets, fix cascade validé (1 page par sentinel, pas de chargement runaway)
- [ ] À valider en review : taille storage paths_json sur la durée (~10k points/3 ans estimé), pourrait nécessiter compaction si historique long
- [ ] Fallback `fallbackToDestructiveMigration` : utilisateur d'un build local-first sans usage_daily ni location pourrait perdre des données au saut v1→v4 — acceptable car mono-user dev