### PR TITLE
feat(unified): D.3 - vue unifiee sleep x usage x location dans HypnogramScreen

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -170,6 +170,7 @@ fun NavGraph(
                         repository = hypnogramRepository,
                         hintDate = dateArg,
                         locationDao = hypnogramDb.locationDao(),
+                        usageStatsDao = hypnogramDb.usageStatsDao(),
                     )
                 }
                 HypnogramScreen(

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
@@ -3,9 +3,11 @@ package fr.datasaillance.nightfall.viewmodel.sleep
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import fr.datasaillance.nightfall.data.local.dao.UsageStatsDao
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,12 +27,19 @@ data class DayLocation(
     val paths: List<LocationPathEntity> = emptyList(),
 )
 
+/** Snapshot d'usage numérique pour la journée associée à la nuit affichée. */
+data class DayUsage(
+    val rows: List<UsageDailyEntity>,
+    val totalForegroundMs: Long,
+)
+
 sealed class HypnogramUiState {
     object Idle    : HypnogramUiState()
     object Loading : HypnogramUiState()
     data class Success(
         val sessions: List<SleepSessionResponse>,
         val dayLocation: DayLocation? = null,
+        val dayUsage: DayUsage? = null,
     ) : HypnogramUiState()
     data class Error(val message: String) : HypnogramUiState()
 }
@@ -40,6 +49,7 @@ class HypnogramViewModel(
     private val repository: SleepRepository,
     private val hintDate: String? = null,
     private val locationDao: LocationDao? = null,
+    private val usageStatsDao: UsageStatsDao? = null,
     private val zone: ZoneId = ZoneId.systemDefault(),
 ) : ViewModel() {
 
@@ -100,11 +110,16 @@ class HypnogramViewModel(
                 Timber.d("scope=hypno_vm night_sessions=${nightSessions.size} total_stages=${nightSessions.sumOf { it.stages?.size ?: 0 }}")
                 _uiState.value = HypnogramUiState.Success(nightSessions)
 
-                // Charge les données GPS du jour en arrière-plan — l'hypnogramme s'affiche
-                // tout de suite, la map apparaît dès que les données sont prêtes.
+                // Charge les données GPS + usage numérique du jour en arrière-plan —
+                // l'hypnogramme s'affiche tout de suite, le reste apparaît dès que prêt.
                 if (targetDate != null) {
                     val dayLoc = loadDayLocation(targetDate)
-                    _uiState.value = HypnogramUiState.Success(nightSessions, dayLocation = dayLoc)
+                    val dayUse = loadDayUsage(targetDate)
+                    _uiState.value = HypnogramUiState.Success(
+                        sessions = nightSessions,
+                        dayLocation = dayLoc,
+                        dayUsage = dayUse,
+                    )
                 }
             } catch (e: Exception) {
                 Timber.w("scope=hypno_vm error=${e::class.simpleName}")
@@ -124,6 +139,19 @@ class HypnogramViewModel(
                 paths = dao.getPathsInRange(fromMs, toMs),
             )
         }.onFailure { Timber.w("scope=hypno_vm location_load_failed error=${it::class.simpleName}") }
+            .getOrNull()
+    }
+
+    private suspend fun loadDayUsage(date: LocalDate): DayUsage? {
+        val dao = usageStatsDao ?: return null
+        val dateStr = date.toString()
+        return runCatching {
+            val rows = dao.getByDate(dateStr)
+            DayUsage(
+                rows = rows,
+                totalForegroundMs = rows.sumOf { it.totalTimeForegroundMs },
+            )
+        }.onFailure { Timber.w("scope=hypno_vm usage_load_failed error=${it::class.simpleName}") }
             .getOrNull()
     }
 

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
@@ -1,0 +1,134 @@
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
+import fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver
+import fr.datasaillance.nightfall.viewmodel.sleep.DayUsage
+
+/**
+ * Section "Bien-être numérique" affichée sous la map dans la page Détails de la
+ * journée. Top 5 apps par temps écran + total cumulé.
+ */
+@Composable
+fun DayUsageSection(
+    dayUsage: DayUsage?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val resolver = remember(context) { PackageInfoResolver(context.packageManager) }
+
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Text(
+            text = "Bien-être numérique",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            dayUsage == null -> UsagePlaceholder("Chargement…")
+            dayUsage.rows.isEmpty() -> UsagePlaceholder(
+                "Pas de collecte d'usage pour ce jour. Active 'Usage Access' dans Bien-être.",
+            )
+            else -> {
+                Text(
+                    text = "Total écran : ${formatScreenTime(dayUsage.totalForegroundMs)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                val top = dayUsage.rows
+                    .sortedByDescending { it.totalTimeForegroundMs }
+                    .take(5)
+                val maxMs = top.firstOrNull()?.totalTimeForegroundMs ?: 1L
+                top.forEach { row ->
+                    AppRow(row = row, label = resolver.labelFor(row.packageName), maxMs = maxMs)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UsagePlaceholder(message: String) {
+    Box(
+        modifier = Modifier.fillMaxWidth().height(80.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun AppRow(row: UsageDailyEntity, label: String, maxMs: Long) {
+    val ratio = if (maxMs <= 0) 0f else (row.totalTimeForegroundMs.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = formatScreenTime(row.totalTimeForegroundMs),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    MaterialTheme.shapes.extraSmall,
+                ),
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth(ratio)
+                    .height(4.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.shapes.extraSmall,
+                    ),
+            )
+        }
+    }
+}
+
+private fun formatScreenTime(ms: Long): String {
+    if (ms < 60_000L) return "${ms / 1000}s"
+    val minutes = ms / 60_000L
+    if (minutes < 60L) return "${minutes}min"
+    val hours = minutes / 60L
+    val rem = minutes % 60L
+    return if (rem == 0L) "${hours}h" else "${hours}h${rem.toString().padStart(2, '0')}"
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
@@ -214,6 +214,8 @@ fun HypnogramScreen(
                             Spacer(modifier = Modifier.height(24.dp))
                             DayMapSection(dayLocation = state.dayLocation)
                             Spacer(modifier = Modifier.height(24.dp))
+                            DayUsageSection(dayUsage = state.dayUsage)
+                            Spacer(modifier = Modifier.height(24.dp))
                         }
                     }
                 }

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 45507c8cbc40c1525ab18eccfa2369748beca4b8
-last_synced: '2026-05-20T16:30:46Z'
-loc: 292
+git_blob: 4051219592fcd219a0f46ec0eacc4344ef3387ac
+last_synced: '2026-05-23T19:13:13Z'
+loc: 312
 annotations: []
 imports: []
 exports: []
@@ -59,6 +59,9 @@ import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
+import fr.datasaillance.nightfall.ui.screens.wellbeing.DigitalWellbeingScreen
+import fr.datasaillance.nightfall.viewmodel.wellbeing.DigitalWellbeingViewModel
+import fr.datasaillance.nightfall.data.local.usage.UsageStatsPermissionHelper
 import fr.datasaillance.nightfall.ui.screens.auth.ForgotPasswordScreen
 import fr.datasaillance.nightfall.ui.screens.auth.LoginScreen
 import fr.datasaillance.nightfall.ui.screens.auth.RegisterScreen
@@ -190,6 +193,7 @@ fun NavGraph(
                         repository = hypnogramRepository,
                         hintDate = dateArg,
                         locationDao = hypnogramDb.locationDao(),
+                        usageStatsDao = hypnogramDb.usageStatsDao(),
                     )
                 }
                 HypnogramScreen(
@@ -215,6 +219,22 @@ fun NavGraph(
                 )
             }
             composable(NavDestination.Activity.route) { ActivityScreen() }
+            composable(NavDestination.Wellbeing.route) {
+                val db = remember(context) {
+                    fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
+                }
+                val viewModel = remember(context, db) {
+                    val helper = UsageStatsPermissionHelper(context.applicationContext)
+                    DigitalWellbeingViewModel(
+                        checkPermission = { helper.hasPermission() },
+                        dao = db.usageStatsDao(),
+                        packageResolver = fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver(
+                            context.applicationContext.packageManager
+                        ),
+                    )
+                }
+                DigitalWellbeingScreen(viewModel = viewModel)
+            }
             composable(NavDestination.Profile.route) {
                 ProfileScreen(
                     onImport   = { navController.navigate(NavDestination.Import.route) },
@@ -320,17 +340,17 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 55-244
-- `NoOpSleepRepository` (class) — lines 246-251
-- `getSessions` (function) — lines 247-250
-- `NoOpImportRepository` (class) — lines 253-268
-- `pingBackend` (function) — lines 254-254
-- `extractCsvEntries` (function) — lines 256-259
-- `uploadCsv` (function) — lines 261-267
-- `NoOpNightfallApi` (class) — lines 270-276
-- `health` (function) — lines 271-271
-- `login` (function) — lines 272-272
-- `register` (function) — lines 273-273
-- `requestPasswordReset` (function) — lines 274-274
-- `googleStart` (function) — lines 275-275
-- `ensureComposeNavigators` (function) — lines 284-292
+- `NavGraph` (function) — lines 58-264
+- `NoOpSleepRepository` (class) — lines 266-271
+- `getSessions` (function) — lines 267-270
+- `NoOpImportRepository` (class) — lines 273-288
+- `pingBackend` (function) — lines 274-274
+- `extractCsvEntries` (function) — lines 276-279
+- `uploadCsv` (function) — lines 281-287
+- `NoOpNightfallApi` (class) — lines 290-296
+- `health` (function) — lines 291-291
+- `login` (function) — lines 292-292
+- `register` (function) — lines 293-293
+- `requestPasswordReset` (function) — lines 294-294
+- `googleStart` (function) — lines 295-295
+- `ensureComposeNavigators` (function) — lines 304-312

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/sleep/HypnogramViewModel.kt
-git_blob: 0f988a37d511847466556d5bf371ce7e8f7a30e0
-last_synced: '2026-05-20T16:30:46Z'
-loc: 139
+git_blob: 604e63601fcc54595eebf602451bfb71e3cb2624
+last_synced: '2026-05-23T19:13:13Z'
+loc: 167
 annotations: []
 imports: []
 exports: []
@@ -26,9 +26,11 @@ package fr.datasaillance.nightfall.viewmodel.sleep
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import fr.datasaillance.nightfall.data.local.dao.UsageStatsDao
 import fr.datasaillance.nightfall.data.local.entity.location.ActivitySegmentEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationPathEntity
 import fr.datasaillance.nightfall.data.local.entity.location.LocationVisitEntity
+import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
 import fr.datasaillance.nightfall.data.sleep.SleepRepository
 import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -48,12 +50,19 @@ data class DayLocation(
     val paths: List<LocationPathEntity> = emptyList(),
 )
 
+/** Snapshot d'usage numérique pour la journée associée à la nuit affichée. */
+data class DayUsage(
+    val rows: List<UsageDailyEntity>,
+    val totalForegroundMs: Long,
+)
+
 sealed class HypnogramUiState {
     object Idle    : HypnogramUiState()
     object Loading : HypnogramUiState()
     data class Success(
         val sessions: List<SleepSessionResponse>,
         val dayLocation: DayLocation? = null,
+        val dayUsage: DayUsage? = null,
     ) : HypnogramUiState()
     data class Error(val message: String) : HypnogramUiState()
 }
@@ -63,6 +72,7 @@ class HypnogramViewModel(
     private val repository: SleepRepository,
     private val hintDate: String? = null,
     private val locationDao: LocationDao? = null,
+    private val usageStatsDao: UsageStatsDao? = null,
     private val zone: ZoneId = ZoneId.systemDefault(),
 ) : ViewModel() {
 
@@ -123,11 +133,16 @@ class HypnogramViewModel(
                 Timber.d("scope=hypno_vm night_sessions=${nightSessions.size} total_stages=${nightSessions.sumOf { it.stages?.size ?: 0 }}")
                 _uiState.value = HypnogramUiState.Success(nightSessions)
 
-                // Charge les données GPS du jour en arrière-plan — l'hypnogramme s'affiche
-                // tout de suite, la map apparaît dès que les données sont prêtes.
+                // Charge les données GPS + usage numérique du jour en arrière-plan —
+                // l'hypnogramme s'affiche tout de suite, le reste apparaît dès que prêt.
                 if (targetDate != null) {
                     val dayLoc = loadDayLocation(targetDate)
-                    _uiState.value = HypnogramUiState.Success(nightSessions, dayLocation = dayLoc)
+                    val dayUse = loadDayUsage(targetDate)
+                    _uiState.value = HypnogramUiState.Success(
+                        sessions = nightSessions,
+                        dayLocation = dayLoc,
+                        dayUsage = dayUse,
+                    )
                 }
             } catch (e: Exception) {
                 Timber.w("scope=hypno_vm error=${e::class.simpleName}")
@@ -150,6 +165,19 @@ class HypnogramViewModel(
             .getOrNull()
     }
 
+    private suspend fun loadDayUsage(date: LocalDate): DayUsage? {
+        val dao = usageStatsDao ?: return null
+        val dateStr = date.toString()
+        return runCatching {
+            val rows = dao.getByDate(dateStr)
+            DayUsage(
+                rows = rows,
+                totalForegroundMs = rows.sumOf { it.totalTimeForegroundMs },
+            )
+        }.onFailure { Timber.w("scope=hypno_vm usage_load_failed error=${it::class.simpleName}") }
+            .getOrNull()
+    }
+
     private fun mapError(throwable: Throwable?): String = when (throwable) {
         is IOException -> "Vérifiez votre connexion réseau"
         is retrofit2.HttpException -> when (throwable.code()) {
@@ -167,12 +195,14 @@ class HypnogramViewModel(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `DayLocation` (class) — lines 22-26
-- `HypnogramUiState` (class) — lines 28-36
-- `Success` (class) — lines 31-34
-- `Error` (class) — lines 35-35
-- `HypnogramViewModel` (class) — lines 38-139
-- `retry` (function) — lines 53-53
-- `loadSession` (function) — lines 55-114
-- `loadDayLocation` (function) — lines 116-128
-- `mapError` (function) — lines 130-138
+- `DayLocation` (class) — lines 24-28
+- `DayUsage` (class) — lines 31-34
+- `HypnogramUiState` (class) — lines 36-45
+- `Success` (class) — lines 39-43
+- `Error` (class) — lines 44-44
+- `HypnogramViewModel` (class) — lines 47-167
+- `retry` (function) — lines 63-63
+- `loadSession` (function) — lines 65-129
+- `loadDayLocation` (function) — lines 131-143
+- `loadDayUsage` (function) — lines 145-156
+- `mapError` (function) — lines 158-166

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.md
@@ -1,0 +1,168 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
+git_blob: ada54e1f2a1c0973e4f9afc2a9f67d32f30d3159
+last_synced: '2026-05-23T19:13:13Z'
+loc: 134
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.sleep
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
+import fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver
+import fr.datasaillance.nightfall.viewmodel.sleep.DayUsage
+
+/**
+ * Section "Bien-être numérique" affichée sous la map dans la page Détails de la
+ * journée. Top 5 apps par temps écran + total cumulé.
+ */
+@Composable
+fun DayUsageSection(
+    dayUsage: DayUsage?,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val resolver = remember(context) { PackageInfoResolver(context.packageManager) }
+
+    Column(modifier = modifier.fillMaxWidth().padding(horizontal = 16.dp)) {
+        Text(
+            text = "Bien-être numérique",
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            dayUsage == null -> UsagePlaceholder("Chargement…")
+            dayUsage.rows.isEmpty() -> UsagePlaceholder(
+                "Pas de collecte d'usage pour ce jour. Active 'Usage Access' dans Bien-être.",
+            )
+            else -> {
+                Text(
+                    text = "Total écran : ${formatScreenTime(dayUsage.totalForegroundMs)}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                val top = dayUsage.rows
+                    .sortedByDescending { it.totalTimeForegroundMs }
+                    .take(5)
+                val maxMs = top.firstOrNull()?.totalTimeForegroundMs ?: 1L
+                top.forEach { row ->
+                    AppRow(row = row, label = resolver.labelFor(row.packageName), maxMs = maxMs)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UsagePlaceholder(message: String) {
+    Box(
+        modifier = Modifier.fillMaxWidth().height(80.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun AppRow(row: UsageDailyEntity, label: String, maxMs: Long) {
+    val ratio = if (maxMs <= 0) 0f else (row.totalTimeForegroundMs.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = formatScreenTime(row.totalTimeForegroundMs),
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant,
+                    MaterialTheme.shapes.extraSmall,
+                ),
+        ) {
+            Spacer(
+                modifier = Modifier
+                    .fillMaxWidth(ratio)
+                    .height(4.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primary,
+                        MaterialTheme.shapes.extraSmall,
+                    ),
+            )
+        }
+    }
+}
+
+private fun formatScreenTime(ms: Long): String {
+    if (ms < 60_000L) return "${ms / 1000}s"
+    val minutes = ms / 60_000L
+    if (minutes < 60L) return "${minutes}min"
+    val hours = minutes / 60L
+    val rem = minutes % 60L
+    return if (rem == 0L) "${hours}h" else "${hours}h${rem.toString().padStart(2, '0')}"
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `DayUsageSection` (function) — lines 30-68
+- `UsagePlaceholder` (function) — lines 70-82
+- `AppRow` (function) — lines 84-125
+- `formatScreenTime` (function) — lines 127-134

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/HypnogramScreen.kt
-git_blob: a53d4063cfab9f32c2981e5542a498f18e529198
-last_synced: '2026-05-20T16:30:46Z'
-loc: 724
+git_blob: 4a6fd6b89bf7db9f569e838d412a5afe86b47e5c
+last_synced: '2026-05-23T19:13:13Z'
+loc: 726
 annotations: []
 imports: []
 exports: []
@@ -236,6 +236,8 @@ fun HypnogramScreen(
                             HypnogramStatsSection(sessions = state.sessions)
                             Spacer(modifier = Modifier.height(24.dp))
                             DayMapSection(dayLocation = state.dayLocation)
+                            Spacer(modifier = Modifier.height(24.dp))
+                            DayUsageSection(dayUsage = state.dayUsage)
                             Spacer(modifier = Modifier.height(24.dp))
                         }
                     }
@@ -758,17 +760,17 @@ private fun LegendItem(color: Color, label: String) {
 - `hypnoStageDisplayName` (function) — lines 64-70
 - `stageAtTime` (function) — lines 76-83
 - `nightTitle` (function) — lines 85-93
-- `HypnogramScreen` (function) — lines 95-223
-- `HypnogramSummarySection` (function) — lines 225-271
-- `HypnogramCanvas` (function) — lines 273-369
-- `drawAxisFourTicks` (function) — lines 371-408
-- `ScrubTooltip` (function) — lines 410-454
-- `drawRoundedSegment` (function) — lines 456-512
-- `HypnoMountainSegment` (class) — lines 516-521
-- `HypnoMicroAwake` (class) — lines 523-523
-- `buildHypnoMountain` (function) — lines 525-553
-- `HypnogramMountainCanvas` (function) — lines 555-696
-- `yForLevel` (function) — lines 595-595
-- `xForMs` (function) — lines 596-596
-- `HypnogramLegend` (function) — lines 698-711
-- `LegendItem` (function) — lines 713-724
+- `HypnogramScreen` (function) — lines 95-225
+- `HypnogramSummarySection` (function) — lines 227-273
+- `HypnogramCanvas` (function) — lines 275-371
+- `drawAxisFourTicks` (function) — lines 373-410
+- `ScrubTooltip` (function) — lines 412-456
+- `drawRoundedSegment` (function) — lines 458-514
+- `HypnoMountainSegment` (class) — lines 518-523
+- `HypnoMicroAwake` (class) — lines 525-525
+- `buildHypnoMountain` (function) — lines 527-555
+- `HypnogramMountainCanvas` (function) — lines 557-698
+- `yForLevel` (function) — lines 597-597
+- `xForMs` (function) — lines 598-598
+- `HypnogramLegend` (function) — lines 700-713
+- `LegendItem` (function) — lines 715-726

--- a/requirements.lock
+++ b/requirements.lock
@@ -1069,9 +1069,9 @@ sqlalchemy==2.0.49 \
     # via
     #   -r requirements.in
     #   alembic
-starlette==1.0.0 \
-    --hash=sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149 \
-    --hash=sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b
+starlette==1.1.0 \
+    --hash=sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382 \
+    --hash=sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f
     # via fastapi
 structlog==25.5.0 \
     --hash=sha256:098522a3bebed9153d4570c6d0288abf80a031dfdb2048d59a49e9dc2190fc98 \


### PR DESCRIPTION
## Summary

Phase D.3 — convergence finale post-merge des branches feat/usage-stats-collector (#87) et feat/gps-collector (#88). Enrichit la page Détails de la journée (HypnogramScreen) avec une section "Bien-être numérique" sous la map.

**Changements** :
- `HypnogramViewModel` : ajout du param `usageStatsDao: UsageStatsDao?` + nouveau data class `DayUsage(rows, totalForegroundMs)` exposé dans `HypnogramUiState.Success`
- `loadDayUsage(date)` : query `dao.getByDate(date.toString())` en arrière-plan post-emit Success initial (l'hypnogramme s'affiche immédiatement, l'usage et la map apparaissent dès qu'ils sont prêts)
- `DayUsageSection.kt` (nouveau, flavor native) : section Compose avec total écran + top 5 apps via PackageInfoResolver pour les labels lisibles + mini-barre proportionnelle
- `HypnogramScreen.kt` : insertion sous `DayMapSection` avec spacer 24dp
- `NavGraph.kt` : passe `hypnogramDb.usageStatsDao()` à l'instanciation du ViewModel

**Comportement** :
- Si pas de collecte pour le jour cible → placeholder "Pas de collecte d'usage pour ce jour. Active 'Usage Access' dans Bien-être."
- Si rows présentes mais total à 0 → affichage de la liste avec 0s (cas rare où Android renvoie des entries mais sans usage)
- Couleur de la barre = primary teal (cohérent avec l'écran Bien-être numérique principal)

**Convergence Phase D complète** : 
- Sleep stages (existant)
- Map OSMDroid + paths GPS (D.2 via #88)
- Bien-être numérique (D.3, ici)
- Le tout sur une page scroll unique par jour

## Test plan

- [x] Build native debug OK
- [ ] Validation device : ouvrir une nuit avec usage collecté → vérifier que la section apparaît, top 5 apps lisibles, total écran cohérent
- [ ] Une nuit sans usage du jour (avant l'activation perm) → placeholder affiché
- [ ] Performance : query est sur 1 jour seulement, devrait être instantané