### PR TITLE
feat(polish): icones apps + legende map + mini bar-chart par jour

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/usage/PackageInfoResolver.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/usage/PackageInfoResolver.kt
@@ -1,28 +1,63 @@
 package fr.datasaillance.nightfall.data.local.usage
 
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 
 /**
- * Résout `packageName → label utilisateur` via `PackageManager.getApplicationLabel`.
- * Cache mémoire — un packageName peut être résolu N fois pour différents jours,
- * inutile de re-query Android à chaque fois.
+ * Résout `packageName → label utilisateur` et `packageName → icône` via
+ * `PackageManager`. Cache mémoire — un packageName peut être résolu N fois
+ * pour différents jours, inutile de re-query Android à chaque fois.
  *
  * Si le package est désinstallé ou inconnu (rare — apps removed après collecte),
- * fallback sur le packageName brut.
+ * fallback sur le packageName brut côté label, `null` côté icône.
  */
 open class PackageInfoResolver(private val pm: PackageManager) {
 
-    private val cache = HashMap<String, String>()
+    private val labelCache = HashMap<String, String>()
+    private val iconCache = HashMap<String, Bitmap?>()
 
     open fun labelFor(packageName: String): String {
-        cache[packageName]?.let { return it }
+        labelCache[packageName]?.let { return it }
         val label = runCatching {
             val info = pm.getApplicationInfo(packageName, 0)
             pm.getApplicationLabel(info).toString()
         }.getOrNull()
             ?.takeIf { it.isNotBlank() }
             ?: packageName
-        cache[packageName] = label
+        labelCache[packageName] = label
         return label
+    }
+
+    /**
+     * Récupère l'icône de l'app sous forme de Bitmap, prêt à être passé à
+     * `Image(painter = BitmapPainter(bitmap.asImageBitmap()))` en Compose.
+     * Cache via `iconCache`. Retourne `null` si l'app n'est plus installée.
+     */
+    open fun iconFor(packageName: String, sizePx: Int = 96): Bitmap? {
+        // Cache par packageName seulement — sizePx est implicite, on assume
+        // l'appelant utilise toujours la même taille (sinon créer une cache key composée).
+        if (iconCache.containsKey(packageName)) return iconCache[packageName]
+        val bitmap = runCatching {
+            val drawable = pm.getApplicationIcon(packageName)
+            drawableToBitmap(drawable, sizePx)
+        }.getOrNull()
+        iconCache[packageName] = bitmap
+        return bitmap
+    }
+
+    private fun drawableToBitmap(drawable: Drawable, sizePx: Int): Bitmap {
+        if (drawable is BitmapDrawable && drawable.bitmap != null) {
+            return drawable.bitmap
+        }
+        val w = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else sizePx
+        val h = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else sizePx
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        return bitmap
     }
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/wellbeing/DigitalWellbeingViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/wellbeing/DigitalWellbeingViewModel.kt
@@ -37,6 +37,12 @@ data class WellbeingUiState(
     val selectedPeriod: WellbeingPeriod = WellbeingPeriod.TODAY,
     val topApps: List<PeriodAppStat> = emptyList(),
     val totalScreenTimeMs: Long = 0,
+    /**
+     * Pour le mini bar-chart par jour (tap-to-expand) :
+     * `packageName → liste ordonnée de paires (date ISO, foreground_ms)` couvrant
+     * tous les jours de la période, 0 inclus pour les jours sans usage.
+     */
+    val dailyByPackage: Map<String, List<Pair<String, Long>>> = emptyMap(),
 )
 
 class DigitalWellbeingViewModel(
@@ -61,12 +67,14 @@ class DigitalWellbeingViewModel(
                 val period = _uiState.value.selectedPeriod
                 val (rowsForPeriod, lastTs) = loadPeriodRows(period)
                 val (topApps, total) = aggregate(rowsForPeriod)
+                val dailyByPkg = buildDailyByPackage(rowsForPeriod, period)
                 _uiState.value = _uiState.value.copy(
                     permissionGranted = checkPermission(),
                     collectedDates = dates,
                     totalRows = dao.count(),
                     topApps = topApps.take(15),
                     totalScreenTimeMs = total,
+                    dailyByPackage = dailyByPkg,
                     isRefreshing = false,
                     lastCollectionAtMs = lastTs,
                 )
@@ -116,6 +124,29 @@ class DigitalWellbeingViewModel(
         val sorted = byPkg.values.sortedByDescending { it.totalForegroundMs }
         val total = sorted.sumOf { it.totalForegroundMs }
         return sorted to total
+    }
+
+    /**
+     * Pour chaque package, retourne la liste ordonnée (par date asc) des paires
+     * `(date ISO, foreground_ms)` couvrant tous les jours de la période. Les jours
+     * sans usage sont remplis avec 0 — le mini bar-chart peut ainsi afficher des
+     * vides à la bonne position chronologique.
+     */
+    private fun buildDailyByPackage(
+        rows: List<UsageDailyEntity>,
+        period: WellbeingPeriod,
+    ): Map<String, List<Pair<String, Long>>> {
+        if (rows.isEmpty()) return emptyMap()
+        val today = clock()
+        val allDates: List<String> = (0 until period.days)
+            .map { offset -> today.minusDays((period.days - 1 - offset).toLong()).toString() }
+        val byPkgByDate: Map<String, Map<String, Long>> = rows.groupBy { it.packageName }
+            .mapValues { (_, rowsForPkg) ->
+                rowsForPkg.associate { it.date to it.totalTimeForegroundMs }
+            }
+        return byPkgByDate.mapValues { (_, byDate) ->
+            allDates.map { date -> date to (byDate[date] ?: 0L) }
+        }
     }
 
     /**

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
@@ -1,6 +1,7 @@
 package fr.datasaillance.nightfall.ui.screens.sleep
 
 import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -84,8 +85,47 @@ fun DayMapSection(
                         .height(280.dp)
                         .testTag("hyp_day_map"),
                 )
+                Spacer(modifier = Modifier.height(8.dp))
+                ActivityLegend(dayLocation = dayLocation)
             }
         }
+    }
+}
+
+/**
+ * Légende dynamique : n'affiche que les types d'activité réellement présents
+ * dans la journée. Évite la légende statique surchargée quand l'utilisateur n'a
+ * fait que marcher (par ex.) — il ne verra que "Marche".
+ */
+@Composable
+private fun ActivityLegend(dayLocation: DayLocation) {
+    val typesPresent = dayLocation.segments.map { it.activityType }.distinct()
+    if (typesPresent.isEmpty()) return
+    Row(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
+        typesPresent.forEach { type ->
+            LegendChip(label = humanizeActivityType(type), colorInt = blendActivityColorInternal(type))
+            Spacer(modifier = Modifier.padding(end = 8.dp))
+        }
+    }
+}
+
+@Composable
+private fun LegendChip(label: String, colorInt: Int) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .padding(end = 4.dp)
+                .background(
+                    androidx.compose.ui.graphics.Color(colorInt),
+                    MaterialTheme.shapes.extraSmall,
+                )
+                .padding(6.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -268,12 +308,20 @@ internal fun humanizeActivityType(type: String): String = when (type) {
 
 /**
  * Couleur du polyline selon le type d'activité.
- * On reste sur la palette DataSaillance (teal/amber/cyan) — pas de gradient décoratif.
+ * Palette DataSaillance (teal/amber/cyan) — pas de gradient décoratif.
+ * Retourne `null` pour les types inconnus → le caller décide du fallback.
  */
-private fun blendActivityColor(type: String, fallback: Int): Int = when (type) {
+private fun colorForActivityType(type: String): Int? = when (type) {
     "WALKING", "RUNNING" -> AndroidColor.parseColor("#3be5e7")  // cyan
     "CYCLING" -> AndroidColor.parseColor("#0e9eb0")             // teal
     "IN_PASSENGER_VEHICLE", "IN_BUS", "IN_SUBWAY", "IN_TRAIN" -> AndroidColor.parseColor("#d37c04")  // amber
     "FLYING" -> AndroidColor.parseColor("#8b5cf6")              // violet sobre
-    else -> fallback
+    else -> null
 }
+
+private fun blendActivityColor(type: String, fallback: Int): Int =
+    colorForActivityType(type) ?: fallback
+
+/** Variante sans fallback pour la légende — gris pour les types inconnus. */
+private fun blendActivityColorInternal(type: String): Int =
+    colorForActivityType(type) ?: AndroidColor.parseColor("#888888")

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
 import fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver
+import fr.datasaillance.nightfall.ui.screens.wellbeing.AppIcon
 import fr.datasaillance.nightfall.viewmodel.sleep.DayUsage
 
 /**
@@ -60,7 +61,12 @@ fun DayUsageSection(
                     .take(5)
                 val maxMs = top.firstOrNull()?.totalTimeForegroundMs ?: 1L
                 top.forEach { row ->
-                    AppRow(row = row, label = resolver.labelFor(row.packageName), maxMs = maxMs)
+                    AppRow(
+                        row = row,
+                        label = resolver.labelFor(row.packageName),
+                        resolver = resolver,
+                        maxMs = maxMs,
+                    )
                 }
             }
         }
@@ -82,7 +88,12 @@ private fun UsagePlaceholder(message: String) {
 }
 
 @Composable
-private fun AppRow(row: UsageDailyEntity, label: String, maxMs: Long) {
+private fun AppRow(
+    row: UsageDailyEntity,
+    label: String,
+    resolver: PackageInfoResolver,
+    maxMs: Long,
+) {
     val ratio = if (maxMs <= 0) 0f else (row.totalTimeForegroundMs.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
     Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
         Row(
@@ -90,6 +101,8 @@ private fun AppRow(row: UsageDailyEntity, label: String, maxMs: Long) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            AppIcon(packageName = row.packageName, resolver = resolver, size = 28.dp)
+            Spacer(modifier = Modifier.padding(end = 8.dp))
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodyMedium,

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/wellbeing/DigitalWellbeingScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/wellbeing/DigitalWellbeingScreen.kt
@@ -32,8 +32,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.size
+import fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver
 import fr.datasaillance.nightfall.data.local.usage.UsageStatsPermissionHelper
 import fr.datasaillance.nightfall.viewmodel.wellbeing.DigitalWellbeingViewModel
 import fr.datasaillance.nightfall.viewmodel.wellbeing.PeriodAppStat
@@ -138,8 +152,21 @@ fun DigitalWellbeingScreen(
                         )
                     } else {
                         val maxMs = state.topApps.firstOrNull()?.totalForegroundMs ?: 1L
+                        // Resolver partagé pour toute la liste (cache mémoire des icônes/labels)
+                        val resolver = remember(context) { PackageInfoResolver(context.packageManager) }
+                        var expandedPkg by remember { mutableStateOf<String?>(null) }
                         state.topApps.forEach { app ->
-                            AppPeriodRow(app, maxMs, state.selectedPeriod.days)
+                            AppPeriodRow(
+                                stat = app,
+                                maxMs = maxMs,
+                                periodDays = state.selectedPeriod.days,
+                                resolver = resolver,
+                                isExpanded = expandedPkg == app.packageName,
+                                dailyHistory = state.dailyByPackage[app.packageName].orEmpty(),
+                                onToggle = {
+                                    expandedPkg = if (expandedPkg == app.packageName) null else app.packageName
+                                },
+                            )
                         }
                     }
                 }
@@ -253,11 +280,20 @@ private fun PeriodChips(
 }
 
 @Composable
-private fun AppPeriodRow(stat: PeriodAppStat, maxMs: Long, periodDays: Int) {
+private fun AppPeriodRow(
+    stat: PeriodAppStat,
+    maxMs: Long,
+    periodDays: Int,
+    resolver: PackageInfoResolver,
+    isExpanded: Boolean = false,
+    dailyHistory: List<Pair<String, Long>> = emptyList(),
+    onToggle: () -> Unit = {},
+) {
     val ratio = if (maxMs <= 0) 0f else (stat.totalForegroundMs.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(enabled = periodDays > 1) { onToggle() }
             .padding(vertical = 6.dp),
     ) {
         Row(
@@ -265,6 +301,8 @@ private fun AppPeriodRow(stat: PeriodAppStat, maxMs: Long, periodDays: Int) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            AppIcon(packageName = stat.packageName, resolver = resolver, size = 32.dp)
+            Spacer(modifier = Modifier.padding(end = 8.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stat.displayLabel,
@@ -308,11 +346,100 @@ private fun AppPeriodRow(stat: PeriodAppStat, maxMs: Long, periodDays: Int) {
         if (periodDays > 1) {
             Spacer(modifier = Modifier.height(2.dp))
             Text(
-                text = "${stat.daysWithUsage}/${periodDays}j",
+                text = if (isExpanded) "${stat.daysWithUsage}/${periodDays}j · tap pour replier"
+                       else "${stat.daysWithUsage}/${periodDays}j · tap pour détail",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        if (isExpanded && dailyHistory.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            DailyHistoryBars(history = dailyHistory)
+        }
+    }
+}
+
+/**
+ * Mini bar-chart horizontal — 1 barre par jour de la période, hauteur
+ * proportionnelle au temps écran du jour. Affiche la date min/max en label
+ * sous les barres pour donner le contexte temporel.
+ */
+@Composable
+private fun DailyHistoryBars(history: List<Pair<String, Long>>) {
+    val maxMs = history.maxOfOrNull { it.second } ?: 0L
+    val barColor = MaterialTheme.colorScheme.primary
+    val emptyColor = MaterialTheme.colorScheme.surfaceVariant
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            history.forEach { (_, ms) ->
+                val ratio = if (maxMs <= 0L) 0f else (ms.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
+                Column(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    verticalArrangement = Arrangement.Bottom,
+                ) {
+                    androidx.compose.foundation.layout.Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight(ratio.coerceAtLeast(0.02f))
+                            .background(
+                                if (ms > 0L) barColor else emptyColor.copy(alpha = 0.3f),
+                                MaterialTheme.shapes.extraSmall,
+                            ),
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = history.first().first.takeLast(5),  // MM-DD
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "max ${formatDuration(maxMs)}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = history.last().first.takeLast(5),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Affiche l'icône d'une app via PackageManager. Placeholder gris en CircleShape
+ * si le package est introuvable (désinstallé après collecte).
+ */
+@Composable
+internal fun AppIcon(packageName: String, resolver: PackageInfoResolver, size: Dp = 32.dp) {
+    val bitmap = remember(packageName) { resolver.iconFor(packageName) }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.size(size).clip(CircleShape),
+        )
+    } else {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        )
     }
 }
 

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/usage/PackageInfoResolver.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/usage/PackageInfoResolver.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/data/local/usage/PackageInfoResolver.kt
-git_blob: 2f9dfba01cbe529326107127d72f01fba02966c7
-last_synced: '2026-05-20T18:53:28Z'
-loc: 28
+git_blob: 7cc6988fe9c73482abeb37915ff0b564930c0510
+last_synced: '2026-05-24T00:52:50Z'
+loc: 63
 annotations: []
 imports: []
 exports: []
@@ -24,29 +24,64 @@ tags:
 package fr.datasaillance.nightfall.data.local.usage
 
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 
 /**
- * Résout `packageName → label utilisateur` via `PackageManager.getApplicationLabel`.
- * Cache mémoire — un packageName peut être résolu N fois pour différents jours,
- * inutile de re-query Android à chaque fois.
+ * Résout `packageName → label utilisateur` et `packageName → icône` via
+ * `PackageManager`. Cache mémoire — un packageName peut être résolu N fois
+ * pour différents jours, inutile de re-query Android à chaque fois.
  *
  * Si le package est désinstallé ou inconnu (rare — apps removed après collecte),
- * fallback sur le packageName brut.
+ * fallback sur le packageName brut côté label, `null` côté icône.
  */
 open class PackageInfoResolver(private val pm: PackageManager) {
 
-    private val cache = HashMap<String, String>()
+    private val labelCache = HashMap<String, String>()
+    private val iconCache = HashMap<String, Bitmap?>()
 
     open fun labelFor(packageName: String): String {
-        cache[packageName]?.let { return it }
+        labelCache[packageName]?.let { return it }
         val label = runCatching {
             val info = pm.getApplicationInfo(packageName, 0)
             pm.getApplicationLabel(info).toString()
         }.getOrNull()
             ?.takeIf { it.isNotBlank() }
             ?: packageName
-        cache[packageName] = label
+        labelCache[packageName] = label
         return label
+    }
+
+    /**
+     * Récupère l'icône de l'app sous forme de Bitmap, prêt à être passé à
+     * `Image(painter = BitmapPainter(bitmap.asImageBitmap()))` en Compose.
+     * Cache via `iconCache`. Retourne `null` si l'app n'est plus installée.
+     */
+    open fun iconFor(packageName: String, sizePx: Int = 96): Bitmap? {
+        // Cache par packageName seulement — sizePx est implicite, on assume
+        // l'appelant utilise toujours la même taille (sinon créer une cache key composée).
+        if (iconCache.containsKey(packageName)) return iconCache[packageName]
+        val bitmap = runCatching {
+            val drawable = pm.getApplicationIcon(packageName)
+            drawableToBitmap(drawable, sizePx)
+        }.getOrNull()
+        iconCache[packageName] = bitmap
+        return bitmap
+    }
+
+    private fun drawableToBitmap(drawable: Drawable, sizePx: Int): Bitmap {
+        if (drawable is BitmapDrawable && drawable.bitmap != null) {
+            return drawable.bitmap
+        }
+        val w = if (drawable.intrinsicWidth > 0) drawable.intrinsicWidth else sizePx
+        val h = if (drawable.intrinsicHeight > 0) drawable.intrinsicHeight else sizePx
+        val bitmap = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        drawable.setBounds(0, 0, canvas.width, canvas.height)
+        drawable.draw(canvas)
+        return bitmap
     }
 }
 ```
@@ -56,5 +91,7 @@ open class PackageInfoResolver(private val pm: PackageManager) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `PackageInfoResolver` (class) — lines 13-28
-- `labelFor` (function) — lines 17-27
+- `PackageInfoResolver` (class) — lines 17-63
+- `labelFor` (function) — lines 22-32
+- `iconFor` (function) — lines 39-49
+- `drawableToBitmap` (function) — lines 51-62

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/wellbeing/DigitalWellbeingViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/wellbeing/DigitalWellbeingViewModel.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/wellbeing/DigitalWellbeingViewModel.kt
-git_blob: 68bbe8820a30e6ad9bf8e8314b0aaead91af4761
-last_synced: '2026-05-20T18:53:28Z'
-loc: 166
+git_blob: 6f3304b3e999219d52fb04c8cd546bbf18c73e28
+last_synced: '2026-05-24T00:52:50Z'
+loc: 197
 annotations: []
 imports: []
 exports: []
@@ -60,6 +60,12 @@ data class WellbeingUiState(
     val selectedPeriod: WellbeingPeriod = WellbeingPeriod.TODAY,
     val topApps: List<PeriodAppStat> = emptyList(),
     val totalScreenTimeMs: Long = 0,
+    /**
+     * Pour le mini bar-chart par jour (tap-to-expand) :
+     * `packageName → liste ordonnée de paires (date ISO, foreground_ms)` couvrant
+     * tous les jours de la période, 0 inclus pour les jours sans usage.
+     */
+    val dailyByPackage: Map<String, List<Pair<String, Long>>> = emptyMap(),
 )
 
 class DigitalWellbeingViewModel(
@@ -84,12 +90,14 @@ class DigitalWellbeingViewModel(
                 val period = _uiState.value.selectedPeriod
                 val (rowsForPeriod, lastTs) = loadPeriodRows(period)
                 val (topApps, total) = aggregate(rowsForPeriod)
+                val dailyByPkg = buildDailyByPackage(rowsForPeriod, period)
                 _uiState.value = _uiState.value.copy(
                     permissionGranted = checkPermission(),
                     collectedDates = dates,
                     totalRows = dao.count(),
                     topApps = topApps.take(15),
                     totalScreenTimeMs = total,
+                    dailyByPackage = dailyByPkg,
                     isRefreshing = false,
                     lastCollectionAtMs = lastTs,
                 )
@@ -139,6 +147,29 @@ class DigitalWellbeingViewModel(
         val sorted = byPkg.values.sortedByDescending { it.totalForegroundMs }
         val total = sorted.sumOf { it.totalForegroundMs }
         return sorted to total
+    }
+
+    /**
+     * Pour chaque package, retourne la liste ordonnée (par date asc) des paires
+     * `(date ISO, foreground_ms)` couvrant tous les jours de la période. Les jours
+     * sans usage sont remplis avec 0 — le mini bar-chart peut ainsi afficher des
+     * vides à la bonne position chronologique.
+     */
+    private fun buildDailyByPackage(
+        rows: List<UsageDailyEntity>,
+        period: WellbeingPeriod,
+    ): Map<String, List<Pair<String, Long>>> {
+        if (rows.isEmpty()) return emptyMap()
+        val today = clock()
+        val allDates: List<String> = (0 until period.days)
+            .map { offset -> today.minusDays((period.days - 1 - offset).toLong()).toString() }
+        val byPkgByDate: Map<String, Map<String, Long>> = rows.groupBy { it.packageName }
+            .mapValues { (_, rowsForPkg) ->
+                rowsForPkg.associate { it.date to it.totalTimeForegroundMs }
+            }
+        return byPkgByDate.mapValues { (_, byDate) ->
+            allDates.map { date -> date to (byDate[date] ?: 0L) }
+        }
     }
 
     /**
@@ -196,11 +227,12 @@ class DigitalWellbeingViewModel(
 ### Symbols
 - `WellbeingPeriod` (class) — lines 16-20
 - `PeriodAppStat` (class) — lines 23-28
-- `WellbeingUiState` (class) — lines 30-40
-- `DigitalWellbeingViewModel` (class) — lines 42-166
-- `refresh` (function) — lines 56-78
-- `setPeriod` (function) — lines 80-84
-- `loadPeriodRows` (function) — lines 86-95
-- `aggregate` (function) — lines 97-119
-- `collectNow` (function) — lines 126-145
-- `backfill` (function) — lines 147-165
+- `WellbeingUiState` (class) — lines 30-46
+- `DigitalWellbeingViewModel` (class) — lines 48-197
+- `refresh` (function) — lines 62-86
+- `setPeriod` (function) — lines 88-92
+- `loadPeriodRows` (function) — lines 94-103
+- `aggregate` (function) — lines 105-127
+- `buildDailyByPackage` (function) — lines 135-150
+- `collectNow` (function) — lines 157-176
+- `backfill` (function) — lines 178-196

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayMapSection.kt
-git_blob: 963a19eddf67bdfe63c37f652d647b546f9b5ba3
-last_synced: '2026-05-20T16:30:46Z'
-loc: 279
+git_blob: d26495ca5fda4a2a5f57dfece97b7552c4534d2a
+last_synced: '2026-05-24T00:52:50Z'
+loc: 327
 annotations: []
 imports: []
 exports: []
@@ -24,6 +24,7 @@ tags:
 package fr.datasaillance.nightfall.ui.screens.sleep
 
 import android.graphics.Color as AndroidColor
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -107,8 +108,47 @@ fun DayMapSection(
                         .height(280.dp)
                         .testTag("hyp_day_map"),
                 )
+                Spacer(modifier = Modifier.height(8.dp))
+                ActivityLegend(dayLocation = dayLocation)
             }
         }
+    }
+}
+
+/**
+ * Légende dynamique : n'affiche que les types d'activité réellement présents
+ * dans la journée. Évite la légende statique surchargée quand l'utilisateur n'a
+ * fait que marcher (par ex.) — il ne verra que "Marche".
+ */
+@Composable
+private fun ActivityLegend(dayLocation: DayLocation) {
+    val typesPresent = dayLocation.segments.map { it.activityType }.distinct()
+    if (typesPresent.isEmpty()) return
+    Row(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
+        typesPresent.forEach { type ->
+            LegendChip(label = humanizeActivityType(type), colorInt = blendActivityColorInternal(type))
+            Spacer(modifier = Modifier.padding(end = 8.dp))
+        }
+    }
+}
+
+@Composable
+private fun LegendChip(label: String, colorInt: Int) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .padding(end = 4.dp)
+                .background(
+                    androidx.compose.ui.graphics.Color(colorInt),
+                    MaterialTheme.shapes.extraSmall,
+                )
+                .padding(6.dp),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
     }
 }
 
@@ -291,15 +331,23 @@ internal fun humanizeActivityType(type: String): String = when (type) {
 
 /**
  * Couleur du polyline selon le type d'activité.
- * On reste sur la palette DataSaillance (teal/amber/cyan) — pas de gradient décoratif.
+ * Palette DataSaillance (teal/amber/cyan) — pas de gradient décoratif.
+ * Retourne `null` pour les types inconnus → le caller décide du fallback.
  */
-private fun blendActivityColor(type: String, fallback: Int): Int = when (type) {
+private fun colorForActivityType(type: String): Int? = when (type) {
     "WALKING", "RUNNING" -> AndroidColor.parseColor("#3be5e7")  // cyan
     "CYCLING" -> AndroidColor.parseColor("#0e9eb0")             // teal
     "IN_PASSENGER_VEHICLE", "IN_BUS", "IN_SUBWAY", "IN_TRAIN" -> AndroidColor.parseColor("#d37c04")  // amber
     "FLYING" -> AndroidColor.parseColor("#8b5cf6")              // violet sobre
-    else -> fallback
+    else -> null
 }
+
+private fun blendActivityColor(type: String, fallback: Int): Int =
+    colorForActivityType(type) ?: fallback
+
+/** Variante sans fallback pour la légende — gris pour les types inconnus. */
+private fun blendActivityColorInternal(type: String): Int =
+    colorForActivityType(type) ?: AndroidColor.parseColor("#888888")
 ```
 
 ---
@@ -307,15 +355,19 @@ private fun blendActivityColor(type: String, fallback: Int): Int = when (type) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `DayMapSection` (function) — lines 35-90
-- `LocationPlaceholder` (function) — lines 92-106
-- `DayStatsRow` (function) — lines 108-129
-- `StatChip` (function) — lines 131-145
-- `populateMap` (function) — lines 147-219
-- `decodePathPoints` (function) — lines 222-235
-- `buildVisitTitle` (function) — lines 237-238
-- `formatVisitTimes` (function) — lines 240-246
-- `formatSegmentMeta` (function) — lines 248-251
-- `formatDistance` (function) — lines 253-254
-- `humanizeActivityType` (function) — lines 256-267
-- `blendActivityColor` (function) — lines 273-279
+- `DayMapSection` (function) — lines 36-93
+- `ActivityLegend` (function) — lines 100-110
+- `LegendChip` (function) — lines 112-130
+- `LocationPlaceholder` (function) — lines 132-146
+- `DayStatsRow` (function) — lines 148-169
+- `StatChip` (function) — lines 171-185
+- `populateMap` (function) — lines 187-259
+- `decodePathPoints` (function) — lines 262-275
+- `buildVisitTitle` (function) — lines 277-278
+- `formatVisitTimes` (function) — lines 280-286
+- `formatSegmentMeta` (function) — lines 288-291
+- `formatDistance` (function) — lines 293-294
+- `humanizeActivityType` (function) — lines 296-307
+- `colorForActivityType` (function) — lines 314-320
+- `blendActivityColor` (function) — lines 322-323
+- `blendActivityColorInternal` (function) — lines 326-327

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/sleep/DayUsageSection.kt
-git_blob: ada54e1f2a1c0973e4f9afc2a9f67d32f30d3159
-last_synced: '2026-05-23T19:13:13Z'
-loc: 134
+git_blob: f273b4ffd004a629c4445a92538cc5c044b09112
+last_synced: '2026-05-24T00:52:50Z'
+loc: 147
 annotations: []
 imports: []
 exports: []
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import fr.datasaillance.nightfall.data.local.entity.usage.UsageDailyEntity
 import fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver
+import fr.datasaillance.nightfall.ui.screens.wellbeing.AppIcon
 import fr.datasaillance.nightfall.viewmodel.sleep.DayUsage
 
 /**
@@ -83,7 +84,12 @@ fun DayUsageSection(
                     .take(5)
                 val maxMs = top.firstOrNull()?.totalTimeForegroundMs ?: 1L
                 top.forEach { row ->
-                    AppRow(row = row, label = resolver.labelFor(row.packageName), maxMs = maxMs)
+                    AppRow(
+                        row = row,
+                        label = resolver.labelFor(row.packageName),
+                        resolver = resolver,
+                        maxMs = maxMs,
+                    )
                 }
             }
         }
@@ -105,7 +111,12 @@ private fun UsagePlaceholder(message: String) {
 }
 
 @Composable
-private fun AppRow(row: UsageDailyEntity, label: String, maxMs: Long) {
+private fun AppRow(
+    row: UsageDailyEntity,
+    label: String,
+    resolver: PackageInfoResolver,
+    maxMs: Long,
+) {
     val ratio = if (maxMs <= 0) 0f else (row.totalTimeForegroundMs.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
     Column(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
         Row(
@@ -113,6 +124,8 @@ private fun AppRow(row: UsageDailyEntity, label: String, maxMs: Long) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            AppIcon(packageName = row.packageName, resolver = resolver, size = 28.dp)
+            Spacer(modifier = Modifier.padding(end = 8.dp))
             Text(
                 text = label,
                 style = MaterialTheme.typography.bodyMedium,
@@ -162,7 +175,7 @@ private fun formatScreenTime(ms: Long): String {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `DayUsageSection` (function) — lines 30-68
-- `UsagePlaceholder` (function) — lines 70-82
-- `AppRow` (function) — lines 84-125
-- `formatScreenTime` (function) — lines 127-134
+- `DayUsageSection` (function) — lines 31-74
+- `UsagePlaceholder` (function) — lines 76-88
+- `AppRow` (function) — lines 90-138
+- `formatScreenTime` (function) — lines 140-147

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/wellbeing/DigitalWellbeingScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/wellbeing/DigitalWellbeingScreen.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/wellbeing/DigitalWellbeingScreen.kt
-git_blob: 09f2049f6d0f9e4939fedd3e8a0320d96b22ea4b
-last_synced: '2026-05-20T18:53:28Z'
-loc: 326
+git_blob: 525281ec3ad22fc47262032d2ea29b345a478174
+last_synced: '2026-05-24T00:52:50Z'
+loc: 453
 annotations: []
 imports: []
 exports: []
@@ -55,8 +55,22 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.size
+import fr.datasaillance.nightfall.data.local.usage.PackageInfoResolver
 import fr.datasaillance.nightfall.data.local.usage.UsageStatsPermissionHelper
 import fr.datasaillance.nightfall.viewmodel.wellbeing.DigitalWellbeingViewModel
 import fr.datasaillance.nightfall.viewmodel.wellbeing.PeriodAppStat
@@ -161,8 +175,21 @@ fun DigitalWellbeingScreen(
                         )
                     } else {
                         val maxMs = state.topApps.firstOrNull()?.totalForegroundMs ?: 1L
+                        // Resolver partagé pour toute la liste (cache mémoire des icônes/labels)
+                        val resolver = remember(context) { PackageInfoResolver(context.packageManager) }
+                        var expandedPkg by remember { mutableStateOf<String?>(null) }
                         state.topApps.forEach { app ->
-                            AppPeriodRow(app, maxMs, state.selectedPeriod.days)
+                            AppPeriodRow(
+                                stat = app,
+                                maxMs = maxMs,
+                                periodDays = state.selectedPeriod.days,
+                                resolver = resolver,
+                                isExpanded = expandedPkg == app.packageName,
+                                dailyHistory = state.dailyByPackage[app.packageName].orEmpty(),
+                                onToggle = {
+                                    expandedPkg = if (expandedPkg == app.packageName) null else app.packageName
+                                },
+                            )
                         }
                     }
                 }
@@ -276,11 +303,20 @@ private fun PeriodChips(
 }
 
 @Composable
-private fun AppPeriodRow(stat: PeriodAppStat, maxMs: Long, periodDays: Int) {
+private fun AppPeriodRow(
+    stat: PeriodAppStat,
+    maxMs: Long,
+    periodDays: Int,
+    resolver: PackageInfoResolver,
+    isExpanded: Boolean = false,
+    dailyHistory: List<Pair<String, Long>> = emptyList(),
+    onToggle: () -> Unit = {},
+) {
     val ratio = if (maxMs <= 0) 0f else (stat.totalForegroundMs.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .clickable(enabled = periodDays > 1) { onToggle() }
             .padding(vertical = 6.dp),
     ) {
         Row(
@@ -288,6 +324,8 @@ private fun AppPeriodRow(stat: PeriodAppStat, maxMs: Long, periodDays: Int) {
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
+            AppIcon(packageName = stat.packageName, resolver = resolver, size = 32.dp)
+            Spacer(modifier = Modifier.padding(end = 8.dp))
             Column(modifier = Modifier.weight(1f)) {
                 Text(
                     text = stat.displayLabel,
@@ -331,11 +369,100 @@ private fun AppPeriodRow(stat: PeriodAppStat, maxMs: Long, periodDays: Int) {
         if (periodDays > 1) {
             Spacer(modifier = Modifier.height(2.dp))
             Text(
-                text = "${stat.daysWithUsage}/${periodDays}j",
+                text = if (isExpanded) "${stat.daysWithUsage}/${periodDays}j · tap pour replier"
+                       else "${stat.daysWithUsage}/${periodDays}j · tap pour détail",
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
+        if (isExpanded && dailyHistory.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            DailyHistoryBars(history = dailyHistory)
+        }
+    }
+}
+
+/**
+ * Mini bar-chart horizontal — 1 barre par jour de la période, hauteur
+ * proportionnelle au temps écran du jour. Affiche la date min/max en label
+ * sous les barres pour donner le contexte temporel.
+ */
+@Composable
+private fun DailyHistoryBars(history: List<Pair<String, Long>>) {
+    val maxMs = history.maxOfOrNull { it.second } ?: 0L
+    val barColor = MaterialTheme.colorScheme.primary
+    val emptyColor = MaterialTheme.colorScheme.surfaceVariant
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            history.forEach { (_, ms) ->
+                val ratio = if (maxMs <= 0L) 0f else (ms.toFloat() / maxMs.toFloat()).coerceIn(0f, 1f)
+                Column(
+                    modifier = Modifier.weight(1f).fillMaxHeight(),
+                    verticalArrangement = Arrangement.Bottom,
+                ) {
+                    androidx.compose.foundation.layout.Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .fillMaxHeight(ratio.coerceAtLeast(0.02f))
+                            .background(
+                                if (ms > 0L) barColor else emptyColor.copy(alpha = 0.3f),
+                                MaterialTheme.shapes.extraSmall,
+                            ),
+                    )
+                }
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = history.first().first.takeLast(5),  // MM-DD
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = "max ${formatDuration(maxMs)}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Text(
+                text = history.last().first.takeLast(5),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+/**
+ * Affiche l'icône d'une app via PackageManager. Placeholder gris en CircleShape
+ * si le package est introuvable (désinstallé après collecte).
+ */
+@Composable
+internal fun AppIcon(packageName: String, resolver: PackageInfoResolver, size: Dp = 32.dp) {
+    val bitmap = remember(packageName) { resolver.iconFor(packageName) }
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier.size(size).clip(CircleShape),
+        )
+    } else {
+        androidx.compose.foundation.layout.Box(
+            modifier = Modifier
+                .size(size)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+        )
     }
 }
 
@@ -354,9 +481,11 @@ private fun formatDuration(ms: Long): String {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `DigitalWellbeingScreen` (function) — lines 42-149
-- `PermissionCard` (function) — lines 151-187
-- `StatusCard` (function) — lines 189-234
-- `PeriodChips` (function) — lines 236-253
-- `AppPeriodRow` (function) — lines 255-317
-- `formatDuration` (function) — lines 319-326
+- `DigitalWellbeingScreen` (function) — lines 56-176
+- `PermissionCard` (function) — lines 178-214
+- `StatusCard` (function) — lines 216-261
+- `PeriodChips` (function) — lines 263-280
+- `AppPeriodRow` (function) — lines 282-360
+- `DailyHistoryBars` (function) — lines 367-420
+- `AppIcon` (function) — lines 426-444
+- `formatDuration` (function) — lines 446-453


### PR DESCRIPTION
## Summary

Polish post-Phase D. 3 ameliorations UI sans nouvelle dependance.

**1. Icones apps** dans Bien-etre + DayUsageSection :
- `PackageInfoResolver` etendu avec `iconFor(packageName, sizePx)` — `PackageManager.getApplicationIcon()` + conversion Drawable -> Bitmap (BitmapDrawable direct ou Canvas.draw pour les vectoriels)
- Cache memoire identique aux labels
- Composable `AppIcon` partage entre `DigitalWellbeingScreen` et `DayUsageSection` (clip CircleShape, fallback placeholder gris)
- Resolver instancie 1x par parent puis passe en param aux rows -> cache reutilise

**2. Legende couleurs map** sous OSMDroid :
- `ActivityLegend` n'affiche que les types reellement presents dans `dayLocation.segments` (pas la palette complete statique)
- Refactor `blendActivityColor` -> `colorForActivityType()` qui retourne `Int?` + 2 wrappers (`blendActivityColor` avec fallback caller, `blendActivityColorInternal` avec fallback gris pour la legende)

**3. Mini bar-chart par jour** dans Bien-etre (tap-to-expand) :
- ViewModel : nouveau champ `dailyByPackage: Map<String, List<Pair<String, Long>>>` calcule via `buildDailyByPackage` (1 entree par jour de la periode, 0 inclus pour les jours sans usage)
- UI : state local `expandedPkg`, `clickable` sur `AppPeriodRow` desactive en TODAY
- Composable `DailyHistoryBars` : Row de Box avec `fillMaxHeight(ratio)` pour barres proportionnelles + labels date min/max + max value
- Sub-label adaptatif : "X/Yj · tap pour detail" ou "tap pour replier"

Validation device : tout joue ensemble. Pas de regression sur les vues existantes.

## Test plan

- [x] Build native debug OK
- [x] Validation device : icones visibles, legende dynamique sous map, bar-chart expand/collapse fonctionnel
- [ ] Edge case Bien-etre period TODAY : tap-to-expand desactive (clickable enabled = periodDays > 1) -> verifier qu'aucun expand parasite
- [ ] App desinstallee depuis la collecte : icone affiche le placeholder gris, label fallback packageName