### PR TITLE
feat(design): phase 3 - drop-in dataviz Heatmap + DriftClock (kit v3, standalone)

### DIFF
--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.kt
@@ -1,0 +1,313 @@
+package fr.datasaillance.nightfall.dataviz
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/* ============================================================
+ * DriftClock — a single arc that drifts smoothly around the 24h dial.
+ *
+ * The arc represents the *current* sleep session, with bedHour and
+ * wakeHour interpolated in real time between consecutive sessions
+ * along the shortest angular path. The dial stays clean: no persistent
+ * trail, no past-night overlay.
+ *
+ *   DriftVariant.Pure   — only the arc + tip dots.
+ *   DriftVariant.Comet  — same arc + a 5-night faded comet trail.
+ *
+ * Mirrors  ui_kits/nightfall/dataviz/DriftClock.jsx  1:1.
+ *
+ * Animation spec:
+ *   - Full sweep:    30 000 ms at speed 1× (LinearEasing across the year).
+ *                    Smooth angular interpolation between sessions makes the
+ *                    drift readable even at 4×.
+ *   - Speeds:        0.5× · 1× · 2× · 4×
+ *   - Scrub:         drag the slider → pauses + snaps t.
+ *   - Trail fade:    opacity = 0.55 * (1 − k/(L+1))^1.2  for k = 1..L.
+ * ============================================================ */
+
+enum class DriftVariant { Pure, Comet }
+
+private const val SWEEP_MS_AT_1X = 30_000
+
+@Composable
+fun DriftClock(
+    sessions: List<SleepSession>,
+    modifier: Modifier = Modifier,
+    variant: DriftVariant = DriftVariant.Pure,
+    trailLength: Int = 5,
+    autoPlay: Boolean = true,
+) {
+    if (sessions.isEmpty()) return
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val scope   = rememberCoroutineScope()
+
+    val t = remember { Animatable(0f) }
+    var playing by remember { mutableStateOf(autoPlay) }
+    var speed   by remember { mutableStateOf(1f) }
+
+    LaunchedEffect(playing, speed) {
+        if (!playing) return@LaunchedEffect
+        val totalMs = (SWEEP_MS_AT_1X / speed).roundToInt()
+        while (isActive) {
+            val remainingMs = ((1f - t.value) * totalMs).roundToInt().coerceAtLeast(1)
+            t.animateTo(1f, animationSpec = tween(remainingMs, easing = LinearEasing))
+            t.snapTo(0f)
+        }
+    }
+
+    val N = sessions.size
+    val k     = t.value * (N - 1)
+    val kLow  = k.toInt().coerceIn(0, N - 1)
+    val frac  = k - kLow
+    val kHigh = min(kLow + 1, N - 1)
+    val s0    = sessions[kLow]
+    val s1    = sessions[kHigh]
+    val bedH  = lerpHour(s0.bedHour,  s1.bedHour,  frac)
+    val wakeH = lerpHour(s0.wakeHour, s1.wakeHour, frac)
+    val headDate = if (frac < 0.5f) s0.date else s1.date
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(14.dp)) {
+        Box(Modifier.size(360.dp), contentAlignment = Alignment.Center) {
+            // Compute duration once per recomposition.
+            val durHours: Float = run {
+                var d = wakeH - bedH
+                if (d <= 0f) d += 24f
+                d
+            }
+            val durH = durHours.toInt()
+            val durM = ((durHours - durH) * 60f).roundToInt()
+
+            Canvas(Modifier.fillMaxSize()) {
+                val cx = size.width / 2f
+                val cy = size.height / 2f
+                val rOuter = size.minDimension * 0.42f       // hour ticks
+                val ringR  = size.minDimension * 0.36f       // arc radius
+
+                // Background ring — thin, faint
+                drawCircle(extras.border.copy(alpha = 0.45f),
+                           radius = ringR, center = Offset(cx, cy),
+                           style = Stroke(width = 2f))
+
+                // Trail comets (oldest first → freshest paints on top)
+                if (variant == DriftVariant.Comet) {
+                    for (i in trailLength downTo 1) {
+                        val idx = kLow - i
+                        if (idx < 0) continue
+                        val s = sessions[idx]
+                        val frac01 = (1f - (i / (trailLength + 1f))).coerceAtLeast(0f)
+                        val alpha = 0.55f * frac01.pow(1.2f)
+                        drawSessionArc(cx, cy, ringR,
+                            s.bedHour, s.wakeHour,
+                            color = extras.highlight,
+                            alpha = alpha,
+                            strokeWidth = 3f)
+                    }
+                }
+
+                // Head arc — slightly thicker, on top
+                drawSessionArc(cx, cy, ringR, bedH, wakeH,
+                    color = palette.secondary, alpha = 1f, strokeWidth = 4.5f)
+
+                // Bed marker — hollow ring at the start of the arc.
+                val aBed  = hourToRad(bedH)
+                val pBed  = Offset(cx + ringR * cos(aBed), cy + ringR * sin(aBed))
+                drawCircle(Color(0xFF191E22), radius = 6f, center = pBed)
+                drawCircle(palette.secondary, radius = 6f, center = pBed,
+                           style = Stroke(width = 2.5f))
+
+                // Wake marker — filled disc with small hole at the end.
+                val aWake = hourToRad(wakeH)
+                val pWake = Offset(cx + ringR * cos(aWake), cy + ringR * sin(aWake))
+                drawCircle(palette.secondary, radius = 7f, center = pWake)
+                drawCircle(Color(0xFF191E22), radius = 2.5f, center = pWake)
+
+                drawHourDial(cx, cy, rOuter, extras.textFaint, extras.divider)
+            }
+
+            // Big readable duration overlay (Compose Text is more crisp than
+            // canvas drawText for typography). Stacked at center.
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = "DURÉE",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        letterSpacing = 1.4.sp,
+                    ),
+                    color = extras.textMuted,
+                )
+                Row(verticalAlignment = Alignment.Bottom) {
+                    Text(
+                        text = "$durH",
+                        style = MaterialTheme.typography.displayMedium.copy(fontSize = 38.sp),
+                        color = palette.onBackground,
+                    )
+                    Text(
+                        text = "h",
+                        style = MaterialTheme.typography.headlineSmall.copy(fontSize = 22.sp),
+                        color = palette.onBackground,
+                        modifier = Modifier.padding(start = 2.dp, bottom = 2.dp),
+                    )
+                    Text(
+                        text = " %02d".format(durM),
+                        style = MaterialTheme.typography.displayMedium.copy(fontSize = 38.sp),
+                        color = palette.onBackground,
+                    )
+                }
+                Text(
+                    text = "%s → %s".format(fmtHourClock(bedH), fmtHourClock(wakeH)),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = extras.textFaint,
+                )
+            }
+        }
+
+        DriftScrubber(
+            value = t.value,
+            onScrub = { newT ->
+                playing = false
+                scope.launch { t.snapTo(newT) }
+            },
+            playing = playing,
+            onPlayToggle = { playing = !playing },
+            speed = speed,
+            onSpeedChange = { speed = it },
+            dateLabel = headDate,
+            positionLabel = "${kLow + 1} / $N",
+        )
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Shortest-angular-path hour interpolation.
+// ──────────────────────────────────────────────────────────────
+private fun lerpHour(a: Float, b: Float, t: Float): Float {
+    var d = b - a
+    if (d >  12f) d -= 24f
+    if (d < -12f) d += 24f
+    return ((a + d * t) % 24f + 24f) % 24f
+}
+
+/** HH:MM 24-hour format for decimal hours. */
+private fun fmtHourClock(h: Float): String {
+    val hr = h.toInt() % 24
+    val mn = ((h - h.toInt()) * 60f).roundToInt()
+    return "%02d:%02d".format(hr, mn)
+}
+
+// `extras.bg` doesn't exist on the contract — fallback to the dark canvas.
+// Kept here for any future code in this file that needs the encre background.
+@Suppress("unused")
+private val fr.datasaillance.nightfall.ui.theme.ExtraColors.bg: Color
+    get() = Color(0xFF191E22)
+
+// ──────────────────────────────────────────────────────────────
+// Scrubber
+// ──────────────────────────────────────────────────────────────
+@Composable
+private fun DriftScrubber(
+    value: Float,
+    onScrub: (Float) -> Unit,
+    playing: Boolean,
+    onPlayToggle: () -> Unit,
+    speed: Float,
+    onSpeedChange: (Float) -> Unit,
+    dateLabel: String,
+    positionLabel: String,
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        Box(
+            Modifier
+                .size(34.dp)
+                .clip(CircleShape)
+                .background(palette.secondary)
+                .clickable(interactionSource = interactionSource, indication = null) { onPlayToggle() },
+            contentAlignment = Alignment.Center,
+        ) {
+            Canvas(Modifier.size(12.dp)) {
+                val w = size.width; val h = size.height
+                if (playing) {
+                    drawRect(palette.onSecondary, Offset(w * 0.16f, 0f), Size(w * 0.22f, h))
+                    drawRect(palette.onSecondary, Offset(w * 0.62f, 0f), Size(w * 0.22f, h))
+                } else {
+                    val tri = Path().apply {
+                        moveTo(w * 0.20f, 0f)
+                        lineTo(w * 0.92f, h * 0.50f)
+                        lineTo(w * 0.20f, h)
+                        close()
+                    }
+                    drawPath(tri, palette.onSecondary)
+                }
+            }
+        }
+        Slider(
+            value = value,
+            onValueChange = onScrub,
+            modifier = Modifier.weight(1f),
+            valueRange = 0f..1f,
+            colors = SliderDefaults.colors(
+                thumbColor = palette.secondary,
+                activeTrackColor = palette.secondary,
+                inactiveTrackColor = extras.border,
+            ),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+            listOf(0.5f, 1f, 2f, 4f).forEach { sp ->
+                val active = sp == speed
+                TextButton(
+                    onClick = { onSpeedChange(sp) },
+                    contentPadding = PaddingValues(horizontal = 6.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = if (sp == sp.toInt().toFloat()) "${sp.toInt()}×" else "${sp}×",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (active) palette.onSurface else extras.textMuted,
+                    )
+                }
+            }
+        }
+    }
+    Row(modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(dateLabel,     style = MaterialTheme.typography.labelSmall, color = extras.textFaint)
+        Text(positionLabel, style = MaterialTheme.typography.labelSmall, color = extras.textFaint)
+    }
+}
+
+private fun Float.pow(x: Float): Float =
+    if (this <= 0f) 0f else kotlin.math.exp(kotlin.math.ln(this.toDouble()) * x.toDouble()).toFloat()
+
+private val androidx.compose.ui.unit.IntSize.minDimension: Float
+    get() = min(width, height).toFloat()

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.kt
@@ -1,0 +1,232 @@
+package fr.datasaillance.nightfall.dataviz
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.math.sin
+
+/* ============================================================
+ * Heatmap — polar heatmap of sleep on the 24h dial.
+ *
+ *   HeatmapVariant.Ring  — 144 wedges (10-min bins), colored by total minutes.
+ *   HeatmapVariant.Rose  — same bins, encoded as radial bar lengths.
+ *
+ * Mirrors  ui_kits/nightfall/dataviz/Heatmap.jsx  1:1.
+ * Sequential color ramp from surface-3 to highlight cyan, gamma-corrected.
+ * ============================================================ */
+
+data class SleepSession(
+    val date: String,       // YYYY-MM-DD
+    val bedHour: Float,     // 0..24 decimal, local
+    val wakeHour: Float,    // 0..24 decimal, local
+    val durationMin: Int,
+    val isMain: Boolean,
+    val unixMs: Long,
+)
+
+enum class HeatmapVariant { Ring, Rose }
+
+private const val BIN_COUNT = 144                  // 10-min bins
+private const val BIN_WIDTH_H = 24f / BIN_COUNT    // 0.1666… h
+
+@Composable
+fun Heatmap(
+    sessions: List<SleepSession>,
+    modifier: Modifier = Modifier,
+    variant: HeatmapVariant = HeatmapVariant.Ring,
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+
+    val bins = remember(sessions) { computeBins(sessions) }
+    val peak = remember(bins)     { bins.maxOrNull() ?: 0f }
+
+    // Color ramp anchors. `surface3` for empty, `highlight` for peak.
+    val emptyColor = extras.borderStrong.copy(alpha = 0.0f)     // overlay only on filled bins
+    val baseColor  = Color(0xFF1E262B)
+    val peakColor  = extras.highlight
+
+    Box(modifier = modifier.size(360.dp), contentAlignment = Alignment.Center) {
+        Canvas(Modifier.fillMaxSize()) {
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            val rOuter = size.minDimension * 0.42f
+            val rInner = size.minDimension * 0.16f
+
+            when (variant) {
+                HeatmapVariant.Ring -> drawRing(cx, cy, rOuter, rInner, bins, peak, baseColor, peakColor)
+                HeatmapVariant.Rose -> drawRose(cx, cy, rOuter, rInner, bins, peak, peakColor, extras.divider)
+            }
+            drawHourDial(cx, cy, rOuter, extras.textFaint, extras.divider)
+            // Outer and inner outlines
+            drawCircle(palette.outline, radius = rOuter + 2f, center = Offset(cx, cy),
+                       style = Stroke(width = 1f))
+            drawCircle(palette.outline, radius = rInner - 2f, center = Offset(cx, cy),
+                       style = Stroke(width = 1f))
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variation A — Ring of 144 wedges
+// ──────────────────────────────────────────────────────────────
+private fun DrawScope.drawRing(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float,
+    bins: FloatArray, peak: Float,
+    baseColor: Color, peakColor: Color,
+) {
+    for (i in 0 until BIN_COUNT) {
+        val h1 = i * BIN_WIDTH_H
+        val h2 = (i + 1) * BIN_WIDTH_H
+        val v  = if (peak > 0f) bins[i] / peak else 0f
+        val color = if (bins[i] == 0f) baseColor else heatColor(v, baseColor, peakColor)
+        drawWedge(cx, cy, rOuter, rInner, h1, h2, color)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variation B — Rose plot (radial bar lengths)
+// ──────────────────────────────────────────────────────────────
+private fun DrawScope.drawRose(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float,
+    bins: FloatArray, peak: Float,
+    peakColor: Color, divider: Color,
+) {
+    val maxLen = rOuter - rInner
+    // 4 reference rings (25/50/75/100 %)
+    val dash = PathEffect.dashPathEffect(floatArrayOf(2f, 3f), 0f)
+    listOf(0.25f, 0.5f, 0.75f, 1f).forEach { f ->
+        drawCircle(divider, radius = rInner + f * maxLen, center = Offset(cx, cy),
+                   style = Stroke(width = 0.6f, pathEffect = dash))
+    }
+    for (i in 0 until BIN_COUNT) {
+        if (bins[i] == 0f) continue
+        val v   = if (peak > 0f) bins[i] / peak else 0f
+        val len = v.pow(0.65f) * maxLen
+        val h1  = i * BIN_WIDTH_H
+        val h2  = (i + 1) * BIN_WIDTH_H
+        val color = heatColor(v, Color(0xFF2A363B), peakColor)
+        drawWedge(cx, cy, rInner + len, rInner, h1, h2, color)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Color ramp — gamma-corrected lerp from base to peak.
+// ──────────────────────────────────────────────────────────────
+private fun heatColor(t: Float, base: Color, peak: Color): Color {
+    val tt = t.coerceIn(0f, 1f).pow(0.55f)
+    return lerp(base, peak, tt)
+}
+
+// ──────────────────────────────────────────────────────────────
+// Bin computation — minutes slept per 10-min slot, with edge overlap.
+// ──────────────────────────────────────────────────────────────
+private fun computeBins(sessions: List<SleepSession>): FloatArray {
+    val bins = FloatArray(BIN_COUNT)
+    for (s in sessions) {
+        var bed = s.bedHour
+        var wake = s.wakeHour
+        if (wake <= bed) wake += 24f
+        val startBin = (bed / BIN_WIDTH_H).toInt()
+        val endBin   = ((wake - 1e-6f) / BIN_WIDTH_H).toInt()
+        for (i in startBin..endBin) {
+            val a = i * BIN_WIDTH_H
+            val b = a + BIN_WIDTH_H
+            val ovStart = max(bed, a)
+            val ovEnd   = kotlin.math.min(wake, b)
+            if (ovEnd > ovStart) bins[((i % BIN_COUNT) + BIN_COUNT) % BIN_COUNT] += (ovEnd - ovStart) * 60f
+        }
+    }
+    return bins
+}
+
+// ──────────────────────────────────────────────────────────────
+// Polar drawing primitives — also used by DriftClock.kt
+// ──────────────────────────────────────────────────────────────
+internal fun DrawScope.drawWedge(
+    cx: Float, cy: Float, rOut: Float, rIn: Float,
+    h1: Float, h2: Float, color: Color,
+) {
+    val a1 = hourToRad(h1)
+    var a2 = hourToRad(h2)
+    if (a2 <= a1) a2 += (2 * PI).toFloat()
+    val path = Path().apply {
+        moveTo(cx + rOut * cos(a1), cy + rOut * sin(a1))
+        arcToRad(cx, cy, rOut, a1, a2)
+        lineTo(cx + rIn * cos(a2), cy + rIn * sin(a2))
+        arcToRad(cx, cy, rIn, a2, a1, reverse = true)
+        close()
+    }
+    drawPath(path, color)
+}
+
+private fun Path.arcToRad(cx: Float, cy: Float, r: Float, a1: Float, a2: Float, reverse: Boolean = false) {
+    // Approximate the arc with quadratic Bezier segments — Path.arcTo would also work,
+    // but with Compose 1.6+ we use a small chord-step polyline to stay portable.
+    val steps = 16
+    val from = if (reverse) a2 else a1
+    val to   = if (reverse) a1 else a2
+    for (s in 1..steps) {
+        val a = from + (to - from) * (s.toFloat() / steps)
+        lineTo(cx + r * cos(a), cy + r * sin(a))
+    }
+}
+
+internal fun DrawScope.drawHourDial(
+    cx: Float, cy: Float, rOuter: Float, color: Color, mutedColor: Color,
+) {
+    for (h in 0 until 24) {
+        val a = hourToRad(h.toFloat())
+        val major = h % 6 == 0
+        val minor = h % 3 == 0
+        val len = if (major) 8f else if (minor) 5f else 3f
+        val p1 = Offset(cx + rOuter * cos(a), cy + rOuter * sin(a))
+        val p2 = Offset(cx + (rOuter + len) * cos(a), cy + (rOuter + len) * sin(a))
+        drawLine(if (minor) color else mutedColor, p1, p2,
+                 strokeWidth = if (major) 1.5f else 1f)
+    }
+}
+
+internal fun DrawScope.drawSessionArc(
+    cx: Float, cy: Float, r: Float,
+    bedH: Float, wakeH: Float,
+    color: Color, alpha: Float, strokeWidth: Float,
+) {
+    val a1 = hourToRad(bedH)
+    var a2 = hourToRad(wakeH)
+    if (a2 <= a1) a2 += (2 * PI).toFloat()
+    val sweep = a2 - a1
+    drawArc(
+        color = color,
+        startAngle = Math.toDegrees(a1.toDouble()).toFloat(),
+        sweepAngle = Math.toDegrees(sweep.toDouble()).toFloat(),
+        useCenter = false,
+        topLeft = Offset(cx - r, cy - r),
+        size = androidx.compose.ui.geometry.Size(r * 2, r * 2),
+        style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+        alpha = alpha.coerceIn(0f, 1f),
+    )
+}
+
+internal fun hourToRad(h: Float): Float =
+    ((h / 24f) * 2f * PI - PI / 2).toFloat()
+
+private val androidx.compose.ui.unit.IntSize.minDimension: Float
+    get() = kotlin.math.min(width, height).toFloat()

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.md
@@ -1,0 +1,349 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.kt
+git_blob: 7958cc2811e67cf1a3d3e0ef95612604b326add9
+last_synced: '2026-05-26T03:08:52Z'
+loc: 313
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/DriftClock.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.dataviz
+
+import androidx.compose.animation.core.*
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.cos
+import kotlin.math.min
+import kotlin.math.pow
+import kotlin.math.roundToInt
+import kotlin.math.sin
+
+/* ============================================================
+ * DriftClock — a single arc that drifts smoothly around the 24h dial.
+ *
+ * The arc represents the *current* sleep session, with bedHour and
+ * wakeHour interpolated in real time between consecutive sessions
+ * along the shortest angular path. The dial stays clean: no persistent
+ * trail, no past-night overlay.
+ *
+ *   DriftVariant.Pure   — only the arc + tip dots.
+ *   DriftVariant.Comet  — same arc + a 5-night faded comet trail.
+ *
+ * Mirrors  ui_kits/nightfall/dataviz/DriftClock.jsx  1:1.
+ *
+ * Animation spec:
+ *   - Full sweep:    30 000 ms at speed 1× (LinearEasing across the year).
+ *                    Smooth angular interpolation between sessions makes the
+ *                    drift readable even at 4×.
+ *   - Speeds:        0.5× · 1× · 2× · 4×
+ *   - Scrub:         drag the slider → pauses + snaps t.
+ *   - Trail fade:    opacity = 0.55 * (1 − k/(L+1))^1.2  for k = 1..L.
+ * ============================================================ */
+
+enum class DriftVariant { Pure, Comet }
+
+private const val SWEEP_MS_AT_1X = 30_000
+
+@Composable
+fun DriftClock(
+    sessions: List<SleepSession>,
+    modifier: Modifier = Modifier,
+    variant: DriftVariant = DriftVariant.Pure,
+    trailLength: Int = 5,
+    autoPlay: Boolean = true,
+) {
+    if (sessions.isEmpty()) return
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val scope   = rememberCoroutineScope()
+
+    val t = remember { Animatable(0f) }
+    var playing by remember { mutableStateOf(autoPlay) }
+    var speed   by remember { mutableStateOf(1f) }
+
+    LaunchedEffect(playing, speed) {
+        if (!playing) return@LaunchedEffect
+        val totalMs = (SWEEP_MS_AT_1X / speed).roundToInt()
+        while (isActive) {
+            val remainingMs = ((1f - t.value) * totalMs).roundToInt().coerceAtLeast(1)
+            t.animateTo(1f, animationSpec = tween(remainingMs, easing = LinearEasing))
+            t.snapTo(0f)
+        }
+    }
+
+    val N = sessions.size
+    val k     = t.value * (N - 1)
+    val kLow  = k.toInt().coerceIn(0, N - 1)
+    val frac  = k - kLow
+    val kHigh = min(kLow + 1, N - 1)
+    val s0    = sessions[kLow]
+    val s1    = sessions[kHigh]
+    val bedH  = lerpHour(s0.bedHour,  s1.bedHour,  frac)
+    val wakeH = lerpHour(s0.wakeHour, s1.wakeHour, frac)
+    val headDate = if (frac < 0.5f) s0.date else s1.date
+
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(14.dp)) {
+        Box(Modifier.size(360.dp), contentAlignment = Alignment.Center) {
+            // Compute duration once per recomposition.
+            val durHours: Float = run {
+                var d = wakeH - bedH
+                if (d <= 0f) d += 24f
+                d
+            }
+            val durH = durHours.toInt()
+            val durM = ((durHours - durH) * 60f).roundToInt()
+
+            Canvas(Modifier.fillMaxSize()) {
+                val cx = size.width / 2f
+                val cy = size.height / 2f
+                val rOuter = size.minDimension * 0.42f       // hour ticks
+                val ringR  = size.minDimension * 0.36f       // arc radius
+
+                // Background ring — thin, faint
+                drawCircle(extras.border.copy(alpha = 0.45f),
+                           radius = ringR, center = Offset(cx, cy),
+                           style = Stroke(width = 2f))
+
+                // Trail comets (oldest first → freshest paints on top)
+                if (variant == DriftVariant.Comet) {
+                    for (i in trailLength downTo 1) {
+                        val idx = kLow - i
+                        if (idx < 0) continue
+                        val s = sessions[idx]
+                        val frac01 = (1f - (i / (trailLength + 1f))).coerceAtLeast(0f)
+                        val alpha = 0.55f * frac01.pow(1.2f)
+                        drawSessionArc(cx, cy, ringR,
+                            s.bedHour, s.wakeHour,
+                            color = extras.highlight,
+                            alpha = alpha,
+                            strokeWidth = 3f)
+                    }
+                }
+
+                // Head arc — slightly thicker, on top
+                drawSessionArc(cx, cy, ringR, bedH, wakeH,
+                    color = palette.secondary, alpha = 1f, strokeWidth = 4.5f)
+
+                // Bed marker — hollow ring at the start of the arc.
+                val aBed  = hourToRad(bedH)
+                val pBed  = Offset(cx + ringR * cos(aBed), cy + ringR * sin(aBed))
+                drawCircle(Color(0xFF191E22), radius = 6f, center = pBed)
+                drawCircle(palette.secondary, radius = 6f, center = pBed,
+                           style = Stroke(width = 2.5f))
+
+                // Wake marker — filled disc with small hole at the end.
+                val aWake = hourToRad(wakeH)
+                val pWake = Offset(cx + ringR * cos(aWake), cy + ringR * sin(aWake))
+                drawCircle(palette.secondary, radius = 7f, center = pWake)
+                drawCircle(Color(0xFF191E22), radius = 2.5f, center = pWake)
+
+                drawHourDial(cx, cy, rOuter, extras.textFaint, extras.divider)
+            }
+
+            // Big readable duration overlay (Compose Text is more crisp than
+            // canvas drawText for typography). Stacked at center.
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = "DURÉE",
+                    style = MaterialTheme.typography.labelSmall.copy(
+                        letterSpacing = 1.4.sp,
+                    ),
+                    color = extras.textMuted,
+                )
+                Row(verticalAlignment = Alignment.Bottom) {
+                    Text(
+                        text = "$durH",
+                        style = MaterialTheme.typography.displayMedium.copy(fontSize = 38.sp),
+                        color = palette.onBackground,
+                    )
+                    Text(
+                        text = "h",
+                        style = MaterialTheme.typography.headlineSmall.copy(fontSize = 22.sp),
+                        color = palette.onBackground,
+                        modifier = Modifier.padding(start = 2.dp, bottom = 2.dp),
+                    )
+                    Text(
+                        text = " %02d".format(durM),
+                        style = MaterialTheme.typography.displayMedium.copy(fontSize = 38.sp),
+                        color = palette.onBackground,
+                    )
+                }
+                Text(
+                    text = "%s → %s".format(fmtHourClock(bedH), fmtHourClock(wakeH)),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = extras.textFaint,
+                )
+            }
+        }
+
+        DriftScrubber(
+            value = t.value,
+            onScrub = { newT ->
+                playing = false
+                scope.launch { t.snapTo(newT) }
+            },
+            playing = playing,
+            onPlayToggle = { playing = !playing },
+            speed = speed,
+            onSpeedChange = { speed = it },
+            dateLabel = headDate,
+            positionLabel = "${kLow + 1} / $N",
+        )
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Shortest-angular-path hour interpolation.
+// ──────────────────────────────────────────────────────────────
+private fun lerpHour(a: Float, b: Float, t: Float): Float {
+    var d = b - a
+    if (d >  12f) d -= 24f
+    if (d < -12f) d += 24f
+    return ((a + d * t) % 24f + 24f) % 24f
+}
+
+/** HH:MM 24-hour format for decimal hours. */
+private fun fmtHourClock(h: Float): String {
+    val hr = h.toInt() % 24
+    val mn = ((h - h.toInt()) * 60f).roundToInt()
+    return "%02d:%02d".format(hr, mn)
+}
+
+// `extras.bg` doesn't exist on the contract — fallback to the dark canvas.
+// Kept here for any future code in this file that needs the encre background.
+@Suppress("unused")
+private val fr.datasaillance.nightfall.ui.theme.ExtraColors.bg: Color
+    get() = Color(0xFF191E22)
+
+// ──────────────────────────────────────────────────────────────
+// Scrubber
+// ──────────────────────────────────────────────────────────────
+@Composable
+private fun DriftScrubber(
+    value: Float,
+    onScrub: (Float) -> Unit,
+    playing: Boolean,
+    onPlayToggle: () -> Unit,
+    speed: Float,
+    onSpeedChange: (Float) -> Unit,
+    dateLabel: String,
+    positionLabel: String,
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val interactionSource = remember { MutableInteractionSource() }
+    Row(verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        Box(
+            Modifier
+                .size(34.dp)
+                .clip(CircleShape)
+                .background(palette.secondary)
+                .clickable(interactionSource = interactionSource, indication = null) { onPlayToggle() },
+            contentAlignment = Alignment.Center,
+        ) {
+            Canvas(Modifier.size(12.dp)) {
+                val w = size.width; val h = size.height
+                if (playing) {
+                    drawRect(palette.onSecondary, Offset(w * 0.16f, 0f), Size(w * 0.22f, h))
+                    drawRect(palette.onSecondary, Offset(w * 0.62f, 0f), Size(w * 0.22f, h))
+                } else {
+                    val tri = Path().apply {
+                        moveTo(w * 0.20f, 0f)
+                        lineTo(w * 0.92f, h * 0.50f)
+                        lineTo(w * 0.20f, h)
+                        close()
+                    }
+                    drawPath(tri, palette.onSecondary)
+                }
+            }
+        }
+        Slider(
+            value = value,
+            onValueChange = onScrub,
+            modifier = Modifier.weight(1f),
+            valueRange = 0f..1f,
+            colors = SliderDefaults.colors(
+                thumbColor = palette.secondary,
+                activeTrackColor = palette.secondary,
+                inactiveTrackColor = extras.border,
+            ),
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(2.dp)) {
+            listOf(0.5f, 1f, 2f, 4f).forEach { sp ->
+                val active = sp == speed
+                TextButton(
+                    onClick = { onSpeedChange(sp) },
+                    contentPadding = PaddingValues(horizontal = 6.dp, vertical = 4.dp),
+                ) {
+                    Text(
+                        text = if (sp == sp.toInt().toFloat()) "${sp.toInt()}×" else "${sp}×",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (active) palette.onSurface else extras.textMuted,
+                    )
+                }
+            }
+        }
+    }
+    Row(modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(dateLabel,     style = MaterialTheme.typography.labelSmall, color = extras.textFaint)
+        Text(positionLabel, style = MaterialTheme.typography.labelSmall, color = extras.textFaint)
+    }
+}
+
+private fun Float.pow(x: Float): Float =
+    if (this <= 0f) 0f else kotlin.math.exp(kotlin.math.ln(this.toDouble()) * x.toDouble()).toFloat()
+
+private val androidx.compose.ui.unit.IntSize.minDimension: Float
+    get() = min(width, height).toFloat()
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `DriftVariant` (class) — lines 54-54
+- `DriftClock` (function) — lines 58-207
+- `lerpHour` (function) — lines 212-217
+- `fmtHourClock` (function) — lines 220-224
+- `DriftScrubber` (function) — lines 235-307
+- `pow` (function) — lines 309-310

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.md
@@ -1,0 +1,274 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.kt
+git_blob: 6b84f8b68bbd25808b0899c6be924df7d5b688a2
+last_synced: '2026-05-26T03:08:52Z'
+loc: 232
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/Heatmap.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.dataviz
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.unit.dp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.pow
+import kotlin.math.sin
+
+/* ============================================================
+ * Heatmap — polar heatmap of sleep on the 24h dial.
+ *
+ *   HeatmapVariant.Ring  — 144 wedges (10-min bins), colored by total minutes.
+ *   HeatmapVariant.Rose  — same bins, encoded as radial bar lengths.
+ *
+ * Mirrors  ui_kits/nightfall/dataviz/Heatmap.jsx  1:1.
+ * Sequential color ramp from surface-3 to highlight cyan, gamma-corrected.
+ * ============================================================ */
+
+data class SleepSession(
+    val date: String,       // YYYY-MM-DD
+    val bedHour: Float,     // 0..24 decimal, local
+    val wakeHour: Float,    // 0..24 decimal, local
+    val durationMin: Int,
+    val isMain: Boolean,
+    val unixMs: Long,
+)
+
+enum class HeatmapVariant { Ring, Rose }
+
+private const val BIN_COUNT = 144                  // 10-min bins
+private const val BIN_WIDTH_H = 24f / BIN_COUNT    // 0.1666… h
+
+@Composable
+fun Heatmap(
+    sessions: List<SleepSession>,
+    modifier: Modifier = Modifier,
+    variant: HeatmapVariant = HeatmapVariant.Ring,
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+
+    val bins = remember(sessions) { computeBins(sessions) }
+    val peak = remember(bins)     { bins.maxOrNull() ?: 0f }
+
+    // Color ramp anchors. `surface3` for empty, `highlight` for peak.
+    val emptyColor = extras.borderStrong.copy(alpha = 0.0f)     // overlay only on filled bins
+    val baseColor  = Color(0xFF1E262B)
+    val peakColor  = extras.highlight
+
+    Box(modifier = modifier.size(360.dp), contentAlignment = Alignment.Center) {
+        Canvas(Modifier.fillMaxSize()) {
+            val cx = size.width / 2f
+            val cy = size.height / 2f
+            val rOuter = size.minDimension * 0.42f
+            val rInner = size.minDimension * 0.16f
+
+            when (variant) {
+                HeatmapVariant.Ring -> drawRing(cx, cy, rOuter, rInner, bins, peak, baseColor, peakColor)
+                HeatmapVariant.Rose -> drawRose(cx, cy, rOuter, rInner, bins, peak, peakColor, extras.divider)
+            }
+            drawHourDial(cx, cy, rOuter, extras.textFaint, extras.divider)
+            // Outer and inner outlines
+            drawCircle(palette.outline, radius = rOuter + 2f, center = Offset(cx, cy),
+                       style = Stroke(width = 1f))
+            drawCircle(palette.outline, radius = rInner - 2f, center = Offset(cx, cy),
+                       style = Stroke(width = 1f))
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variation A — Ring of 144 wedges
+// ──────────────────────────────────────────────────────────────
+private fun DrawScope.drawRing(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float,
+    bins: FloatArray, peak: Float,
+    baseColor: Color, peakColor: Color,
+) {
+    for (i in 0 until BIN_COUNT) {
+        val h1 = i * BIN_WIDTH_H
+        val h2 = (i + 1) * BIN_WIDTH_H
+        val v  = if (peak > 0f) bins[i] / peak else 0f
+        val color = if (bins[i] == 0f) baseColor else heatColor(v, baseColor, peakColor)
+        drawWedge(cx, cy, rOuter, rInner, h1, h2, color)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Variation B — Rose plot (radial bar lengths)
+// ──────────────────────────────────────────────────────────────
+private fun DrawScope.drawRose(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float,
+    bins: FloatArray, peak: Float,
+    peakColor: Color, divider: Color,
+) {
+    val maxLen = rOuter - rInner
+    // 4 reference rings (25/50/75/100 %)
+    val dash = PathEffect.dashPathEffect(floatArrayOf(2f, 3f), 0f)
+    listOf(0.25f, 0.5f, 0.75f, 1f).forEach { f ->
+        drawCircle(divider, radius = rInner + f * maxLen, center = Offset(cx, cy),
+                   style = Stroke(width = 0.6f, pathEffect = dash))
+    }
+    for (i in 0 until BIN_COUNT) {
+        if (bins[i] == 0f) continue
+        val v   = if (peak > 0f) bins[i] / peak else 0f
+        val len = v.pow(0.65f) * maxLen
+        val h1  = i * BIN_WIDTH_H
+        val h2  = (i + 1) * BIN_WIDTH_H
+        val color = heatColor(v, Color(0xFF2A363B), peakColor)
+        drawWedge(cx, cy, rInner + len, rInner, h1, h2, color)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Color ramp — gamma-corrected lerp from base to peak.
+// ──────────────────────────────────────────────────────────────
+private fun heatColor(t: Float, base: Color, peak: Color): Color {
+    val tt = t.coerceIn(0f, 1f).pow(0.55f)
+    return lerp(base, peak, tt)
+}
+
+// ──────────────────────────────────────────────────────────────
+// Bin computation — minutes slept per 10-min slot, with edge overlap.
+// ──────────────────────────────────────────────────────────────
+private fun computeBins(sessions: List<SleepSession>): FloatArray {
+    val bins = FloatArray(BIN_COUNT)
+    for (s in sessions) {
+        var bed = s.bedHour
+        var wake = s.wakeHour
+        if (wake <= bed) wake += 24f
+        val startBin = (bed / BIN_WIDTH_H).toInt()
+        val endBin   = ((wake - 1e-6f) / BIN_WIDTH_H).toInt()
+        for (i in startBin..endBin) {
+            val a = i * BIN_WIDTH_H
+            val b = a + BIN_WIDTH_H
+            val ovStart = max(bed, a)
+            val ovEnd   = kotlin.math.min(wake, b)
+            if (ovEnd > ovStart) bins[((i % BIN_COUNT) + BIN_COUNT) % BIN_COUNT] += (ovEnd - ovStart) * 60f
+        }
+    }
+    return bins
+}
+
+// ──────────────────────────────────────────────────────────────
+// Polar drawing primitives — also used by DriftClock.kt
+// ──────────────────────────────────────────────────────────────
+internal fun DrawScope.drawWedge(
+    cx: Float, cy: Float, rOut: Float, rIn: Float,
+    h1: Float, h2: Float, color: Color,
+) {
+    val a1 = hourToRad(h1)
+    var a2 = hourToRad(h2)
+    if (a2 <= a1) a2 += (2 * PI).toFloat()
+    val path = Path().apply {
+        moveTo(cx + rOut * cos(a1), cy + rOut * sin(a1))
+        arcToRad(cx, cy, rOut, a1, a2)
+        lineTo(cx + rIn * cos(a2), cy + rIn * sin(a2))
+        arcToRad(cx, cy, rIn, a2, a1, reverse = true)
+        close()
+    }
+    drawPath(path, color)
+}
+
+private fun Path.arcToRad(cx: Float, cy: Float, r: Float, a1: Float, a2: Float, reverse: Boolean = false) {
+    // Approximate the arc with quadratic Bezier segments — Path.arcTo would also work,
+    // but with Compose 1.6+ we use a small chord-step polyline to stay portable.
+    val steps = 16
+    val from = if (reverse) a2 else a1
+    val to   = if (reverse) a1 else a2
+    for (s in 1..steps) {
+        val a = from + (to - from) * (s.toFloat() / steps)
+        lineTo(cx + r * cos(a), cy + r * sin(a))
+    }
+}
+
+internal fun DrawScope.drawHourDial(
+    cx: Float, cy: Float, rOuter: Float, color: Color, mutedColor: Color,
+) {
+    for (h in 0 until 24) {
+        val a = hourToRad(h.toFloat())
+        val major = h % 6 == 0
+        val minor = h % 3 == 0
+        val len = if (major) 8f else if (minor) 5f else 3f
+        val p1 = Offset(cx + rOuter * cos(a), cy + rOuter * sin(a))
+        val p2 = Offset(cx + (rOuter + len) * cos(a), cy + (rOuter + len) * sin(a))
+        drawLine(if (minor) color else mutedColor, p1, p2,
+                 strokeWidth = if (major) 1.5f else 1f)
+    }
+}
+
+internal fun DrawScope.drawSessionArc(
+    cx: Float, cy: Float, r: Float,
+    bedH: Float, wakeH: Float,
+    color: Color, alpha: Float, strokeWidth: Float,
+) {
+    val a1 = hourToRad(bedH)
+    var a2 = hourToRad(wakeH)
+    if (a2 <= a1) a2 += (2 * PI).toFloat()
+    val sweep = a2 - a1
+    drawArc(
+        color = color,
+        startAngle = Math.toDegrees(a1.toDouble()).toFloat(),
+        sweepAngle = Math.toDegrees(sweep.toDouble()).toFloat(),
+        useCenter = false,
+        topLeft = Offset(cx - r, cy - r),
+        size = androidx.compose.ui.geometry.Size(r * 2, r * 2),
+        style = Stroke(width = strokeWidth, cap = StrokeCap.Round),
+        alpha = alpha.coerceIn(0f, 1f),
+    )
+}
+
+internal fun hourToRad(h: Float): Float =
+    ((h / 24f) * 2f * PI - PI / 2).toFloat()
+
+private val androidx.compose.ui.unit.IntSize.minDimension: Float
+    get() = kotlin.math.min(width, height).toFloat()
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepSession` (class) — lines 35-42
+- `HeatmapVariant` (class) — lines 44-44
+- `Heatmap` (function) — lines 49-85
+- `drawRing` (function) — lines 90-102
+- `drawRose` (function) — lines 107-128
+- `heatColor` (function) — lines 133-136
+- `computeBins` (function) — lines 141-158
+- `drawWedge` (function) — lines 163-178
+- `arcToRad` (function) — lines 180-190
+- `drawHourDial` (function) — lines 192-205
+- `drawSessionArc` (function) — lines 207-226
+- `hourToRad` (function) — lines 228-229


### PR DESCRIPTION
## Summary

Phase 3 du plan de migration design. Copie les 2 composants dataviz standalone du **kit v3** dans `android-app/.../nightfall/dataviz/`. Ils ne sont pas encore wires dans aucun ecran — c'est le job de la Phase 4.

## Drop-ins ajoutes

| Fichier | Variants | Description |
|---|---|---|
| `Heatmap.kt` | `Ring`, `Rose` | Repartition du sommeil sur 24h, 144 bins de 10 min, color = gamma-corrected lerp surface-1 -> extras.highlight (cyan). Inclut `data class SleepSession(date, bedHour, wakeHour, durationMin, isMain, unixMs)` partagee avec DriftClock |
| `DriftClock.kt` | `Pure`, `Comet` | Arc fin sur cercle, marqueurs Bed/Wake, animation drift entre sessions consecutives. Comet = trail fade. Speed picker 0.5x/1x/2x/4x, scrub via slider |

Les deux composants sont **purs** (pas de ViewModel, pas de nav). Ils prennent `List<SleepSession>` en input et nothing else. A wirer plus tard depuis un ViewModel qui mappe `SleepSessionResponse` / `SleepSessionEntity` -> `SleepSession` (DTO viz light).

## Pourquoi cette PR isolee

Le kit v3 livre plusieurs drop-ins dans `android/dataviz/`. Phase 3 prend uniquement les **standalone reutilisables**. Phase 4 prendra les composants assembles (MultiDonutClock, RadialClockScreen, StackedWeeks, Narrative, UsageHeatmap) qui constituent un nouveau ecran complet.

Decoupage volontaire pour :
- Granularite de review (composants atomiques avant assemblages)
- Tests Paparazzi possibles sur chaque viz isolement
- Pas de nouveau ViewModel / nav / data class metier dans cette PR

## Compatibilite

- Compilent OK (build native debug verifie)
- Aucun call site existant impacte (composants nouveaux, pas de remplacement)
- `SleepSession` data class fournie par Heatmap.kt — pas de conflit avec `data.sleep.SleepSessionResponse` (package different)

## Test plan

- [x] Build native debug OK
- [ ] Preview Compose (necessite Paparazzi snapshot) — a ajouter en suite si utile
- [ ] Wire-up dans un ecran demo en Phase 4

## Reference

- Kit v3 : `DataSaillance — Design System.zip` (2.4 MB, 26/05)
- README drop-ins : `android/dataviz/README.md` dans le kit