### PR TITLE
feat(design): phase 4adef - MultiDonutClock radial + ViewModel + onglet Cadran

### DIFF
--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt
@@ -2,7 +2,7 @@ package fr.datasaillance.nightfall.ui.navigation
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.DonutLarge
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.ShowChart
@@ -17,7 +17,7 @@ private fun iconForDestination(destination: NavDestination): ImageVector = when 
     is NavDestination.Sleep     -> Icons.Default.Home
     is NavDestination.Timeline  -> Icons.Default.ShowChart
     is NavDestination.Wellbeing -> Icons.Default.PhoneAndroid
-    is NavDestination.Activity  -> Icons.Default.FitnessCenter
+    is NavDestination.Activity  -> Icons.Default.DonutLarge  // route 'activity' = Cadran radial
     is NavDestination.Profile   -> Icons.Default.AccountCircle
     else                        -> Icons.Default.Home
 }

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
@@ -9,7 +9,9 @@ sealed class NavDestination(
     object ForgotPassword : NavDestination("forgot_password", "Mot de passe oublié")
     object Sleep    : NavDestination("sleep",    "Sommeil")
     object Timeline : NavDestination("timeline", "Timeline")
-    object Activity : NavDestination("activity", "Activité")
+    // 'activity' route conservée pour rétro-compat tests, mais le label affiché
+    // est désormais 'Cadran' — radial clock = évolution moderne de l'écran Activité.
+    object Activity : NavDestination("activity", "Cadran")
     object Wellbeing : NavDestination("wellbeing", "Bien-être")
     object Profile  : NavDestination("profile",  "Profil")
     object Import   : NavDestination("import",   "Importer")

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
@@ -36,6 +36,7 @@ import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
+import fr.datasaillance.nightfall.ui.screens.radial.RadialRoute
 import fr.datasaillance.nightfall.ui.screens.wellbeing.DigitalWellbeingScreen
 import fr.datasaillance.nightfall.viewmodel.wellbeing.DigitalWellbeingViewModel
 import fr.datasaillance.nightfall.data.local.usage.UsageStatsPermissionHelper
@@ -195,7 +196,10 @@ fun NavGraph(
                     },
                 )
             }
-            composable(NavDestination.Activity.route) { ActivityScreen() }
+            // Route 'activity' rendered as the new MultiDonutClock radial view
+            // (phase 4a) — l'ancien ActivityScreen placeholder reste compilé pour
+            // les flavors qui n'ont pas Compose Canvas natif.
+            composable(NavDestination.Activity.route) { RadialRoute() }
             composable(NavDestination.Wellbeing.route) {
                 val db = remember(context) {
                     fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)

--- a/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.kt
+++ b/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.kt
@@ -1,0 +1,162 @@
+package fr.datasaillance.nightfall.viewmodel.radial
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.dao.UsageStatsDao
+import fr.datasaillance.nightfall.dataviz.radial.RadialActivity
+import fr.datasaillance.nightfall.dataviz.radial.RadialDay
+import fr.datasaillance.nightfall.dataviz.radial.RadialUsageRow
+import fr.datasaillance.nightfall.dataviz.radial.RadialVisit
+import fr.datasaillance.nightfall.dataviz.radial.SleepStage
+import fr.datasaillance.nightfall.dataviz.radial.StageInterval
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Agrège sleep + visits + activities + usage par jour pour le `MultiDonutClock`.
+ *
+ * Charge la fenêtre [today - windowDays + 1, today] et expose un `Map<LocalDate, RadialDay>`.
+ * Chaque RadialDay agrège les 4 sources de données dans le fuseau local.
+ *
+ * Le radial clock fait le rendu — ce ViewModel fait juste la transformation
+ * Room entities → DTO viz light (`SleepStage` enum, `RadialVisit/Activity/UsageRow`).
+ */
+data class RadialUiState(
+    val days: Map<LocalDate, RadialDay> = emptyMap(),
+    val initialDate: LocalDate = LocalDate.now(),
+    val typicalUsageHourDist: FloatArray? = null,
+    val isLoading: Boolean = true,
+)
+
+class RadialClockViewModel(
+    private val sleepDao: SleepDao,
+    private val locationDao: LocationDao,
+    private val usageStatsDao: UsageStatsDao,
+    private val windowDays: Int = 30,
+    private val zone: ZoneId = ZoneId.systemDefault(),
+    private val clock: () -> LocalDate = { LocalDate.now() },
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RadialUiState())
+    val uiState: StateFlow<RadialUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun reload() = load()
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true)
+            runCatching { buildDaysMap() }
+                .onSuccess { days ->
+                    val today = clock()
+                    _uiState.value = RadialUiState(
+                        days = days,
+                        initialDate = today,
+                        typicalUsageHourDist = computeTypicalHourDist(days),
+                        isLoading = false,
+                    )
+                }
+                .onFailure { e ->
+                    Timber.w("scope=radial_vm load_failed error=${e::class.simpleName} msg=${e.message}")
+                    _uiState.value = _uiState.value.copy(isLoading = false)
+                }
+        }
+    }
+
+    private suspend fun buildDaysMap(): Map<LocalDate, RadialDay> {
+        val today = clock()
+        val from = today.minusDays((windowDays - 1).toLong())
+        val fromMs = from.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMs = today.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+
+        // --- Sleep stages — group par session puis aplati ---
+        val sessions = runCatching { sleepDao.getSessionsInRange(fromMs, toMs) }.getOrDefault(emptyList())
+        val allStages = if (sessions.isEmpty()) emptyList()
+            else runCatching { sleepDao.getStagesForSessions(sessions.map { it.id }) }.getOrDefault(emptyList())
+
+        // Map stage entity → StageInterval DTO viz, group par date (du sleep_start de la session)
+        val sessionIdToDate: Map<Long, LocalDate> = sessions.associate { s ->
+            s.id to java.time.Instant.ofEpochMilli(s.sleepStartMs).atZone(zone).toLocalDate()
+        }
+        val stagesByDay: MutableMap<LocalDate, MutableList<StageInterval>> = HashMap()
+        allStages.forEach { stage ->
+            val day = sessionIdToDate[stage.sessionId] ?: return@forEach
+            val type = stageEnum(stage.stageType) ?: return@forEach
+            stagesByDay.getOrPut(day) { mutableListOf() }.add(
+                StageInterval(type = type, startMs = stage.stageStartMs, endMs = stage.stageEndMs)
+            )
+        }
+
+        // --- Location ---
+        val allVisits = runCatching { locationDao.getVisitsInRange(fromMs, toMs) }.getOrDefault(emptyList())
+        val allSegments = runCatching { locationDao.getSegmentsInRange(fromMs, toMs) }.getOrDefault(emptyList())
+
+        // --- Usage ---
+        val allUsage = runCatching {
+            usageStatsDao.getInRange(from.toString(), today.toString())
+        }.getOrDefault(emptyList())
+
+        val result = HashMap<LocalDate, RadialDay>()
+        for (offset in 0 until windowDays) {
+            val date = today.minusDays(offset.toLong())
+            val dayStart = date.atStartOfDay(zone).toInstant().toEpochMilli()
+            val dayEnd = date.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+            val dateStr = date.toString()
+
+            result[date] = RadialDay(
+                date = date,
+                sleepStages = stagesByDay[date]?.sortedBy { it.startMs }?.toList().orEmpty(),
+                visits = allVisits
+                    .filter { it.startMs < dayEnd && it.endMs > dayStart }
+                    .map { RadialVisit(it.startMs, it.endMs, it.placeName ?: it.address ?: "—") },
+                activities = allSegments
+                    .filter { it.startMs < dayEnd && it.endMs > dayStart }
+                    .map { RadialActivity(it.startMs, it.endMs, it.activityType, it.distanceMeters ?: 0) },
+                usageRows = allUsage
+                    .filter { it.date == dateStr }
+                    .map { RadialUsageRow(it.packageName, it.totalTimeForegroundMs, it.lastTimeUsedMs) },
+            )
+        }
+        return result
+    }
+
+    /**
+     * Distribution horaire typique d'usage sur la fenêtre — 24 buckets normalisés
+     * à somme = 1 (fraction du temps total). Sert de fallback Heat ring quand un
+     * jour précis n'a pas de donnée d'usage.
+     */
+    private fun computeTypicalHourDist(days: Map<LocalDate, RadialDay>): FloatArray? {
+        val buckets = FloatArray(24)
+        var total = 0L
+        days.values.forEach { d ->
+            d.usageRows.forEach { row ->
+                if (row.lastTimeUsedMs <= 0L) return@forEach
+                val hour = java.time.Instant.ofEpochMilli(row.lastTimeUsedMs)
+                    .atZone(zone).toLocalTime().hour.coerceIn(0, 23)
+                buckets[hour] += row.totalTimeForegroundMs.toFloat()
+                total += row.totalTimeForegroundMs
+            }
+        }
+        if (total <= 0L) return null
+        for (i in buckets.indices) buckets[i] = buckets[i] / total.toFloat()
+        return buckets
+    }
+
+    private fun stageEnum(type: String): SleepStage? = when (type) {
+        "AWAKE" -> SleepStage.AWAKE
+        "REM" -> SleepStage.REM
+        "LIGHT" -> SleepStage.LIGHT
+        "DEEP" -> SleepStage.DEEP
+        else -> null
+    }
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.kt
@@ -1,0 +1,546 @@
+package fr.datasaillance.nightfall.dataviz.radial
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/* ============================================================
+ * MultiDonutClock — Compose port of dataviz/MultiDonutClock.jsx.
+ *
+ * Three concentric donuts on a 24-hour dial:
+ *   • Outer   — sleep stages, with each wedge's inner radius set by
+ *               stage depth (AWAKE at the rim, DEEP at the inner edge).
+ *   • Middle  — phone usage, two interchangeable variants:
+ *               UsageVariant.Heat — 24 hour-wedges colored by app-close
+ *                                   density for the selected day (or by
+ *                                   the supplied typical-day fallback).
+ *               UsageVariant.Apps — top apps as concentric sub-rings,
+ *                                   each showing today's foreground share
+ *                                   and last-use time.
+ *   • Inner   — timeline. Place visits as wedges, activity segments
+ *               drawn within the inner half of the same band.
+ *
+ * Tap inside the donut → fires onQuadrantTap(0..3) where the quadrant
+ * is the 6-hour block under the touch.
+ *
+ * The composable is "pure paint" — pass a `RadialDay` (immutable),
+ * a variant, and (optionally) the typical-day usage distribution.
+ *
+ * Drop into:
+ *   android-app/app/src/main/java/fr/datasaillance/nightfall/dataviz/radial/
+ *
+ * Depends on the existing DataSaillanceTheme. Extra brand tokens used:
+ *   colorScheme.background  / secondary
+ *   extras.highlight  / divider / textMuted / textFaint / borderStrong
+ *   extras.stageAwake / stageRem / stageLight / stageDeep
+ * ============================================================ */
+
+// ─────────────────────────────────────────────────────────────
+// Data model
+// ─────────────────────────────────────────────────────────────
+enum class SleepStage { AWAKE, REM, LIGHT, DEEP }
+
+data class StageInterval(val type: SleepStage, val startMs: Long, val endMs: Long)
+data class RadialVisit(val startMs: Long, val endMs: Long, val placeName: String)
+data class RadialActivity(val startMs: Long, val endMs: Long, val activityType: String, val distanceMeters: Int)
+data class RadialUsageRow(val packageName: String, val totalTimeForegroundMs: Long, val lastTimeUsedMs: Long)
+
+data class RadialDay(
+    val date: LocalDate,
+    val sleepStages: List<StageInterval> = emptyList(),
+    val visits: List<RadialVisit> = emptyList(),
+    val activities: List<RadialActivity> = emptyList(),
+    val usageRows: List<RadialUsageRow> = emptyList(),
+)
+
+enum class UsageVariant { Heat, Apps }
+
+// ─────────────────────────────────────────────────────────────
+// Brand-aware activity color resolver
+// ─────────────────────────────────────────────────────────────
+internal object Activity {
+    val WALKING               = Color(0xFF6FB58A) to "marche"
+    val RUNNING               = Color(0xFFA8C8A8) to "course"
+    val CYCLING               = Color(0xFFE4C99A) to "vélo"
+    val IN_PASSENGER_VEHICLE  = Color(0xFFE07260) to "voiture"
+    val IN_BUS                = Color(0xFFC5B6D6) to "bus"
+    val IN_SUBWAY             = Color(0xFFB7D4DE) to "métro"
+    val FLYING                = Color(0xFF3BE5E7) to "avion"
+    val FALLBACK              = Color(0xFF828587) to "autre"
+    fun resolve(type: String): Pair<Color, String> = when (type) {
+        "WALKING" -> WALKING; "RUNNING" -> RUNNING; "CYCLING" -> CYCLING
+        "IN_PASSENGER_VEHICLE" -> IN_PASSENGER_VEHICLE
+        "IN_BUS" -> IN_BUS; "IN_SUBWAY" -> IN_SUBWAY; "FLYING" -> FLYING
+        else -> FALLBACK
+    }
+}
+
+internal fun placeColor(name: String): Color = when {
+    name.startsWith("Maison")  -> Color(0xFFD37C04)
+    name.startsWith("Travail") -> Color(0xFF0E9EB0)
+    else                       -> Color(0xFF7A9AAA)
+}
+
+// Sequential gamma-corrected color ramp (surface3 → cyan).
+internal fun heatColor(t: Float): Color =
+    lerp(Color(0xFF2A363B), Color(0xFF3BE5E7), t.coerceIn(0f, 1f).pow(0.55f))
+
+// Stage → depth (0 = thinnest, 1 = deepest into the dial).
+internal val stageDepth = mapOf(
+    SleepStage.AWAKE to 0.0f,
+    SleepStage.REM   to 0.32f,
+    SleepStage.LIGHT to 0.66f,
+    SleepStage.DEEP  to 1.0f,
+)
+
+internal fun stageColor(stage: SleepStage, extras: fr.datasaillance.nightfall.ui.theme.ExtraColors): Color =
+    when (stage) {
+        SleepStage.AWAKE -> extras.stageAwake
+        SleepStage.REM   -> extras.stageRem
+        SleepStage.LIGHT -> extras.stageLight
+        SleepStage.DEEP  -> extras.stageDeep
+    }
+
+// ─────────────────────────────────────────────────────────────
+// Public composable
+// ─────────────────────────────────────────────────────────────
+@Composable
+fun MultiDonutClock(
+    day: RadialDay,
+    modifier: Modifier = Modifier,
+    usageVariant: UsageVariant = UsageVariant.Heat,
+    typicalUsageHourDist: FloatArray? = null,
+    selectedQuadrant: Int? = null,
+    onQuadrantTap: (Int) -> Unit = {},
+    zone: ZoneId = ZoneId.systemDefault(),
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val density = LocalDensity.current
+
+    // Precompute per-hour usage minutes for the heat variant.
+    val hourBuckets: FloatArray = remember(day, typicalUsageHourDist) {
+        val out = FloatArray(24)
+        if (day.usageRows.isNotEmpty()) {
+            day.usageRows.forEach { r ->
+                val h = Instant.ofEpochMilli(r.lastTimeUsedMs).atZone(zone).hour
+                out[h] += r.totalTimeForegroundMs.toFloat()
+            }
+        } else if (typicalUsageHourDist != null) {
+            typicalUsageHourDist.forEachIndexed { i, v -> out[i] = v }
+        }
+        out
+    }
+
+    // Top apps by foreground time (used by the Apps variant).
+    val topApps: List<RadialUsageRow> = remember(day) {
+        day.usageRows.sortedByDescending { it.totalTimeForegroundMs }.take(6)
+    }
+
+    BoxWithConstraints(
+        modifier = modifier.aspectRatio(1f),
+        contentAlignment = Alignment.Center,
+    ) {
+        val sizePx = with(density) { minOf(maxWidth, maxHeight).toPx() }
+        val cx = sizePx / 2f
+        val cy = sizePx / 2f
+        // Radii (fractions of the canvas size)
+        val rHourTicks      = sizePx * 0.470f
+        val rSleepOuter     = sizePx * 0.460f
+        val rSleepDeepInner = sizePx * 0.330f
+        val rUsageOuter     = sizePx * 0.310f
+        val rUsageInner     = sizePx * 0.225f
+        val rTimelineOuter  = sizePx * 0.205f
+        val rTimelineInner  = sizePx * 0.135f
+        val rCenter         = sizePx * 0.130f
+
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures { offset ->
+                        val q = hitTestQuadrant(offset, cx, cy,
+                            rInner = rTimelineInner, rOuter = rSleepOuter + 25f)
+                        if (q != null) onQuadrantTap(q)
+                    }
+                },
+        ) {
+            // 1. Selected-quadrant highlight (behind everything)
+            selectedQuadrant?.let { q ->
+                val color = palette.secondary.copy(alpha = 0.10f)
+                drawDonutWedge(cx, cy, rSleepOuter + 25f, rTimelineInner,
+                    h1 = q * 6f, h2 = q * 6f + 6f, color = color)
+            }
+
+            // 2. Sleep donut
+            drawSleepDonut(day.sleepStages, cx, cy,
+                rOuter = rSleepOuter, rInner = rSleepDeepInner, zone, extras)
+
+            // 3. Usage donut
+            when (usageVariant) {
+                UsageVariant.Heat -> drawUsageHeat(hourBuckets, cx, cy,
+                    rOuter = rUsageOuter, rInner = rUsageInner, palette.background)
+                UsageVariant.Apps -> drawUsageApps(topApps, cx, cy,
+                    rOuter = rUsageOuter, rInner = rUsageInner, zone)
+            }
+
+            // 4. Timeline donut
+            drawTimelineDonut(day.visits, day.activities,
+                cx, cy, rTimelineOuter, rTimelineInner, zone, extras.divider)
+
+            // 5. Quadrant separator hairlines
+            listOf(0f, 6f, 12f, 18f).forEach { h ->
+                val a = hourToRad(h)
+                val p1 = polar(cx, cy, rTimelineInner, a)
+                val p2 = polar(cx, cy, rSleepOuter, a)
+                drawLine(extras.divider, p1, p2, strokeWidth = 1f)
+            }
+
+            // 6. Hour ticks
+            drawHourTicks(cx, cy, rHourTicks, extras.textMuted, extras.textFaint)
+
+            // 7. Center hub
+            drawCircle(palette.background, radius = rCenter, center = Offset(cx, cy))
+            drawCircle(extras.divider, radius = rCenter, center = Offset(cx, cy),
+                       style = Stroke(width = 1f))
+        }
+
+        // Overlay text labels (Compose Text for crisp typography)
+        HourLabels(cx, cy, rHourTicks + 30f, density)
+        CenterLabel(day, cx, cy, density)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sleep donut — stage wedges with variable inner radius
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawSleepDonut(
+    stages: List<StageInterval>,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    zone: ZoneId,
+    extras: fr.datasaillance.nightfall.ui.theme.ExtraColors,
+) {
+    if (stages.isEmpty()) {
+        drawEmptyBand(cx, cy, rOuter, rInner, extras.divider)
+        return
+    }
+
+    val range = rOuter - rInner
+    // Background hint band so the donut shape is always visible
+    drawCircle(extras.divider.copy(alpha = 0.5f), radius = (rOuter + rInner) / 2f,
+               center = Offset(cx, cy), style = Stroke(width = range))
+
+    // Merge consecutive identical-stage intervals for cleaner wedges
+    val merged = mutableListOf<StageInterval>()
+    for (st in stages) {
+        val last = merged.lastOrNull()
+        if (last != null && last.type == st.type && (st.startMs - last.endMs) < 1000L) {
+            merged[merged.lastIndex] = last.copy(endMs = st.endMs)
+        } else {
+            merged += st
+        }
+    }
+    for (st in merged) {
+        val depth = stageDepth[st.type] ?: 0f
+        val rIn = rOuter - depth * range
+        val h1 = localHour(st.startMs, zone)
+        val h2 = localHour(st.endMs, zone)
+        drawDonutWedge(cx, cy, rOuter, rIn, h1, h2, stageColor(st.type, extras).copy(alpha = 0.92f))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Usage donut — heatmap variant (24 hour-wedges)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawUsageHeat(
+    buckets: FloatArray,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    bgColor: Color,
+) {
+    val peak = (buckets.maxOrNull() ?: 0f).coerceAtLeast(1f)
+    for (h in 0 until 24) {
+        val v = buckets[h]
+        val color = if (v == 0f) Color(0xFF1E262B) else heatColor(v / peak)
+        drawDonutWedge(cx, cy, rOuter, rInner, h.toFloat(), h + 1f, color)
+    }
+    // Hairline separators between hour wedges
+    for (h in 0 until 24) {
+        val a = hourToRad(h.toFloat())
+        val p1 = polar(cx, cy, rInner, a)
+        val p2 = polar(cx, cy, rOuter, a)
+        drawLine(bgColor.copy(alpha = 0.7f), p1, p2, strokeWidth = 1f)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Usage donut — apps variant (concentric sub-rings per app)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawUsageApps(
+    apps: List<RadialUsageRow>,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    zone: ZoneId,
+) {
+    if (apps.isEmpty()) {
+        drawEmptyBand(cx, cy, rOuter, rInner, Color(0xFF2E3D44))
+        return
+    }
+    val bandH = (rOuter - rInner) / apps.size
+    val peakMs = apps.maxOf { it.totalTimeForegroundMs }.toFloat()
+
+    apps.forEachIndexed { i, app ->
+        val rOut = rOuter - i * bandH
+        val rIn  = rOut - bandH * 0.85f
+        val h = localHour(app.lastTimeUsedMs, zone)
+        val widthH = 0.4f + (app.totalTimeForegroundMs / peakMs) * 1.8f
+        // Faint background sub-ring
+        drawCircle(
+            color = Color(0xFFE8EFF2).copy(alpha = 0.05f),
+            radius = (rOut + rIn) / 2f,
+            center = Offset(cx, cy),
+            style = Stroke(width = rOut - rIn),
+        )
+        // Per-app marker arc
+        val color = heatColor(0.4f + (i.toFloat() / apps.size) * 0.5f)
+        drawDonutWedge(cx, cy, rOut, rIn, h - widthH, h, color)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Timeline donut — visits (full band) + activities (inner half)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawTimelineDonut(
+    visits: List<RadialVisit>,
+    activities: List<RadialActivity>,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    zone: ZoneId,
+    dividerColor: Color,
+) {
+    if (visits.isEmpty() && activities.isEmpty()) {
+        drawEmptyBand(cx, cy, rOuter, rInner, dividerColor)
+        return
+    }
+    // Faint background band
+    drawCircle(dividerColor.copy(alpha = 0.5f),
+        radius = (rOuter + rInner) / 2f, center = Offset(cx, cy),
+        style = Stroke(width = rOuter - rInner))
+
+    visits.forEach { v ->
+        drawDonutWedge(cx, cy, rOuter, rInner,
+            localHour(v.startMs, zone), localHour(v.endMs, zone),
+            placeColor(v.placeName).copy(alpha = 0.85f))
+    }
+    val rActOuter = rInner + (rOuter - rInner) * 0.65f
+    activities.forEach { a ->
+        val color = Activity.resolve(a.activityType).first
+        drawDonutWedge(cx, cy, rActOuter, rInner,
+            localHour(a.startMs, zone), localHour(a.endMs, zone),
+            color.copy(alpha = 0.95f))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Hour ticks (24, with majors at 0/6/12/18)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawHourTicks(
+    cx: Float, cy: Float, r: Float, minorColor: Color, mutedColor: Color,
+) {
+    for (h in 0 until 24) {
+        val a = hourToRad(h.toFloat())
+        val major = h % 6 == 0
+        val minor = h % 3 == 0
+        val len = if (major) 14f else if (minor) 8f else 4f
+        val p1 = polar(cx, cy, r, a)
+        val p2 = polar(cx, cy, r + len, a)
+        drawLine(if (minor) minorColor else mutedColor, p1, p2,
+                 strokeWidth = if (major) 1.5f else 1f)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Hour labels (Compose Text overlay)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun BoxWithConstraintsScope.HourLabels(
+    cx: Float, cy: Float, r: Float, density: androidx.compose.ui.unit.Density,
+) {
+    val labels = listOf(
+        0 to "minuit", 6 to "06h", 12 to "midi", 18 to "18h",
+    )
+    labels.forEach { (h, label) ->
+        val a = hourToRad(h.toFloat())
+        val px = cx + r * cos(a)
+        val py = cy + r * sin(a)
+        Text(
+            text = label,
+            color = if (h == 0 || h == 12) Color(0xFFF2F6F8) else Color(0xFFE8EFF2),
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontSize = if (h == 0 || h == 12) 13.sp else 12.sp,
+                fontWeight = if (h == 0 || h == 12) FontWeight.Bold else FontWeight.Medium,
+                letterSpacing = 0.06f.sp,
+            ),
+            modifier = Modifier.absoluteOffsetPx(px, py, density),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Center label (date-aware metric)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun BoxWithConstraintsScope.CenterLabel(
+    day: RadialDay, cx: Float, cy: Float, density: androidx.compose.ui.unit.Density,
+) {
+    val extras = DataSaillance.extras
+    val sleepMin = day.sleepStages.sumOf { (it.endMs - it.startMs) }.toFloat() / 60_000f
+    val usageMin = day.usageRows.sumOf { it.totalTimeForegroundMs }.toFloat() / 60_000f
+    val main    = if (sleepMin > 0f) sleepMin else usageMin
+    val label   = when {
+        sleepMin > 0f -> "sommeil"
+        usageMin > 0f -> "téléphone"
+        else          -> "—"
+    }
+    val h = (main / 60).toInt()
+    val m = (main % 60).toInt()
+    Column(
+        modifier = Modifier.absoluteOffsetPx(cx, cy, density),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = label,
+            color = extras.textMuted,
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 2.5.sp,
+                fontWeight = FontWeight.SemiBold,
+            ),
+        )
+        Text(
+            text = if (main > 0f) "${h}h${"%02d".format(m)}" else "—",
+            color = Color(0xFFF2F6F8),
+            style = MaterialTheme.typography.headlineMedium.copy(
+                fontSize = 34.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.6).sp,
+            ),
+        )
+        Text(
+            text = "${day.visits.size + day.activities.size} déplacements",
+            color = extras.textFaint,
+            style = MaterialTheme.typography.labelSmall,
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Donut wedge primitive (filled sector between two radii)
+// ─────────────────────────────────────────────────────────────
+internal fun DrawScope.drawDonutWedge(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float,
+    h1: Float, h2: Float, color: Color,
+) {
+    val h2Adj = if (h2 <= h1) h2 + 24f else h2
+    val sweepDeg = ((h2Adj - h1) / 24f) * 360f
+    val startDeg = (h1 / 24f) * 360f - 90f
+    val outerRect = Rect(cx - rOuter, cy - rOuter, cx + rOuter, cy + rOuter)
+    val innerRect = Rect(cx - rInner, cy - rInner, cx + rInner, cy + rInner)
+    val path = Path().apply {
+        // Outer arc forward
+        arcTo(rect = outerRect, startAngleDegrees = startDeg,
+              sweepAngleDegrees = sweepDeg, forceMoveTo = true)
+        // Inner arc backward
+        arcTo(rect = innerRect, startAngleDegrees = startDeg + sweepDeg,
+              sweepAngleDegrees = -sweepDeg, forceMoveTo = false)
+        close()
+    }
+    drawPath(path, color)
+}
+
+internal fun DrawScope.drawEmptyBand(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float, color: Color,
+) {
+    drawCircle(color.copy(alpha = 0.55f),
+        radius = (rOuter + rInner) / 2f, center = Offset(cx, cy),
+        style = Stroke(width = rOuter - rInner))
+}
+
+// ─────────────────────────────────────────────────────────────
+// Math
+// ─────────────────────────────────────────────────────────────
+internal fun hourToRad(h: Float): Float =
+    ((h / 24f) * 2f * PI - PI / 2).toFloat()
+
+internal fun polar(cx: Float, cy: Float, r: Float, a: Float): Offset =
+    Offset(cx + r * cos(a), cy + r * sin(a))
+
+internal fun localHour(ms: Long, zone: ZoneId): Float {
+    val z = Instant.ofEpochMilli(ms).atZone(zone)
+    return z.hour + z.minute / 60f + z.second / 3600f
+}
+
+private fun hitTestQuadrant(
+    offset: Offset, cx: Float, cy: Float, rInner: Float, rOuter: Float,
+): Int? {
+    val dx = offset.x - cx
+    val dy = offset.y - cy
+    val r = sqrt(dx * dx + dy * dy)
+    if (r !in rInner..rOuter) return null
+    val a = atan2(dy, dx)
+    val raw = (((a + PI / 2) / (2 * PI)) * 24f).toFloat()
+    val hour = ((raw % 24f) + 24f) % 24f
+    return (hour / 6f).toInt().coerceIn(0, 3)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Modifier helper — position an overlay so its CENTER lands at (x, y) in px.
+// ─────────────────────────────────────────────────────────────
+private fun Modifier.absoluteOffsetPx(
+    x: Float, y: Float, density: androidx.compose.ui.unit.Density,
+): Modifier = this.then(
+    Modifier.layout { measurable, constraints ->
+        val placeable = measurable.measure(constraints)
+        layout(placeable.width, placeable.height) {
+            placeable.placeRelative(
+                x = (x - placeable.width / 2f).toInt(),
+                y = (y - placeable.height / 2f).toInt(),
+            )
+        }
+    }
+)

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.kt
@@ -1,0 +1,482 @@
+package fr.datasaillance.nightfall.dataviz.radial
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/* ============================================================
+ * RadialClockScreen — full mobile screen wrapping MultiDonutClock.
+ *
+ * Layout (top → bottom, single column):
+ *   • Page header (eyebrow + title + description)
+ *   • Date navigator (prev / next + formatted date + index)
+ *   • Multi-donut clock (square, 1:1)
+ *   • Variant toggle (Heat / Apps)
+ *   • Day summary card (sleep + stage strip + usage + visits/acts)
+ *   • Quadrants card (4 tappable rows)
+ *   • Top apps card (filtered by selected quadrant if any)
+ *
+ * The screen owns selectedDate / variant / quadrant. Sleep / timeline /
+ * usage data come from a `days: Map<LocalDate, RadialDay>` map supplied by
+ * the parent (typically a ViewModel that joins SleepDao + LocationDao +
+ * UsageStatsDao queries).
+ * ============================================================ */
+
+@Composable
+fun RadialClockScreen(
+    days: Map<LocalDate, RadialDay>,
+    initialDate: LocalDate,
+    typicalUsageHourDist: FloatArray? = null,
+    modifier: Modifier = Modifier,
+    zone: ZoneId = ZoneId.systemDefault(),
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val sorted  = remember(days) { days.keys.sorted() }
+    var dateIdx by remember(initialDate, sorted) {
+        mutableStateOf(sorted.indexOf(initialDate).coerceAtLeast(0))
+    }
+    var variant   by remember { mutableStateOf(UsageVariant.Heat) }
+    var quadrant  by remember { mutableStateOf<Int?>(null) }
+
+    val date = sorted.getOrNull(dateIdx) ?: return
+    val day = days[date] ?: RadialDay(date)
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .background(palette.background),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        item {
+            PageHeader()
+        }
+        item {
+            DateNavigator(
+                date = date,
+                index = dateIdx,
+                total = sorted.size,
+                onPrev = { if (dateIdx > 0) { dateIdx--; quadrant = null } },
+                onNext = { if (dateIdx < sorted.size - 1) { dateIdx++; quadrant = null } },
+            )
+        }
+        item {
+            MultiDonutClock(
+                day = day,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(palette.surface, RoundedCornerShape(20.dp))
+                    .padding(8.dp),
+                usageVariant = variant,
+                typicalUsageHourDist = typicalUsageHourDist,
+                selectedQuadrant = quadrant,
+                onQuadrantTap = { q -> quadrant = if (q == quadrant) null else q },
+                zone = zone,
+            )
+        }
+        item {
+            VariantToggle(value = variant, onChange = { variant = it })
+        }
+        item { DaySummaryCard(day, zone) }
+        item { QuadrantsCard(day, quadrant, onTap = { q -> quadrant = if (q == quadrant) null else q }, zone) }
+        item { TopAppsCard(day, quadrant, zone) }
+        item { Spacer(Modifier.height(24.dp)) }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Page header
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun PageHeader() {
+    val extras = DataSaillance.extras
+    Column {
+        Text(
+            text = "NIGHTFALL · MULTI-DONUT",
+            color = extras.textMuted,
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 2.sp, fontWeight = FontWeight.SemiBold,
+            ),
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "Une journée, trois couches concentriques.",
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontWeight = FontWeight.Bold, letterSpacing = (-0.5).sp,
+            ),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Date navigator (prev / next + formatted date + index)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun DateNavigator(
+    date: LocalDate, index: Int, total: Int,
+    onPrev: () -> Unit, onNext: () -> Unit,
+) {
+    val extras  = DataSaillance.extras
+    val palette = MaterialTheme.colorScheme
+    val fmt = DateTimeFormatter.ofPattern("EEEE d MMMM yyyy", Locale.FRENCH)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(palette.surface, RoundedCornerShape(14.dp))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        ArrowButton(prev = true, onClick = onPrev)
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = date.format(fmt).replaceFirstChar { it.uppercase() },
+                color = palette.onBackground,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+            )
+            Text(
+                text = "${index + 1} / $total",
+                color = extras.textFaint,
+                style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.2.sp),
+            )
+        }
+        ArrowButton(prev = false, onClick = onNext)
+    }
+}
+
+@Composable
+private fun ArrowButton(prev: Boolean, onClick: () -> Unit) {
+    val palette = MaterialTheme.colorScheme
+    val extras = DataSaillance.extras
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(extras.borderStrong.copy(alpha = 0.4f))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = if (prev) "‹" else "›",
+            color = palette.onBackground,
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Variant toggle
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun VariantToggle(value: UsageVariant, onChange: (UsageVariant) -> Unit) {
+    val extras = DataSaillance.extras
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "ANNEAU USAGE · 2 VERSIONS",
+            color = extras.textFaint,
+            style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp,
+                                                              fontWeight = FontWeight.SemiBold),
+        )
+        Spacer(Modifier.height(6.dp))
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .border(1.dp, extras.borderStrong, RoundedCornerShape(999.dp))
+                .padding(3.dp),
+        ) {
+            UsageVariant.entries.forEach { v ->
+                ToggleChip(
+                    text = if (v == UsageVariant.Heat) "Heatmap horaire" else "Une ligne / app",
+                    active = value == v,
+                    onClick = { onChange(v) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleChip(text: String, active: Boolean, onClick: () -> Unit) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    Text(
+        text = text,
+        color = if (active) palette.onBackground else extras.textMuted,
+        style = MaterialTheme.typography.labelMedium.copy(
+            fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium,
+        ),
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(if (active) palette.primary else Color.Transparent)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────
+// Day summary card
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun DaySummaryCard(day: RadialDay, zone: ZoneId) {
+    val extras = DataSaillance.extras
+    val sleepMin = day.sleepStages.sumOf { (it.endMs - it.startMs) }.toFloat() / 60_000f
+    val stageMin = mutableMapOf(
+        SleepStage.AWAKE to 0f, SleepStage.REM to 0f,
+        SleepStage.LIGHT to 0f, SleepStage.DEEP to 0f,
+    )
+    day.sleepStages.forEach { stageMin[it.type] = (stageMin[it.type] ?: 0f) +
+        (it.endMs - it.startMs) / 60_000f }
+    val usageMin = day.usageRows.sumOf { it.totalTimeForegroundMs }.toFloat() / 60_000f
+    val totalKm  = day.activities.sumOf { it.distanceMeters }.toFloat() / 1000f
+
+    SectionCard(title = "LA JOURNÉE", subtitle = "résumé") {
+        MetricRow("sommeil",  formatDuration(sleepMin))
+        if (sleepMin > 0f) StageStrip(stageMin, sleepMin)
+        MetricRow("téléphone",     formatDuration(usageMin))
+        MetricRow("lieux visités", "${day.visits.size}")
+        MetricRow("trajets",
+            "${day.activities.size}${if (totalKm > 0f) " · %.1f km".format(totalKm) else ""}")
+    }
+}
+
+@Composable
+private fun StageStrip(stageMin: Map<SleepStage, Float>, totalMin: Float) {
+    val extras = DataSaillance.extras
+    val stages = listOf(SleepStage.AWAKE, SleepStage.REM, SleepStage.LIGHT, SleepStage.DEEP)
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
+        ) {
+            stages.forEach { s ->
+                val frac = ((stageMin[s] ?: 0f) / totalMin).coerceIn(0f, 1f)
+                if (frac > 0f) {
+                    Box(
+                        Modifier
+                            .weight(frac)
+                            .fillMaxHeight()
+                            .background(stageColor(s, extras)),
+                    )
+                }
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            stages.forEach { s ->
+                val pct = ((stageMin[s] ?: 0f) / totalMin * 100f).toInt()
+                Text(
+                    text = "$pct% ${s.name.lowercase().take(3)}",
+                    color = extras.textMuted,
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                )
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Quadrants card
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun QuadrantsCard(day: RadialDay, selected: Int?, onTap: (Int) -> Unit, zone: ZoneId) {
+    val labels = listOf("Nuit · 00-06", "Matin · 06-12", "Après-midi · 12-18", "Soir · 18-24")
+    SectionCard(title = "QUADRANTS 6 H", subtitle = "tap un cadran sur le donut") {
+        labels.forEachIndexed { q, label ->
+            QuadrantRow(label, summary = quadrantSummary(day, q, zone),
+                        active = selected == q, onClick = { onTap(q) })
+        }
+    }
+}
+
+private fun quadrantSummary(day: RadialDay, q: Int, zone: ZoneId): String {
+    val h1 = q * 6f; val h2 = h1 + 6f
+    fun overlaps(s: Float, e: Float) = s < h2 && e > h1
+    val sleepMin = day.sleepStages
+        .filter { overlaps(localHour(it.startMs, zone), localHour(it.endMs, zone)) }
+        .sumOf { (it.endMs - it.startMs) }.toFloat() / 60_000f
+    val visits = day.visits.count { overlaps(localHour(it.startMs, zone), localHour(it.endMs, zone)) }
+    val acts   = day.activities.count { overlaps(localHour(it.startMs, zone), localHour(it.endMs, zone)) }
+    val parts = mutableListOf<String>()
+    if (sleepMin > 0f) parts += "${sleepMin.toInt()} min sommeil"
+    if (visits > 0)    parts += "$visits lieu${if (visits > 1) "x" else ""}"
+    if (acts > 0)      parts += "$acts trajet${if (acts > 1) "s" else ""}"
+    return parts.joinToString(" · ").ifEmpty { "—" }
+}
+
+@Composable
+private fun QuadrantRow(label: String, summary: String, active: Boolean, onClick: () -> Unit) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(
+                if (active) palette.secondary.copy(alpha = 0.12f) else Color.Transparent,
+                RoundedCornerShape(10.dp),
+            )
+            .border(
+                1.dp,
+                if (active) palette.secondary else extras.borderStrong.copy(alpha = 0.5f),
+                RoundedCornerShape(10.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(label, color = palette.onBackground,
+                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium))
+            Text(summary, color = extras.textMuted, style = MaterialTheme.typography.labelSmall)
+        }
+        if (active) {
+            Text("SÉLECTIONNÉ", color = palette.secondary,
+                 style = MaterialTheme.typography.labelSmall.copy(
+                     letterSpacing = 1.8.sp, fontWeight = FontWeight.SemiBold))
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Top apps card (filtered by selected quadrant if any)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun TopAppsCard(day: RadialDay, quadrant: Int?, zone: ZoneId) {
+    if (day.usageRows.isEmpty()) return
+    val apps = day.usageRows.sortedByDescending { it.totalTimeForegroundMs }.take(6)
+    val peak = apps.maxOf { it.totalTimeForegroundMs }.toFloat()
+    val quadrantLabel = quadrant?.let { " · ${listOf("00-06", "06-12", "12-18", "18-24")[it]}" } ?: ""
+
+    SectionCard(
+        title = "TOP APPS$quadrantLabel",
+        subtitle = if (quadrant != null) "fermées dans le quadran" else "sur la journée",
+    ) {
+        val filtered = apps.filter { r ->
+            if (quadrant == null) return@filter true
+            val h = localHour(r.lastTimeUsedMs, zone)
+            h >= quadrant * 6f && h < quadrant * 6f + 6f
+        }
+        if (filtered.isEmpty()) {
+            Text(
+                "Aucune fermeture d'app top-6 dans ce quadran.",
+                color = DataSaillance.extras.textFaint,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+        }
+        filtered.forEachIndexed { i, app ->
+            val h = localHour(app.lastTimeUsedMs, zone)
+            val w = app.totalTimeForegroundMs / peak
+            val color = heatColor(0.4f + (i.toFloat() / apps.size) * 0.5f)
+            AppBarRow(app, h, w, color)
+        }
+    }
+}
+
+@Composable
+private fun AppBarRow(app: RadialUsageRow, h: Float, fillFrac: Float, color: Color) {
+    val palette = MaterialTheme.colorScheme
+    val extras = DataSaillance.extras
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(app.packageName, color = palette.onBackground,
+                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium))
+            Text(
+                text = "${(app.totalTimeForegroundMs / 60_000).toInt()}m · close %02d:%02d"
+                    .format(h.toInt(), ((h - h.toInt()) * 60f).toInt()),
+                color = extras.textMuted,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(palette.surface),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(fillFrac.coerceIn(0f, 1f))
+                    .background(color),
+            )
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Shared card chrome
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun SectionCard(title: String, subtitle: String, content: @Composable ColumnScope.() -> Unit) {
+    val extras  = DataSaillance.extras
+    val palette = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(palette.surface, RoundedCornerShape(14.dp))
+            .border(1.dp, extras.borderStrong.copy(alpha = 0.4f), RoundedCornerShape(14.dp))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(title, color = extras.textMuted,
+             style = MaterialTheme.typography.labelSmall.copy(
+                 letterSpacing = 2.sp, fontWeight = FontWeight.SemiBold))
+        Text(subtitle, color = extras.textFaint, style = MaterialTheme.typography.bodySmall)
+        content()
+    }
+}
+
+@Composable
+private fun MetricRow(label: String, value: String) {
+    val extras = DataSaillance.extras
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label.uppercase(Locale.FRENCH), color = extras.textMuted,
+             style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.2.sp))
+        Text(value, color = MaterialTheme.colorScheme.onBackground,
+             style = MaterialTheme.typography.titleMedium.copy(
+                 fontWeight = FontWeight.SemiBold, letterSpacing = (-0.2).sp))
+    }
+}
+
+private fun formatDuration(min: Float): String {
+    if (min <= 0f) return "—"
+    val h = (min / 60).toInt(); val m = (min % 60).toInt()
+    return "${h}h${"%02d".format(m)}"
+}

--- a/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
+++ b/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
@@ -1,0 +1,57 @@
+package fr.datasaillance.nightfall.ui.screens.radial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.dataviz.radial.RadialClockScreen
+import fr.datasaillance.nightfall.viewmodel.radial.RadialClockViewModel
+
+/**
+ * Route Compose qui assemble `RadialClockViewModel` + `RadialClockScreen`.
+ * Affiche un spinner pendant le 1er load, puis le multi-donut radial avec
+ * navigation entre les jours de la fenêtre.
+ */
+@Composable
+fun RadialRoute() {
+    val context = LocalContext.current
+    val db = remember(context) { NightfallDatabase.get(context.applicationContext) }
+    val viewModel = remember(db) {
+        RadialClockViewModel(
+            sleepDao = db.sleepDao(),
+            locationDao = db.locationDao(),
+            usageStatsDao = db.usageStatsDao(),
+            windowDays = 30,
+        )
+    }
+    val state by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        if (state.isLoading || state.days.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            }
+        } else {
+            RadialClockScreen(
+                days = state.days,
+                initialDate = state.initialDate,
+                typicalUsageHourDist = state.typicalUsageHourDist,
+            )
+        }
+    }
+}

--- a/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
+++ b/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
@@ -1,0 +1,29 @@
+package fr.datasaillance.nightfall.ui.screens.radial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Stub flavor `webview` — le cadran radial est rendu nativement via Compose
+ * Canvas, pas disponible en WebView.
+ */
+@Composable
+fun RadialRoute() {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Cadran radial — disponible uniquement en mode natif.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.md
@@ -2,8 +2,8 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/BottomNavBar.kt
-git_blob: 409c087914b738cbc5db33291426851c0fdab1b2
-last_synced: '2026-05-20T18:28:21Z'
+git_blob: 202b57d183e71133738602723466190745b2fc89
+last_synced: '2026-05-26T03:20:22Z'
 loc: 40
 annotations: []
 imports: []
@@ -25,7 +25,7 @@ package fr.datasaillance.nightfall.ui.navigation
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
-import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.DonutLarge
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.ShowChart
@@ -40,7 +40,7 @@ private fun iconForDestination(destination: NavDestination): ImageVector = when 
     is NavDestination.Sleep     -> Icons.Default.Home
     is NavDestination.Timeline  -> Icons.Default.ShowChart
     is NavDestination.Wellbeing -> Icons.Default.PhoneAndroid
-    is NavDestination.Activity  -> Icons.Default.FitnessCenter
+    is NavDestination.Activity  -> Icons.Default.DonutLarge  // route 'activity' = Cadran radial
     is NavDestination.Profile   -> Icons.Default.AccountCircle
     else                        -> Icons.Default.Home
 }

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavDestination.kt
-git_blob: 03d0d92dd930ae6768049dfe6dc03a0beb19aa5c
-last_synced: '2026-05-20T18:28:21Z'
-loc: 27
+git_blob: b7029815b7b51501d5510e14c8fedb6063ae4c7c
+last_synced: '2026-05-26T03:20:22Z'
+loc: 29
 annotations: []
 imports: []
 exports: []
@@ -32,7 +32,9 @@ sealed class NavDestination(
     object ForgotPassword : NavDestination("forgot_password", "Mot de passe oublié")
     object Sleep    : NavDestination("sleep",    "Sommeil")
     object Timeline : NavDestination("timeline", "Timeline")
-    object Activity : NavDestination("activity", "Activité")
+    // 'activity' route conservée pour rétro-compat tests, mais le label affiché
+    // est désormais 'Cadran' — radial clock = évolution moderne de l'écran Activité.
+    object Activity : NavDestination("activity", "Cadran")
     object Wellbeing : NavDestination("wellbeing", "Bien-être")
     object Profile  : NavDestination("profile",  "Profil")
     object Import   : NavDestination("import",   "Importer")
@@ -55,6 +57,6 @@ sealed class NavDestination(
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavDestination` (class) — lines 3-27
-- `route` (function) — lines 20-21
-- `bottomNavItems` (function) — lines 25-25
+- `NavDestination` (class) — lines 3-29
+- `route` (function) — lines 22-23
+- `bottomNavItems` (function) — lines 27-27

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.md
@@ -2,9 +2,9 @@
 type: code-source
 language: kotlin
 file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/ui/navigation/NavGraph.kt
-git_blob: 4051219592fcd219a0f46ec0eacc4344ef3387ac
-last_synced: '2026-05-23T19:13:13Z'
-loc: 312
+git_blob: 6b5d73334e2fa6e9779ca813799fb820e168db1e
+last_synced: '2026-05-26T03:20:22Z'
+loc: 316
 annotations: []
 imports: []
 exports: []
@@ -59,6 +59,7 @@ import fr.datasaillance.nightfall.data.sleep.SleepSessionResponse
 import fr.datasaillance.nightfall.domain.import_.ImportDataType
 import fr.datasaillance.nightfall.domain.import_.ImportResult
 import fr.datasaillance.nightfall.ui.screens.activity.ActivityScreen
+import fr.datasaillance.nightfall.ui.screens.radial.RadialRoute
 import fr.datasaillance.nightfall.ui.screens.wellbeing.DigitalWellbeingScreen
 import fr.datasaillance.nightfall.viewmodel.wellbeing.DigitalWellbeingViewModel
 import fr.datasaillance.nightfall.data.local.usage.UsageStatsPermissionHelper
@@ -218,7 +219,10 @@ fun NavGraph(
                     },
                 )
             }
-            composable(NavDestination.Activity.route) { ActivityScreen() }
+            // Route 'activity' rendered as the new MultiDonutClock radial view
+            // (phase 4a) — l'ancien ActivityScreen placeholder reste compilé pour
+            // les flavors qui n'ont pas Compose Canvas natif.
+            composable(NavDestination.Activity.route) { RadialRoute() }
             composable(NavDestination.Wellbeing.route) {
                 val db = remember(context) {
                     fr.datasaillance.nightfall.data.local.database.NightfallDatabase.get(context.applicationContext)
@@ -340,17 +344,17 @@ private fun ensureComposeNavigators(navController: NavHostController) {
 ## Appendix — symbols & navigation *(auto)*
 
 ### Symbols
-- `NavGraph` (function) — lines 58-264
-- `NoOpSleepRepository` (class) — lines 266-271
-- `getSessions` (function) — lines 267-270
-- `NoOpImportRepository` (class) — lines 273-288
-- `pingBackend` (function) — lines 274-274
-- `extractCsvEntries` (function) — lines 276-279
-- `uploadCsv` (function) — lines 281-287
-- `NoOpNightfallApi` (class) — lines 290-296
-- `health` (function) — lines 291-291
-- `login` (function) — lines 292-292
-- `register` (function) — lines 293-293
-- `requestPasswordReset` (function) — lines 294-294
-- `googleStart` (function) — lines 295-295
-- `ensureComposeNavigators` (function) — lines 304-312
+- `NavGraph` (function) — lines 59-268
+- `NoOpSleepRepository` (class) — lines 270-275
+- `getSessions` (function) — lines 271-274
+- `NoOpImportRepository` (class) — lines 277-292
+- `pingBackend` (function) — lines 278-278
+- `extractCsvEntries` (function) — lines 280-283
+- `uploadCsv` (function) — lines 285-291
+- `NoOpNightfallApi` (class) — lines 294-300
+- `health` (function) — lines 295-295
+- `login` (function) — lines 296-296
+- `register` (function) — lines 297-297
+- `requestPasswordReset` (function) — lines 298-298
+- `googleStart` (function) — lines 299-299
+- `ensureComposeNavigators` (function) — lines 308-316

--- a/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.md
+++ b/docs/vault/code/android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.md
@@ -1,0 +1,199 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.kt
+git_blob: 9e04fad95fcaddccaf6387a270a281f25fa5f7e4
+last_synced: '2026-05-26T03:20:22Z'
+loc: 162
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.kt`](../../../android-app/app/src/main/java/fr/datasaillance/nightfall/viewmodel/radial/RadialClockViewModel.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.viewmodel.radial
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import fr.datasaillance.nightfall.data.local.dao.LocationDao
+import fr.datasaillance.nightfall.data.local.dao.SleepDao
+import fr.datasaillance.nightfall.data.local.dao.UsageStatsDao
+import fr.datasaillance.nightfall.dataviz.radial.RadialActivity
+import fr.datasaillance.nightfall.dataviz.radial.RadialDay
+import fr.datasaillance.nightfall.dataviz.radial.RadialUsageRow
+import fr.datasaillance.nightfall.dataviz.radial.RadialVisit
+import fr.datasaillance.nightfall.dataviz.radial.SleepStage
+import fr.datasaillance.nightfall.dataviz.radial.StageInterval
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.time.LocalDate
+import java.time.ZoneId
+
+/**
+ * Agrège sleep + visits + activities + usage par jour pour le `MultiDonutClock`.
+ *
+ * Charge la fenêtre [today - windowDays + 1, today] et expose un `Map<LocalDate, RadialDay>`.
+ * Chaque RadialDay agrège les 4 sources de données dans le fuseau local.
+ *
+ * Le radial clock fait le rendu — ce ViewModel fait juste la transformation
+ * Room entities → DTO viz light (`SleepStage` enum, `RadialVisit/Activity/UsageRow`).
+ */
+data class RadialUiState(
+    val days: Map<LocalDate, RadialDay> = emptyMap(),
+    val initialDate: LocalDate = LocalDate.now(),
+    val typicalUsageHourDist: FloatArray? = null,
+    val isLoading: Boolean = true,
+)
+
+class RadialClockViewModel(
+    private val sleepDao: SleepDao,
+    private val locationDao: LocationDao,
+    private val usageStatsDao: UsageStatsDao,
+    private val windowDays: Int = 30,
+    private val zone: ZoneId = ZoneId.systemDefault(),
+    private val clock: () -> LocalDate = { LocalDate.now() },
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(RadialUiState())
+    val uiState: StateFlow<RadialUiState> = _uiState.asStateFlow()
+
+    init {
+        load()
+    }
+
+    fun reload() = load()
+
+    private fun load() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isLoading = true)
+            runCatching { buildDaysMap() }
+                .onSuccess { days ->
+                    val today = clock()
+                    _uiState.value = RadialUiState(
+                        days = days,
+                        initialDate = today,
+                        typicalUsageHourDist = computeTypicalHourDist(days),
+                        isLoading = false,
+                    )
+                }
+                .onFailure { e ->
+                    Timber.w("scope=radial_vm load_failed error=${e::class.simpleName} msg=${e.message}")
+                    _uiState.value = _uiState.value.copy(isLoading = false)
+                }
+        }
+    }
+
+    private suspend fun buildDaysMap(): Map<LocalDate, RadialDay> {
+        val today = clock()
+        val from = today.minusDays((windowDays - 1).toLong())
+        val fromMs = from.atStartOfDay(zone).toInstant().toEpochMilli()
+        val toMs = today.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+
+        // --- Sleep stages — group par session puis aplati ---
+        val sessions = runCatching { sleepDao.getSessionsInRange(fromMs, toMs) }.getOrDefault(emptyList())
+        val allStages = if (sessions.isEmpty()) emptyList()
+            else runCatching { sleepDao.getStagesForSessions(sessions.map { it.id }) }.getOrDefault(emptyList())
+
+        // Map stage entity → StageInterval DTO viz, group par date (du sleep_start de la session)
+        val sessionIdToDate: Map<Long, LocalDate> = sessions.associate { s ->
+            s.id to java.time.Instant.ofEpochMilli(s.sleepStartMs).atZone(zone).toLocalDate()
+        }
+        val stagesByDay: MutableMap<LocalDate, MutableList<StageInterval>> = HashMap()
+        allStages.forEach { stage ->
+            val day = sessionIdToDate[stage.sessionId] ?: return@forEach
+            val type = stageEnum(stage.stageType) ?: return@forEach
+            stagesByDay.getOrPut(day) { mutableListOf() }.add(
+                StageInterval(type = type, startMs = stage.stageStartMs, endMs = stage.stageEndMs)
+            )
+        }
+
+        // --- Location ---
+        val allVisits = runCatching { locationDao.getVisitsInRange(fromMs, toMs) }.getOrDefault(emptyList())
+        val allSegments = runCatching { locationDao.getSegmentsInRange(fromMs, toMs) }.getOrDefault(emptyList())
+
+        // --- Usage ---
+        val allUsage = runCatching {
+            usageStatsDao.getInRange(from.toString(), today.toString())
+        }.getOrDefault(emptyList())
+
+        val result = HashMap<LocalDate, RadialDay>()
+        for (offset in 0 until windowDays) {
+            val date = today.minusDays(offset.toLong())
+            val dayStart = date.atStartOfDay(zone).toInstant().toEpochMilli()
+            val dayEnd = date.plusDays(1).atStartOfDay(zone).toInstant().toEpochMilli()
+            val dateStr = date.toString()
+
+            result[date] = RadialDay(
+                date = date,
+                sleepStages = stagesByDay[date]?.sortedBy { it.startMs }?.toList().orEmpty(),
+                visits = allVisits
+                    .filter { it.startMs < dayEnd && it.endMs > dayStart }
+                    .map { RadialVisit(it.startMs, it.endMs, it.placeName ?: it.address ?: "—") },
+                activities = allSegments
+                    .filter { it.startMs < dayEnd && it.endMs > dayStart }
+                    .map { RadialActivity(it.startMs, it.endMs, it.activityType, it.distanceMeters ?: 0) },
+                usageRows = allUsage
+                    .filter { it.date == dateStr }
+                    .map { RadialUsageRow(it.packageName, it.totalTimeForegroundMs, it.lastTimeUsedMs) },
+            )
+        }
+        return result
+    }
+
+    /**
+     * Distribution horaire typique d'usage sur la fenêtre — 24 buckets normalisés
+     * à somme = 1 (fraction du temps total). Sert de fallback Heat ring quand un
+     * jour précis n'a pas de donnée d'usage.
+     */
+    private fun computeTypicalHourDist(days: Map<LocalDate, RadialDay>): FloatArray? {
+        val buckets = FloatArray(24)
+        var total = 0L
+        days.values.forEach { d ->
+            d.usageRows.forEach { row ->
+                if (row.lastTimeUsedMs <= 0L) return@forEach
+                val hour = java.time.Instant.ofEpochMilli(row.lastTimeUsedMs)
+                    .atZone(zone).toLocalTime().hour.coerceIn(0, 23)
+                buckets[hour] += row.totalTimeForegroundMs.toFloat()
+                total += row.totalTimeForegroundMs
+            }
+        }
+        if (total <= 0L) return null
+        for (i in buckets.indices) buckets[i] = buckets[i] / total.toFloat()
+        return buckets
+    }
+
+    private fun stageEnum(type: String): SleepStage? = when (type) {
+        "AWAKE" -> SleepStage.AWAKE
+        "REM" -> SleepStage.REM
+        "LIGHT" -> SleepStage.LIGHT
+        "DEEP" -> SleepStage.DEEP
+        else -> null
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `RadialUiState` (class) — lines 31-36
+- `RadialClockViewModel` (class) — lines 38-162
+- `reload` (function) — lines 54-54
+- `load` (function) — lines 56-74
+- `buildDaysMap` (function) — lines 76-131
+- `computeTypicalHourDist` (function) — lines 138-153
+- `stageEnum` (function) — lines 155-161

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.md
@@ -1,0 +1,602 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.kt
+git_blob: 43806a75e7515f9bcbeea575500f72e3040185e6
+last_synced: '2026-05-26T03:20:22Z'
+loc: 546
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/MultiDonutClock.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.dataviz.radial
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.pow
+import kotlin.math.sin
+import kotlin.math.sqrt
+
+/* ============================================================
+ * MultiDonutClock — Compose port of dataviz/MultiDonutClock.jsx.
+ *
+ * Three concentric donuts on a 24-hour dial:
+ *   • Outer   — sleep stages, with each wedge's inner radius set by
+ *               stage depth (AWAKE at the rim, DEEP at the inner edge).
+ *   • Middle  — phone usage, two interchangeable variants:
+ *               UsageVariant.Heat — 24 hour-wedges colored by app-close
+ *                                   density for the selected day (or by
+ *                                   the supplied typical-day fallback).
+ *               UsageVariant.Apps — top apps as concentric sub-rings,
+ *                                   each showing today's foreground share
+ *                                   and last-use time.
+ *   • Inner   — timeline. Place visits as wedges, activity segments
+ *               drawn within the inner half of the same band.
+ *
+ * Tap inside the donut → fires onQuadrantTap(0..3) where the quadrant
+ * is the 6-hour block under the touch.
+ *
+ * The composable is "pure paint" — pass a `RadialDay` (immutable),
+ * a variant, and (optionally) the typical-day usage distribution.
+ *
+ * Drop into:
+ *   android-app/app/src/main/java/fr/datasaillance/nightfall/dataviz/radial/
+ *
+ * Depends on the existing DataSaillanceTheme. Extra brand tokens used:
+ *   colorScheme.background  / secondary
+ *   extras.highlight  / divider / textMuted / textFaint / borderStrong
+ *   extras.stageAwake / stageRem / stageLight / stageDeep
+ * ============================================================ */
+
+// ─────────────────────────────────────────────────────────────
+// Data model
+// ─────────────────────────────────────────────────────────────
+enum class SleepStage { AWAKE, REM, LIGHT, DEEP }
+
+data class StageInterval(val type: SleepStage, val startMs: Long, val endMs: Long)
+data class RadialVisit(val startMs: Long, val endMs: Long, val placeName: String)
+data class RadialActivity(val startMs: Long, val endMs: Long, val activityType: String, val distanceMeters: Int)
+data class RadialUsageRow(val packageName: String, val totalTimeForegroundMs: Long, val lastTimeUsedMs: Long)
+
+data class RadialDay(
+    val date: LocalDate,
+    val sleepStages: List<StageInterval> = emptyList(),
+    val visits: List<RadialVisit> = emptyList(),
+    val activities: List<RadialActivity> = emptyList(),
+    val usageRows: List<RadialUsageRow> = emptyList(),
+)
+
+enum class UsageVariant { Heat, Apps }
+
+// ─────────────────────────────────────────────────────────────
+// Brand-aware activity color resolver
+// ─────────────────────────────────────────────────────────────
+internal object Activity {
+    val WALKING               = Color(0xFF6FB58A) to "marche"
+    val RUNNING               = Color(0xFFA8C8A8) to "course"
+    val CYCLING               = Color(0xFFE4C99A) to "vélo"
+    val IN_PASSENGER_VEHICLE  = Color(0xFFE07260) to "voiture"
+    val IN_BUS                = Color(0xFFC5B6D6) to "bus"
+    val IN_SUBWAY             = Color(0xFFB7D4DE) to "métro"
+    val FLYING                = Color(0xFF3BE5E7) to "avion"
+    val FALLBACK              = Color(0xFF828587) to "autre"
+    fun resolve(type: String): Pair<Color, String> = when (type) {
+        "WALKING" -> WALKING; "RUNNING" -> RUNNING; "CYCLING" -> CYCLING
+        "IN_PASSENGER_VEHICLE" -> IN_PASSENGER_VEHICLE
+        "IN_BUS" -> IN_BUS; "IN_SUBWAY" -> IN_SUBWAY; "FLYING" -> FLYING
+        else -> FALLBACK
+    }
+}
+
+internal fun placeColor(name: String): Color = when {
+    name.startsWith("Maison")  -> Color(0xFFD37C04)
+    name.startsWith("Travail") -> Color(0xFF0E9EB0)
+    else                       -> Color(0xFF7A9AAA)
+}
+
+// Sequential gamma-corrected color ramp (surface3 → cyan).
+internal fun heatColor(t: Float): Color =
+    lerp(Color(0xFF2A363B), Color(0xFF3BE5E7), t.coerceIn(0f, 1f).pow(0.55f))
+
+// Stage → depth (0 = thinnest, 1 = deepest into the dial).
+internal val stageDepth = mapOf(
+    SleepStage.AWAKE to 0.0f,
+    SleepStage.REM   to 0.32f,
+    SleepStage.LIGHT to 0.66f,
+    SleepStage.DEEP  to 1.0f,
+)
+
+internal fun stageColor(stage: SleepStage, extras: fr.datasaillance.nightfall.ui.theme.ExtraColors): Color =
+    when (stage) {
+        SleepStage.AWAKE -> extras.stageAwake
+        SleepStage.REM   -> extras.stageRem
+        SleepStage.LIGHT -> extras.stageLight
+        SleepStage.DEEP  -> extras.stageDeep
+    }
+
+// ─────────────────────────────────────────────────────────────
+// Public composable
+// ─────────────────────────────────────────────────────────────
+@Composable
+fun MultiDonutClock(
+    day: RadialDay,
+    modifier: Modifier = Modifier,
+    usageVariant: UsageVariant = UsageVariant.Heat,
+    typicalUsageHourDist: FloatArray? = null,
+    selectedQuadrant: Int? = null,
+    onQuadrantTap: (Int) -> Unit = {},
+    zone: ZoneId = ZoneId.systemDefault(),
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val density = LocalDensity.current
+
+    // Precompute per-hour usage minutes for the heat variant.
+    val hourBuckets: FloatArray = remember(day, typicalUsageHourDist) {
+        val out = FloatArray(24)
+        if (day.usageRows.isNotEmpty()) {
+            day.usageRows.forEach { r ->
+                val h = Instant.ofEpochMilli(r.lastTimeUsedMs).atZone(zone).hour
+                out[h] += r.totalTimeForegroundMs.toFloat()
+            }
+        } else if (typicalUsageHourDist != null) {
+            typicalUsageHourDist.forEachIndexed { i, v -> out[i] = v }
+        }
+        out
+    }
+
+    // Top apps by foreground time (used by the Apps variant).
+    val topApps: List<RadialUsageRow> = remember(day) {
+        day.usageRows.sortedByDescending { it.totalTimeForegroundMs }.take(6)
+    }
+
+    BoxWithConstraints(
+        modifier = modifier.aspectRatio(1f),
+        contentAlignment = Alignment.Center,
+    ) {
+        val sizePx = with(density) { minOf(maxWidth, maxHeight).toPx() }
+        val cx = sizePx / 2f
+        val cy = sizePx / 2f
+        // Radii (fractions of the canvas size)
+        val rHourTicks      = sizePx * 0.470f
+        val rSleepOuter     = sizePx * 0.460f
+        val rSleepDeepInner = sizePx * 0.330f
+        val rUsageOuter     = sizePx * 0.310f
+        val rUsageInner     = sizePx * 0.225f
+        val rTimelineOuter  = sizePx * 0.205f
+        val rTimelineInner  = sizePx * 0.135f
+        val rCenter         = sizePx * 0.130f
+
+        Canvas(
+            modifier = Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    detectTapGestures { offset ->
+                        val q = hitTestQuadrant(offset, cx, cy,
+                            rInner = rTimelineInner, rOuter = rSleepOuter + 25f)
+                        if (q != null) onQuadrantTap(q)
+                    }
+                },
+        ) {
+            // 1. Selected-quadrant highlight (behind everything)
+            selectedQuadrant?.let { q ->
+                val color = palette.secondary.copy(alpha = 0.10f)
+                drawDonutWedge(cx, cy, rSleepOuter + 25f, rTimelineInner,
+                    h1 = q * 6f, h2 = q * 6f + 6f, color = color)
+            }
+
+            // 2. Sleep donut
+            drawSleepDonut(day.sleepStages, cx, cy,
+                rOuter = rSleepOuter, rInner = rSleepDeepInner, zone, extras)
+
+            // 3. Usage donut
+            when (usageVariant) {
+                UsageVariant.Heat -> drawUsageHeat(hourBuckets, cx, cy,
+                    rOuter = rUsageOuter, rInner = rUsageInner, palette.background)
+                UsageVariant.Apps -> drawUsageApps(topApps, cx, cy,
+                    rOuter = rUsageOuter, rInner = rUsageInner, zone)
+            }
+
+            // 4. Timeline donut
+            drawTimelineDonut(day.visits, day.activities,
+                cx, cy, rTimelineOuter, rTimelineInner, zone, extras.divider)
+
+            // 5. Quadrant separator hairlines
+            listOf(0f, 6f, 12f, 18f).forEach { h ->
+                val a = hourToRad(h)
+                val p1 = polar(cx, cy, rTimelineInner, a)
+                val p2 = polar(cx, cy, rSleepOuter, a)
+                drawLine(extras.divider, p1, p2, strokeWidth = 1f)
+            }
+
+            // 6. Hour ticks
+            drawHourTicks(cx, cy, rHourTicks, extras.textMuted, extras.textFaint)
+
+            // 7. Center hub
+            drawCircle(palette.background, radius = rCenter, center = Offset(cx, cy))
+            drawCircle(extras.divider, radius = rCenter, center = Offset(cx, cy),
+                       style = Stroke(width = 1f))
+        }
+
+        // Overlay text labels (Compose Text for crisp typography)
+        HourLabels(cx, cy, rHourTicks + 30f, density)
+        CenterLabel(day, cx, cy, density)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sleep donut — stage wedges with variable inner radius
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawSleepDonut(
+    stages: List<StageInterval>,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    zone: ZoneId,
+    extras: fr.datasaillance.nightfall.ui.theme.ExtraColors,
+) {
+    if (stages.isEmpty()) {
+        drawEmptyBand(cx, cy, rOuter, rInner, extras.divider)
+        return
+    }
+
+    val range = rOuter - rInner
+    // Background hint band so the donut shape is always visible
+    drawCircle(extras.divider.copy(alpha = 0.5f), radius = (rOuter + rInner) / 2f,
+               center = Offset(cx, cy), style = Stroke(width = range))
+
+    // Merge consecutive identical-stage intervals for cleaner wedges
+    val merged = mutableListOf<StageInterval>()
+    for (st in stages) {
+        val last = merged.lastOrNull()
+        if (last != null && last.type == st.type && (st.startMs - last.endMs) < 1000L) {
+            merged[merged.lastIndex] = last.copy(endMs = st.endMs)
+        } else {
+            merged += st
+        }
+    }
+    for (st in merged) {
+        val depth = stageDepth[st.type] ?: 0f
+        val rIn = rOuter - depth * range
+        val h1 = localHour(st.startMs, zone)
+        val h2 = localHour(st.endMs, zone)
+        drawDonutWedge(cx, cy, rOuter, rIn, h1, h2, stageColor(st.type, extras).copy(alpha = 0.92f))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Usage donut — heatmap variant (24 hour-wedges)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawUsageHeat(
+    buckets: FloatArray,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    bgColor: Color,
+) {
+    val peak = (buckets.maxOrNull() ?: 0f).coerceAtLeast(1f)
+    for (h in 0 until 24) {
+        val v = buckets[h]
+        val color = if (v == 0f) Color(0xFF1E262B) else heatColor(v / peak)
+        drawDonutWedge(cx, cy, rOuter, rInner, h.toFloat(), h + 1f, color)
+    }
+    // Hairline separators between hour wedges
+    for (h in 0 until 24) {
+        val a = hourToRad(h.toFloat())
+        val p1 = polar(cx, cy, rInner, a)
+        val p2 = polar(cx, cy, rOuter, a)
+        drawLine(bgColor.copy(alpha = 0.7f), p1, p2, strokeWidth = 1f)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Usage donut — apps variant (concentric sub-rings per app)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawUsageApps(
+    apps: List<RadialUsageRow>,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    zone: ZoneId,
+) {
+    if (apps.isEmpty()) {
+        drawEmptyBand(cx, cy, rOuter, rInner, Color(0xFF2E3D44))
+        return
+    }
+    val bandH = (rOuter - rInner) / apps.size
+    val peakMs = apps.maxOf { it.totalTimeForegroundMs }.toFloat()
+
+    apps.forEachIndexed { i, app ->
+        val rOut = rOuter - i * bandH
+        val rIn  = rOut - bandH * 0.85f
+        val h = localHour(app.lastTimeUsedMs, zone)
+        val widthH = 0.4f + (app.totalTimeForegroundMs / peakMs) * 1.8f
+        // Faint background sub-ring
+        drawCircle(
+            color = Color(0xFFE8EFF2).copy(alpha = 0.05f),
+            radius = (rOut + rIn) / 2f,
+            center = Offset(cx, cy),
+            style = Stroke(width = rOut - rIn),
+        )
+        // Per-app marker arc
+        val color = heatColor(0.4f + (i.toFloat() / apps.size) * 0.5f)
+        drawDonutWedge(cx, cy, rOut, rIn, h - widthH, h, color)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Timeline donut — visits (full band) + activities (inner half)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawTimelineDonut(
+    visits: List<RadialVisit>,
+    activities: List<RadialActivity>,
+    cx: Float, cy: Float,
+    rOuter: Float, rInner: Float,
+    zone: ZoneId,
+    dividerColor: Color,
+) {
+    if (visits.isEmpty() && activities.isEmpty()) {
+        drawEmptyBand(cx, cy, rOuter, rInner, dividerColor)
+        return
+    }
+    // Faint background band
+    drawCircle(dividerColor.copy(alpha = 0.5f),
+        radius = (rOuter + rInner) / 2f, center = Offset(cx, cy),
+        style = Stroke(width = rOuter - rInner))
+
+    visits.forEach { v ->
+        drawDonutWedge(cx, cy, rOuter, rInner,
+            localHour(v.startMs, zone), localHour(v.endMs, zone),
+            placeColor(v.placeName).copy(alpha = 0.85f))
+    }
+    val rActOuter = rInner + (rOuter - rInner) * 0.65f
+    activities.forEach { a ->
+        val color = Activity.resolve(a.activityType).first
+        drawDonutWedge(cx, cy, rActOuter, rInner,
+            localHour(a.startMs, zone), localHour(a.endMs, zone),
+            color.copy(alpha = 0.95f))
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Hour ticks (24, with majors at 0/6/12/18)
+// ─────────────────────────────────────────────────────────────
+private fun DrawScope.drawHourTicks(
+    cx: Float, cy: Float, r: Float, minorColor: Color, mutedColor: Color,
+) {
+    for (h in 0 until 24) {
+        val a = hourToRad(h.toFloat())
+        val major = h % 6 == 0
+        val minor = h % 3 == 0
+        val len = if (major) 14f else if (minor) 8f else 4f
+        val p1 = polar(cx, cy, r, a)
+        val p2 = polar(cx, cy, r + len, a)
+        drawLine(if (minor) minorColor else mutedColor, p1, p2,
+                 strokeWidth = if (major) 1.5f else 1f)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Hour labels (Compose Text overlay)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun BoxWithConstraintsScope.HourLabels(
+    cx: Float, cy: Float, r: Float, density: androidx.compose.ui.unit.Density,
+) {
+    val labels = listOf(
+        0 to "minuit", 6 to "06h", 12 to "midi", 18 to "18h",
+    )
+    labels.forEach { (h, label) ->
+        val a = hourToRad(h.toFloat())
+        val px = cx + r * cos(a)
+        val py = cy + r * sin(a)
+        Text(
+            text = label,
+            color = if (h == 0 || h == 12) Color(0xFFF2F6F8) else Color(0xFFE8EFF2),
+            style = MaterialTheme.typography.labelMedium.copy(
+                fontSize = if (h == 0 || h == 12) 13.sp else 12.sp,
+                fontWeight = if (h == 0 || h == 12) FontWeight.Bold else FontWeight.Medium,
+                letterSpacing = 0.06f.sp,
+            ),
+            modifier = Modifier.absoluteOffsetPx(px, py, density),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Center label (date-aware metric)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun BoxWithConstraintsScope.CenterLabel(
+    day: RadialDay, cx: Float, cy: Float, density: androidx.compose.ui.unit.Density,
+) {
+    val extras = DataSaillance.extras
+    val sleepMin = day.sleepStages.sumOf { (it.endMs - it.startMs) }.toFloat() / 60_000f
+    val usageMin = day.usageRows.sumOf { it.totalTimeForegroundMs }.toFloat() / 60_000f
+    val main    = if (sleepMin > 0f) sleepMin else usageMin
+    val label   = when {
+        sleepMin > 0f -> "sommeil"
+        usageMin > 0f -> "téléphone"
+        else          -> "—"
+    }
+    val h = (main / 60).toInt()
+    val m = (main % 60).toInt()
+    Column(
+        modifier = Modifier.absoluteOffsetPx(cx, cy, density),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = label,
+            color = extras.textMuted,
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 2.5.sp,
+                fontWeight = FontWeight.SemiBold,
+            ),
+        )
+        Text(
+            text = if (main > 0f) "${h}h${"%02d".format(m)}" else "—",
+            color = Color(0xFFF2F6F8),
+            style = MaterialTheme.typography.headlineMedium.copy(
+                fontSize = 34.sp,
+                fontWeight = FontWeight.Bold,
+                letterSpacing = (-0.6).sp,
+            ),
+        )
+        Text(
+            text = "${day.visits.size + day.activities.size} déplacements",
+            color = extras.textFaint,
+            style = MaterialTheme.typography.labelSmall,
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Donut wedge primitive (filled sector between two radii)
+// ─────────────────────────────────────────────────────────────
+internal fun DrawScope.drawDonutWedge(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float,
+    h1: Float, h2: Float, color: Color,
+) {
+    val h2Adj = if (h2 <= h1) h2 + 24f else h2
+    val sweepDeg = ((h2Adj - h1) / 24f) * 360f
+    val startDeg = (h1 / 24f) * 360f - 90f
+    val outerRect = Rect(cx - rOuter, cy - rOuter, cx + rOuter, cy + rOuter)
+    val innerRect = Rect(cx - rInner, cy - rInner, cx + rInner, cy + rInner)
+    val path = Path().apply {
+        // Outer arc forward
+        arcTo(rect = outerRect, startAngleDegrees = startDeg,
+              sweepAngleDegrees = sweepDeg, forceMoveTo = true)
+        // Inner arc backward
+        arcTo(rect = innerRect, startAngleDegrees = startDeg + sweepDeg,
+              sweepAngleDegrees = -sweepDeg, forceMoveTo = false)
+        close()
+    }
+    drawPath(path, color)
+}
+
+internal fun DrawScope.drawEmptyBand(
+    cx: Float, cy: Float, rOuter: Float, rInner: Float, color: Color,
+) {
+    drawCircle(color.copy(alpha = 0.55f),
+        radius = (rOuter + rInner) / 2f, center = Offset(cx, cy),
+        style = Stroke(width = rOuter - rInner))
+}
+
+// ─────────────────────────────────────────────────────────────
+// Math
+// ─────────────────────────────────────────────────────────────
+internal fun hourToRad(h: Float): Float =
+    ((h / 24f) * 2f * PI - PI / 2).toFloat()
+
+internal fun polar(cx: Float, cy: Float, r: Float, a: Float): Offset =
+    Offset(cx + r * cos(a), cy + r * sin(a))
+
+internal fun localHour(ms: Long, zone: ZoneId): Float {
+    val z = Instant.ofEpochMilli(ms).atZone(zone)
+    return z.hour + z.minute / 60f + z.second / 3600f
+}
+
+private fun hitTestQuadrant(
+    offset: Offset, cx: Float, cy: Float, rInner: Float, rOuter: Float,
+): Int? {
+    val dx = offset.x - cx
+    val dy = offset.y - cy
+    val r = sqrt(dx * dx + dy * dy)
+    if (r !in rInner..rOuter) return null
+    val a = atan2(dy, dx)
+    val raw = (((a + PI / 2) / (2 * PI)) * 24f).toFloat()
+    val hour = ((raw % 24f) + 24f) % 24f
+    return (hour / 6f).toInt().coerceIn(0, 3)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Modifier helper — position an overlay so its CENTER lands at (x, y) in px.
+// ─────────────────────────────────────────────────────────────
+private fun Modifier.absoluteOffsetPx(
+    x: Float, y: Float, density: androidx.compose.ui.unit.Density,
+): Modifier = this.then(
+    Modifier.layout { measurable, constraints ->
+        val placeable = measurable.measure(constraints)
+        layout(placeable.width, placeable.height) {
+            placeable.placeRelative(
+                x = (x - placeable.width / 2f).toInt(),
+                y = (y - placeable.height / 2f).toInt(),
+            )
+        }
+    }
+)
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `SleepStage` (class) — lines 76-76
+- `StageInterval` (class) — lines 78-78
+- `RadialVisit` (class) — lines 79-79
+- `RadialActivity` (class) — lines 80-80
+- `RadialUsageRow` (class) — lines 81-81
+- `RadialDay` (class) — lines 83-89
+- `UsageVariant` (class) — lines 91-91
+- `resolve` (function) — lines 105-110
+- `placeColor` (function) — lines 113-117
+- `heatColor` (function) — lines 120-121
+- `stageColor` (function) — lines 131-137
+- `MultiDonutClock` (function) — lines 142-247
+- `drawSleepDonut` (function) — lines 252-286
+- `drawUsageHeat` (function) — lines 291-310
+- `drawUsageApps` (function) — lines 315-344
+- `drawTimelineDonut` (function) — lines 349-378
+- `drawHourTicks` (function) — lines 383-396
+- `HourLabels` (function) — lines 401-423
+- `CenterLabel` (function) — lines 428-470
+- `drawDonutWedge` (function) — lines 475-494
+- `drawEmptyBand` (function) — lines 496-502
+- `hourToRad` (function) — lines 507-508
+- `polar` (function) — lines 510-511
+- `localHour` (function) — lines 513-516
+- `hitTestQuadrant` (function) — lines 518-529
+- `absoluteOffsetPx` (function) — lines 534-546

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.md
@@ -1,0 +1,529 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.kt
+git_blob: 9b38ef005c42fed0e0eaf8ccc0e2e2c0d873aa68
+last_synced: '2026-05-26T03:20:22Z'
+loc: 482
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/dataviz/radial/RadialClockScreen.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.dataviz.radial
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import fr.datasaillance.nightfall.ui.theme.DataSaillance
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/* ============================================================
+ * RadialClockScreen — full mobile screen wrapping MultiDonutClock.
+ *
+ * Layout (top → bottom, single column):
+ *   • Page header (eyebrow + title + description)
+ *   • Date navigator (prev / next + formatted date + index)
+ *   • Multi-donut clock (square, 1:1)
+ *   • Variant toggle (Heat / Apps)
+ *   • Day summary card (sleep + stage strip + usage + visits/acts)
+ *   • Quadrants card (4 tappable rows)
+ *   • Top apps card (filtered by selected quadrant if any)
+ *
+ * The screen owns selectedDate / variant / quadrant. Sleep / timeline /
+ * usage data come from a `days: Map<LocalDate, RadialDay>` map supplied by
+ * the parent (typically a ViewModel that joins SleepDao + LocationDao +
+ * UsageStatsDao queries).
+ * ============================================================ */
+
+@Composable
+fun RadialClockScreen(
+    days: Map<LocalDate, RadialDay>,
+    initialDate: LocalDate,
+    typicalUsageHourDist: FloatArray? = null,
+    modifier: Modifier = Modifier,
+    zone: ZoneId = ZoneId.systemDefault(),
+) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    val sorted  = remember(days) { days.keys.sorted() }
+    var dateIdx by remember(initialDate, sorted) {
+        mutableStateOf(sorted.indexOf(initialDate).coerceAtLeast(0))
+    }
+    var variant   by remember { mutableStateOf(UsageVariant.Heat) }
+    var quadrant  by remember { mutableStateOf<Int?>(null) }
+
+    val date = sorted.getOrNull(dateIdx) ?: return
+    val day = days[date] ?: RadialDay(date)
+
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .background(palette.background),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(14.dp),
+    ) {
+        item {
+            PageHeader()
+        }
+        item {
+            DateNavigator(
+                date = date,
+                index = dateIdx,
+                total = sorted.size,
+                onPrev = { if (dateIdx > 0) { dateIdx--; quadrant = null } },
+                onNext = { if (dateIdx < sorted.size - 1) { dateIdx++; quadrant = null } },
+            )
+        }
+        item {
+            MultiDonutClock(
+                day = day,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(palette.surface, RoundedCornerShape(20.dp))
+                    .padding(8.dp),
+                usageVariant = variant,
+                typicalUsageHourDist = typicalUsageHourDist,
+                selectedQuadrant = quadrant,
+                onQuadrantTap = { q -> quadrant = if (q == quadrant) null else q },
+                zone = zone,
+            )
+        }
+        item {
+            VariantToggle(value = variant, onChange = { variant = it })
+        }
+        item { DaySummaryCard(day, zone) }
+        item { QuadrantsCard(day, quadrant, onTap = { q -> quadrant = if (q == quadrant) null else q }, zone) }
+        item { TopAppsCard(day, quadrant, zone) }
+        item { Spacer(Modifier.height(24.dp)) }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Page header
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun PageHeader() {
+    val extras = DataSaillance.extras
+    Column {
+        Text(
+            text = "NIGHTFALL · MULTI-DONUT",
+            color = extras.textMuted,
+            style = MaterialTheme.typography.labelSmall.copy(
+                letterSpacing = 2.sp, fontWeight = FontWeight.SemiBold,
+            ),
+        )
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text = "Une journée, trois couches concentriques.",
+            color = MaterialTheme.colorScheme.onBackground,
+            style = MaterialTheme.typography.headlineSmall.copy(
+                fontWeight = FontWeight.Bold, letterSpacing = (-0.5).sp,
+            ),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Date navigator (prev / next + formatted date + index)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun DateNavigator(
+    date: LocalDate, index: Int, total: Int,
+    onPrev: () -> Unit, onNext: () -> Unit,
+) {
+    val extras  = DataSaillance.extras
+    val palette = MaterialTheme.colorScheme
+    val fmt = DateTimeFormatter.ofPattern("EEEE d MMMM yyyy", Locale.FRENCH)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(palette.surface, RoundedCornerShape(14.dp))
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        ArrowButton(prev = true, onClick = onPrev)
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text = date.format(fmt).replaceFirstChar { it.uppercase() },
+                color = palette.onBackground,
+                style = MaterialTheme.typography.titleSmall.copy(
+                    fontWeight = FontWeight.SemiBold,
+                ),
+            )
+            Text(
+                text = "${index + 1} / $total",
+                color = extras.textFaint,
+                style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.2.sp),
+            )
+        }
+        ArrowButton(prev = false, onClick = onNext)
+    }
+}
+
+@Composable
+private fun ArrowButton(prev: Boolean, onClick: () -> Unit) {
+    val palette = MaterialTheme.colorScheme
+    val extras = DataSaillance.extras
+    Box(
+        modifier = Modifier
+            .size(36.dp)
+            .clip(CircleShape)
+            .background(extras.borderStrong.copy(alpha = 0.4f))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = if (prev) "‹" else "›",
+            color = palette.onBackground,
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Variant toggle
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun VariantToggle(value: UsageVariant, onChange: (UsageVariant) -> Unit) {
+    val extras = DataSaillance.extras
+    Column(horizontalAlignment = Alignment.CenterHorizontally, modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = "ANNEAU USAGE · 2 VERSIONS",
+            color = extras.textFaint,
+            style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 2.sp,
+                                                              fontWeight = FontWeight.SemiBold),
+        )
+        Spacer(Modifier.height(6.dp))
+        Row(
+            modifier = Modifier
+                .clip(RoundedCornerShape(999.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .border(1.dp, extras.borderStrong, RoundedCornerShape(999.dp))
+                .padding(3.dp),
+        ) {
+            UsageVariant.entries.forEach { v ->
+                ToggleChip(
+                    text = if (v == UsageVariant.Heat) "Heatmap horaire" else "Une ligne / app",
+                    active = value == v,
+                    onClick = { onChange(v) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ToggleChip(text: String, active: Boolean, onClick: () -> Unit) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    Text(
+        text = text,
+        color = if (active) palette.onBackground else extras.textMuted,
+        style = MaterialTheme.typography.labelMedium.copy(
+            fontWeight = if (active) FontWeight.SemiBold else FontWeight.Medium,
+        ),
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(if (active) palette.primary else Color.Transparent)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+    )
+}
+
+// ─────────────────────────────────────────────────────────────
+// Day summary card
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun DaySummaryCard(day: RadialDay, zone: ZoneId) {
+    val extras = DataSaillance.extras
+    val sleepMin = day.sleepStages.sumOf { (it.endMs - it.startMs) }.toFloat() / 60_000f
+    val stageMin = mutableMapOf(
+        SleepStage.AWAKE to 0f, SleepStage.REM to 0f,
+        SleepStage.LIGHT to 0f, SleepStage.DEEP to 0f,
+    )
+    day.sleepStages.forEach { stageMin[it.type] = (stageMin[it.type] ?: 0f) +
+        (it.endMs - it.startMs) / 60_000f }
+    val usageMin = day.usageRows.sumOf { it.totalTimeForegroundMs }.toFloat() / 60_000f
+    val totalKm  = day.activities.sumOf { it.distanceMeters }.toFloat() / 1000f
+
+    SectionCard(title = "LA JOURNÉE", subtitle = "résumé") {
+        MetricRow("sommeil",  formatDuration(sleepMin))
+        if (sleepMin > 0f) StageStrip(stageMin, sleepMin)
+        MetricRow("téléphone",     formatDuration(usageMin))
+        MetricRow("lieux visités", "${day.visits.size}")
+        MetricRow("trajets",
+            "${day.activities.size}${if (totalKm > 0f) " · %.1f km".format(totalKm) else ""}")
+    }
+}
+
+@Composable
+private fun StageStrip(stageMin: Map<SleepStage, Float>, totalMin: Float) {
+    val extras = DataSaillance.extras
+    val stages = listOf(SleepStage.AWAKE, SleepStage.REM, SleepStage.LIGHT, SleepStage.DEEP)
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp), modifier = Modifier.padding(vertical = 4.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth().height(6.dp).clip(RoundedCornerShape(3.dp)),
+        ) {
+            stages.forEach { s ->
+                val frac = ((stageMin[s] ?: 0f) / totalMin).coerceIn(0f, 1f)
+                if (frac > 0f) {
+                    Box(
+                        Modifier
+                            .weight(frac)
+                            .fillMaxHeight()
+                            .background(stageColor(s, extras)),
+                    )
+                }
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            stages.forEach { s ->
+                val pct = ((stageMin[s] ?: 0f) / totalMin * 100f).toInt()
+                Text(
+                    text = "$pct% ${s.name.lowercase().take(3)}",
+                    color = extras.textMuted,
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                )
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Quadrants card
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun QuadrantsCard(day: RadialDay, selected: Int?, onTap: (Int) -> Unit, zone: ZoneId) {
+    val labels = listOf("Nuit · 00-06", "Matin · 06-12", "Après-midi · 12-18", "Soir · 18-24")
+    SectionCard(title = "QUADRANTS 6 H", subtitle = "tap un cadran sur le donut") {
+        labels.forEachIndexed { q, label ->
+            QuadrantRow(label, summary = quadrantSummary(day, q, zone),
+                        active = selected == q, onClick = { onTap(q) })
+        }
+    }
+}
+
+private fun quadrantSummary(day: RadialDay, q: Int, zone: ZoneId): String {
+    val h1 = q * 6f; val h2 = h1 + 6f
+    fun overlaps(s: Float, e: Float) = s < h2 && e > h1
+    val sleepMin = day.sleepStages
+        .filter { overlaps(localHour(it.startMs, zone), localHour(it.endMs, zone)) }
+        .sumOf { (it.endMs - it.startMs) }.toFloat() / 60_000f
+    val visits = day.visits.count { overlaps(localHour(it.startMs, zone), localHour(it.endMs, zone)) }
+    val acts   = day.activities.count { overlaps(localHour(it.startMs, zone), localHour(it.endMs, zone)) }
+    val parts = mutableListOf<String>()
+    if (sleepMin > 0f) parts += "${sleepMin.toInt()} min sommeil"
+    if (visits > 0)    parts += "$visits lieu${if (visits > 1) "x" else ""}"
+    if (acts > 0)      parts += "$acts trajet${if (acts > 1) "s" else ""}"
+    return parts.joinToString(" · ").ifEmpty { "—" }
+}
+
+@Composable
+private fun QuadrantRow(label: String, summary: String, active: Boolean, onClick: () -> Unit) {
+    val palette = MaterialTheme.colorScheme
+    val extras  = DataSaillance.extras
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(10.dp))
+            .background(
+                if (active) palette.secondary.copy(alpha = 0.12f) else Color.Transparent,
+                RoundedCornerShape(10.dp),
+            )
+            .border(
+                1.dp,
+                if (active) palette.secondary else extras.borderStrong.copy(alpha = 0.5f),
+                RoundedCornerShape(10.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+            Text(label, color = palette.onBackground,
+                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium))
+            Text(summary, color = extras.textMuted, style = MaterialTheme.typography.labelSmall)
+        }
+        if (active) {
+            Text("SÉLECTIONNÉ", color = palette.secondary,
+                 style = MaterialTheme.typography.labelSmall.copy(
+                     letterSpacing = 1.8.sp, fontWeight = FontWeight.SemiBold))
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Top apps card (filtered by selected quadrant if any)
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun TopAppsCard(day: RadialDay, quadrant: Int?, zone: ZoneId) {
+    if (day.usageRows.isEmpty()) return
+    val apps = day.usageRows.sortedByDescending { it.totalTimeForegroundMs }.take(6)
+    val peak = apps.maxOf { it.totalTimeForegroundMs }.toFloat()
+    val quadrantLabel = quadrant?.let { " · ${listOf("00-06", "06-12", "12-18", "18-24")[it]}" } ?: ""
+
+    SectionCard(
+        title = "TOP APPS$quadrantLabel",
+        subtitle = if (quadrant != null) "fermées dans le quadran" else "sur la journée",
+    ) {
+        val filtered = apps.filter { r ->
+            if (quadrant == null) return@filter true
+            val h = localHour(r.lastTimeUsedMs, zone)
+            h >= quadrant * 6f && h < quadrant * 6f + 6f
+        }
+        if (filtered.isEmpty()) {
+            Text(
+                "Aucune fermeture d'app top-6 dans ce quadran.",
+                color = DataSaillance.extras.textFaint,
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(vertical = 4.dp),
+            )
+        }
+        filtered.forEachIndexed { i, app ->
+            val h = localHour(app.lastTimeUsedMs, zone)
+            val w = app.totalTimeForegroundMs / peak
+            val color = heatColor(0.4f + (i.toFloat() / apps.size) * 0.5f)
+            AppBarRow(app, h, w, color)
+        }
+    }
+}
+
+@Composable
+private fun AppBarRow(app: RadialUsageRow, h: Float, fillFrac: Float, color: Color) {
+    val palette = MaterialTheme.colorScheme
+    val extras = DataSaillance.extras
+    Column(
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(app.packageName, color = palette.onBackground,
+                 style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium))
+            Text(
+                text = "${(app.totalTimeForegroundMs / 60_000).toInt()}m · close %02d:%02d"
+                    .format(h.toInt(), ((h - h.toInt()) * 60f).toInt()),
+                color = extras.textMuted,
+                style = MaterialTheme.typography.labelSmall,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(palette.surface),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .fillMaxWidth(fillFrac.coerceIn(0f, 1f))
+                    .background(color),
+            )
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Shared card chrome
+// ─────────────────────────────────────────────────────────────
+@Composable
+private fun SectionCard(title: String, subtitle: String, content: @Composable ColumnScope.() -> Unit) {
+    val extras  = DataSaillance.extras
+    val palette = MaterialTheme.colorScheme
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(palette.surface, RoundedCornerShape(14.dp))
+            .border(1.dp, extras.borderStrong.copy(alpha = 0.4f), RoundedCornerShape(14.dp))
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Text(title, color = extras.textMuted,
+             style = MaterialTheme.typography.labelSmall.copy(
+                 letterSpacing = 2.sp, fontWeight = FontWeight.SemiBold))
+        Text(subtitle, color = extras.textFaint, style = MaterialTheme.typography.bodySmall)
+        content()
+    }
+}
+
+@Composable
+private fun MetricRow(label: String, value: String) {
+    val extras = DataSaillance.extras
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(label.uppercase(Locale.FRENCH), color = extras.textMuted,
+             style = MaterialTheme.typography.labelSmall.copy(letterSpacing = 1.2.sp))
+        Text(value, color = MaterialTheme.colorScheme.onBackground,
+             style = MaterialTheme.typography.titleMedium.copy(
+                 fontWeight = FontWeight.SemiBold, letterSpacing = (-0.2).sp))
+    }
+}
+
+private fun formatDuration(min: Float): String {
+    if (min <= 0f) return "—"
+    val h = (min / 60).toInt(); val m = (min % 60).toInt()
+    return "${h}h${"%02d".format(m)}"
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `RadialClockScreen` (function) — lines 46-107
+- `PageHeader` (function) — lines 112-132
+- `DateNavigator` (function) — lines 137-170
+- `ArrowButton` (function) — lines 172-190
+- `VariantToggle` (function) — lines 195-222
+- `ToggleChip` (function) — lines 224-240
+- `DaySummaryCard` (function) — lines 245-266
+- `StageStrip` (function) — lines 268-299
+- `QuadrantsCard` (function) — lines 304-313
+- `quadrantSummary` (function) — lines 315-328
+- `overlaps` (function) — lines 317-317
+- `QuadrantRow` (function) — lines 330-363
+- `TopAppsCard` (function) — lines 368-399
+- `AppBarRow` (function) — lines 401-437
+- `SectionCard` (function) — lines 442-460
+- `MetricRow` (function) — lines 462-476
+- `formatDuration` (function) — lines 478-482

--- a/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.md
+++ b/docs/vault/code/android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.md
@@ -1,0 +1,88 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
+git_blob: 6d33d38e430b80556279c5d9b91b37fdb14f529c
+last_synced: '2026-05-26T03:20:22Z'
+loc: 57
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt`](../../../android-app/app/src/native/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.radial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import fr.datasaillance.nightfall.data.local.database.NightfallDatabase
+import fr.datasaillance.nightfall.dataviz.radial.RadialClockScreen
+import fr.datasaillance.nightfall.viewmodel.radial.RadialClockViewModel
+
+/**
+ * Route Compose qui assemble `RadialClockViewModel` + `RadialClockScreen`.
+ * Affiche un spinner pendant le 1er load, puis le multi-donut radial avec
+ * navigation entre les jours de la fenêtre.
+ */
+@Composable
+fun RadialRoute() {
+    val context = LocalContext.current
+    val db = remember(context) { NightfallDatabase.get(context.applicationContext) }
+    val viewModel = remember(db) {
+        RadialClockViewModel(
+            sleepDao = db.sleepDao(),
+            locationDao = db.locationDao(),
+            usageStatsDao = db.usageStatsDao(),
+            windowDays = 30,
+        )
+    }
+    val state by viewModel.uiState.collectAsState()
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        if (state.isLoading || state.days.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+            }
+        } else {
+            RadialClockScreen(
+                days = state.days,
+                initialDate = state.initialDate,
+                typicalUsageHourDist = state.typicalUsageHourDist,
+            )
+        }
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `RadialRoute` (function) — lines 24-57

--- a/docs/vault/code/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.md
+++ b/docs/vault/code/android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.md
@@ -1,0 +1,60 @@
+---
+type: code-source
+language: kotlin
+file_path: android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
+git_blob: f2ec276629982f1b3a297548ff09f76d172da205
+last_synced: '2026-05-26T03:20:22Z'
+loc: 29
+annotations: []
+imports: []
+exports: []
+tags:
+- code
+- kotlin
+---
+
+# android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt
+
+> [!info] Code mirror
+> Ce fichier est un **miroir auto-généré** de [`android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt`](../../../android-app/app/src/webview/java/fr/datasaillance/nightfall/ui/screens/radial/RadialRoute.kt).
+> Code = source de vérité. Annotations dans `docs/vault/annotations/`.
+> Régénéré par `code-cartographer` au commit. Ne pas éditer directement.
+
+```kotlin
+package fr.datasaillance.nightfall.ui.screens.radial
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+/**
+ * Stub flavor `webview` — le cadran radial est rendu nativement via Compose
+ * Canvas, pas disponible en WebView.
+ */
+@Composable
+fun RadialRoute() {
+    Box(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "Cadran radial — disponible uniquement en mode natif.",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+```
+
+---
+
+## Appendix — symbols & navigation *(auto)*
+
+### Symbols
+- `RadialRoute` (function) — lines 17-29


### PR DESCRIPTION
## Summary

Phase 4 sub-etapes a + d + e + f. Wire-up complet du **multi-donut radial clock** comme nouveau ecran principal accessible depuis le bottom nav.

## Ce qui est livre

| Sub-etape | Contenu |
|---|---|
| **4a** | Drop-in `dataviz/radial/MultiDonutClock.kt` + `RadialClockScreen.kt` du kit v3 (1027 LOC). Outer ring = sleep stages, middle = usage (Heat ou Apps), inner = visits + activities |
| **4d** | Mappers Room entities -> DTO viz light dans le ViewModel : `SleepStageEntity` -> `StageInterval`, `LocationVisitEntity` -> `RadialVisit`, `ActivitySegmentEntity` -> `RadialActivity`, `UsageDailyEntity` -> `RadialUsageRow` |
| **4e** | `RadialClockViewModel` (~135 LOC) : agrege les 4 sources par jour sur fenetre 30j + calcule `typicalUsageHourDist` (fallback FloatArray 24 buckets normalises pour le Heat ring quand un jour n'a pas d'usage) |
| **4f** | Route `Activity` (label change `Activité` -> `Cadran`, icone `FitnessCenter` -> `DonutLarge`) — l'ecran placeholder `ActivityScreen` est remplace par `RadialRoute` qui wrap le ViewModel + RadialClockScreen |

## Pourquoi remplacer 'Activité' ?

L'ancien `ActivityScreen.kt` etait un placeholder vide (`Text(\"Activité — Phase 5\")`). Le radial clock est l'evolution moderne de cet onglet : il agrege **sleep stages + visits + activities + usage** sur un meme cadran 24h. Plus puissant qu'un ecran 'fitness' classique.

La **route** `activity` est conservee pour pas casser les tests existants (`NavGraphTest`, `BottomNavBarTest`). Seul le **label** + l'**icone** + le **composable rendered** changent.

## Architecture

```
Bottom nav 'Cadran' (DonutLarge icon)
  └─ NavDestination.Activity (route: 'activity')
      └─ RadialRoute (flavor native)
          ├─ DataSaillanceTheme scope
          ├─ RadialClockViewModel(sleepDao, locationDao, usageStatsDao)
          │   ├─ buildDaysMap() — agrege fenetre 30j en Map<LocalDate, RadialDay>
          │   └─ computeTypicalHourDist() — fallback FloatArray[24] normalise
          └─ RadialClockScreen(days, initialDate, typicalUsageHourDist)
              └─ MultiDonutClock (Canvas pur, 3 rings concentriques)
```

Flavor webview : `RadialRoute` stub affiche 'Disponible uniquement en mode natif'.

## Validation

- [x] Build native debug OK
- [x] Build webview debug OK (stub place-holder)
- [ ] Validation device : ouvrir l'onglet Cadran -> verifier les 3 rings (sleep + usage + timeline) sur les jours du dernier mois, navigation ±1 jour, toggle Heat/Apps
- [ ] Tests existants `NavGraphTest` / `BottomNavBarTest` — route 'activity' inchangee, devrait passer

## Compromis / TODO

- L'onglet 'Cadran' n'est dispo que si Compose Canvas natif (flavor `native`). Le flavor `webview` reste un placeholder.
- Le label dans `NavDestination.Activity` est maintenant 'Cadran' alors que la route reste 'activity'. C'est un compromis pour pas casser les tests — a propre-iser plus tard (renommer la route en `radial` avec une migration de tests).
- L'icone Material Symbols `DonutLarge` est utilisee mais le kit v3 suggere plutot une icone custom. A regarder si besoin.
- Phase 4b (StackedWeeks pour TimelineScreen) + 4c (UsageHeatmap dans Bien-etre) + 4g + 4h restent a faire dans des PR dediees.

## Reference

- Kit v3 : `DataSaillance — Design System.zip` (2.4 MB, 26/05)
- Drop-ins copies : `android/dataviz/radial/MultiDonutClock.kt` + `RadialClockScreen.kt`
- README : `android/dataviz/radial/README.md`

## Followup

Issue : retirer le placeholder `ActivityScreen.kt` ou le renommer en `RadialPlaceholder.kt` (actuellement il existe encore mais n'est plus appele).